### PR TITLE
Remove EOL in command channel message logs

### DIFF
--- a/src/async_ftp/mod.rs
+++ b/src/async_ftp/mod.rs
@@ -617,7 +617,7 @@ impl FtpStream {
 
     /// Write data to stream
     async fn write_str<S: AsRef<str>>(&mut self, command: S) -> FtpResult<()> {
-        trace!("CMD {}", command.as_ref());
+        trace!("CC OUT: {}", command.as_ref().trim_end_matches("\r\n"));
 
         let stream = self.reader.get_mut();
         stream
@@ -639,7 +639,7 @@ impl FtpStream {
             .await
             .map_err(FtpError::ConnectionError)?;
 
-        trace!("FTP {}", line);
+        trace!("CC IN: {}", line.trim_end());
 
         if line.len() < 5 {
             return Err(FtpError::BadResponse);
@@ -657,7 +657,7 @@ impl FtpStream {
                 return Err(FtpError::ConnectionError(e));
             }
 
-            print!("FTP {}", line);
+            trace!("CC IN: {}", line.trim_end());
         }
 
         line = String::from(line.trim());

--- a/src/sync_ftp/mod.rs
+++ b/src/sync_ftp/mod.rs
@@ -644,7 +644,7 @@ impl FtpStream {
 
     /// Write data to stream
     fn write_str<S: AsRef<str>>(&mut self, command: S) -> FtpResult<()> {
-        trace!("CMD {}", command.as_ref());
+        trace!("CC OUT: {}", command.as_ref().trim_end_matches("\r\n"));
 
         let stream = self.reader.get_mut();
         stream
@@ -664,7 +664,7 @@ impl FtpStream {
             .read_line(&mut line)
             .map_err(FtpError::ConnectionError)?;
 
-        trace!("FTP {}", line);
+        trace!("CC IN: {}", line.trim_end());
 
         if line.len() < 5 {
             return Err(FtpError::BadResponse);
@@ -682,7 +682,7 @@ impl FtpStream {
                 return Err(FtpError::ConnectionError(e));
             }
 
-            trace!("FTP {}", line);
+            trace!("CC IN: {}", line.trim_end());
         }
 
         line = String::from(line.trim());


### PR DESCRIPTION
## Description

FTP commands and responses end with CRLF, which is logged, resulting in a double line return.

This removes the EOL from message to fix it.

FTP specifies CRLF as the only valid EOL marker. 
We know we use it, so I trimmed the end CRLF in sent commands.
For response, I went for a safer approach in case some server don't use proper CRLF.

Let me know if you have a better idea than "CC OUT" / "CC IN" for control channel in/out !
("CMD"/"RESP", "CC ->"/"CC <-" ...)

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no *C-bindings*
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [x] regression test: log lines are displayed correctly
