### PR TITLE
Add active mode

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --no-default-features --features secure --features async-secure --features with-containers --no-fail-fast -- --test-threads 1
+          args: --lib --no-default-features --features secure,async-secure,with-containers --no-fail-fast
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy without secure

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --no-default-features --features secure --features async-secure --features with-containers --no-fail-fast -- --test-threads 1
+          args: --lib --no-default-features --features secure,async-secure,with-containers --no-fail-fast
         env:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 Released on ??
 
+- **Active mode**
+  - suppaftp now supports Active-mode (credit [@devbydav](https://github.com/devbydav))
+  - You can change mode with `set_mode(Mode::Passive) or set_mode(Mode::Active)` whenever you want
+
 ## 4.1.3
 
 Released on 01/12/2021

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ thiserror = "^1.0.20"
 [dev-dependencies]
 async-attributes = "1.1.2"
 pretty_assertions = "^1.0.0"
-rand = "0.8.4"
+rand = "^0.8.4"
+serial_test = "^0.5.1"
 
 [features]
 # Enable async support for suppaftp

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ SuppaFTP is a FTP/FTPS client library written in Rust, with both support for syn
 ### Main differences between SuppaFTP and rust-ftp 🤔
 
 - Added methods to work with streams (e.g. `put_with_stream`) ⬇️
+- suppaftp supports **Active mode**
 - Added `get_welcome_msg` method 👋
 - Supports for both sync/async rust
 - Some extra features, such as the **LIST** command output parser

--- a/cli/actions.rs
+++ b/cli/actions.rs
@@ -1,5 +1,3 @@
-extern crate rpassword;
-
 use super::{FtpError, FtpStream};
 
 use std::fs::File;
@@ -7,6 +5,7 @@ use std::io;
 use std::path::Path;
 use suppaftp::native_tls::TlsConnector;
 use suppaftp::types::FileType;
+use suppaftp::Mode;
 
 pub fn quit(mut ftp: Option<FtpStream>) {
     if let Some(mut ftp) = ftp.take() {
@@ -117,6 +116,11 @@ pub fn mkdir(ftp: &mut FtpStream, f: &str) {
         Ok(_) => println!("OK"),
         Err(err) => eprintln!("MDTM error: {}", err),
     }
+}
+
+pub fn set_mode(ftp: &mut FtpStream, mode: Mode) {
+    ftp.set_mode(mode);
+    println!("OK");
 }
 
 pub fn noop(ftp: &mut FtpStream) {

--- a/cli/command.rs
+++ b/cli/command.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::str::FromStr;
+use suppaftp::Mode;
 
 pub enum Command {
     Cdup,
@@ -10,6 +11,7 @@ pub enum Command {
     Login,
     Mdtm(String),
     Mkdir(String),
+    Mode(Mode),
     Noop,
     Put(PathBuf, String),
     Pwd,
@@ -56,6 +58,12 @@ impl FromStr for Command {
                 "MKDIR" => match args.next() {
                     Some(file) => Ok(Self::Mkdir(file.to_string())),
                     None => Err("Missing `file` field"),
+                },
+                "MODE" => match args.next() {
+                    Some("ACTIVE") => Ok(Self::Mode(Mode::Active)),
+                    Some("PASSIVE") => Ok(Self::Mode(Mode::Passive)),
+                    Some(_) => Err("Invalid mode"),
+                    None => Err("Missing `mode` field"),
                 },
                 "NOOP" => Ok(Self::Noop),
                 "PUT" => {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -6,9 +6,6 @@
 const SUPPAFTP_AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 const SUPPAFTP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-extern crate rpassword;
-extern crate suppaftp;
-
 // -- mods
 mod actions;
 mod command;
@@ -39,6 +36,7 @@ fn usage() {
     println!("LIST [dir]                          List files. If directory is not provided, current directory is used");
     println!("LOGIN                               Login to remote");
     println!("MDTM <file>                         Get modification time for `file`");
+    println!("MODE <PASSIVE|ACTIVE>               Set mode");
     println!("NOOP                                Ping server");
     println!("PUT <file> <dest>                   Upload local file `file` to `dest`");
     println!("PWD                                 Print working directory");
@@ -125,6 +123,7 @@ fn perform_connected(ftp: &mut FtpStream, command: Command) {
         Command::Login => login(ftp),
         Command::Mdtm(p) => mdtm(ftp, p.as_str()),
         Command::Mkdir(p) => mkdir(ftp, p.as_str()),
+        Command::Mode(m) => set_mode(ftp, m),
         Command::Noop => noop(ftp),
         Command::Put(src, dest) => put(ftp, src.as_path(), dest.as_str()),
         Command::Pwd => pwd(ftp),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,4 +155,4 @@ pub use async_ftp::FtpStream;
 #[cfg(not(any(feature = "async", feature = "async-secure")))]
 pub use sync_ftp::FtpStream;
 // -- export (common)
-pub use types::FtpError;
+pub use types::{FtpError, Mode};

--- a/src/types.rs
+++ b/src/types.rs
@@ -78,6 +78,15 @@ pub enum FileType {
     Local(u8),
 }
 
+/// ## Mode
+///
+/// Connection mode for data channel
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Passive,
+    Active,
+}
+
 impl Response {
     /// ### new
     ///


### PR DESCRIPTION
#4  - Add support for active mode

## Description

This PR adds support for active mode.

To open a data stream with active mode, we create a tcp listener and send a PORT command to tell the ftp server which ip/port to connect to.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works: No, github CI won't allow me to open ports.
- [x] I have introduced no *C-bindings*
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [x] regression test: no regression when using passive mode
- [x] regression test: no regression when using active mode
- [x] switch test: I can switch mode at any time without any issue
