### PR TITLE
Close ssl stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Released on ??
   - suppaftp now supports Active-mode (credit [@devbydav](https://github.com/devbydav))
   - You can change mode with `set_mode(Mode::Passive) or set_mode(Mode::Active)` whenever you want
 - **Logging**: `log` crate has been implemented for debugging. You can disable logging with `no-log` feature
+- Security
+  - **TlsStream shutdown**: fixed [issue 5](https://github.com/veeso/suppaftp/issues/5)
 
 ## 4.1.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,19 @@ path = "cli/main.rs"
 required-features = ["secure", "cli-bin"]
 
 [dependencies]
-async-std = { version = "^1.10.0", optional = true }
-async-native-tls = { version = "^0.4.0", optional = true }
-chrono = "^0.4.19"
+chrono  = "^0.4.19"
 lazy_static = "^1.4.0"
 log = "^0.4.0"
+regex = "^1.4.2"
+thiserror = "^1.0.0"
+# async
+async-std = { version = "^1.10.0", optional = true }
+async-native-tls = { version = "^0.4.0", optional = true }
 native-tls = { version = "^0.2", optional = true }
 pin-project = { version = "^1.0.8", optional = true }
-regex = "^1.4.2"
+# cli-bin
+env_logger = { version = "^0.9.0", optional = true }
 rpassword = { version = "5.0.1", optional = true }
-thiserror = "^1.0.20"
 
 [dev-dependencies]
 async-attributes = "1.1.2"
@@ -55,4 +58,4 @@ no-log = [ "log/max_level_off" ]
 with-containers = []
 
 # Don't enable this feature; is used by suppaftp binary only
-cli-bin = ["rpassword"]
+cli-bin = [ "env_logger", "rpassword"]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -74,6 +74,8 @@ fn main() {
         usage();
         exit(255);
     }
+    // init logger
+    env_logger::init();
     // Main loop
     let mut ftp: Option<FtpStream> = None;
     loop {


### PR DESCRIPTION
#5 - Close SSL stream

Fixes errors with certain ftp servers, and possible vulnerability to truncation attack.

## Description

Close SSL stream properly for every data channel that was opened. Inspired by a fix made on parent [repo](https://github.com/mattnenterprise/rust-ftp)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no *C-bindings*
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: regression test secure ftp
- [ ] SSL stream is correctly shut down when stream is dropped
