### PR TITLE
NAT workaround for passive mode

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -26,17 +26,17 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features secure
+          args: --features secure,deprecated
       - name: Build async
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features async
+          args: --features async,deprecated
       - name: Build async-secure
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features async-secure
+          args: --features async-secure,deprecated
       - name: Build suppaftp-cli
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --no-default-features --features secure,async-secure,with-containers --no-fail-fast
+          args: --lib --no-default-features --features secure,deprecated,async-secure,with-containers --no-fail-fast
         env:
           RUST_LOG: trace
           CARGO_INCREMENTAL: "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,6 @@ secure = ["native-tls"]
 # Disable logging
 no-log = [ "log/max_level_off" ]
 
-# Enable support of FTP servers running behind a NAT/proxy
-nat = []
-
 # Must be enabled whenever testing with docker containers
 with-containers = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ secure = ["native-tls"]
 # Disable logging
 no-log = [ "log/max_level_off" ]
 
+# Enable support of FTP servers running behind a NAT/proxy
+nat = []
+
 # Must be enabled whenever testing with docker containers
 with-containers = []
 

--- a/src/async_ftp/mod.rs
+++ b/src/async_ftp/mod.rs
@@ -918,7 +918,7 @@ mod test {
     fn should_set_passive_nat_workaround() {
         crate::log_init();
         let mut stream: FtpStream = setup_stream().await;
-        stream.set_passive_nat_workaround();
+        stream.set_passive_nat_workaround(true);
         assert!(stream.nat_workaround);
         finalize_stream(stream).await;
     }

--- a/src/async_ftp/mod.rs
+++ b/src/async_ftp/mod.rs
@@ -36,6 +36,7 @@ static SIZE_RE: Lazy<Regex> = lazy_regex!(r"\s+(\d+)\s*$");
 pub struct FtpStream {
     reader: BufReader<DataStream>,
     mode: Mode,
+    nat_workaround: bool,
     welcome_msg: Option<String>,
     #[cfg(feature = "async-secure")]
     tls_ctx: Option<TlsConnector>,
@@ -56,6 +57,7 @@ impl FtpStream {
         let mut ftp_stream = FtpStream {
             reader: BufReader::new(DataStream::Tcp(stream)),
             mode: Mode::Passive,
+            nat_workaround: false,
             welcome_msg: None,
         };
         debug!("Reading server response...");
@@ -80,6 +82,7 @@ impl FtpStream {
         let mut ftp_stream = FtpStream {
             reader: BufReader::new(DataStream::Tcp(stream)),
             mode: Mode::Passive,
+            nat_workaround: false,
             welcome_msg: None,
             tls_ctx: None,
             domain: None,
@@ -132,6 +135,7 @@ impl FtpStream {
         let mut secured_ftp_tream = FtpStream {
             reader: BufReader::new(DataStream::Ssl(stream)),
             mode: self.mode,
+            nat_workaround: self.nat_workaround,
             tls_ctx: Some(tls_connector),
             domain: Some(String::from(domain)),
             welcome_msg: self.welcome_msg,
@@ -225,6 +229,11 @@ impl FtpStream {
     pub fn set_mode(&mut self, mode: Mode) {
         debug!("Changed mode to {:?}", mode);
         self.mode = mode;
+    }
+
+    /// Set NAT workaround for passive mode
+    pub fn set_nat_workaround(&mut self, nat_workaround: bool) {
+        self.nat_workaround = nat_workaround;
     }
 
     /// Returns a reference to the underlying TcpStream.
@@ -644,20 +653,16 @@ impl FtpStream {
         let port = (u16::from(msb) << 8) | u16::from(lsb);
         let addr = SocketAddr::new(ip.into(), port);
         trace!("Passive address: {}", addr);
-        if cfg!(feature = "nat") {
-            if ip.is_private() {
-                let mut remote = self
-                    .reader
-                    .get_ref()
-                    .get_ref()
-                    .peer_addr()
-                    .map_err(FtpError::ConnectionError)?;
-                remote.set_port(port);
-                trace!("Replacing site local address {} with {}", addr, remote);
-                Ok(remote)
-            } else {
-                Ok(addr)
-            }
+        if self.nat_workaround && ip.is_private() {
+            let mut remote = self
+                .reader
+                .get_ref()
+                .get_ref()
+                .peer_addr()
+                .map_err(FtpError::ConnectionError)?;
+            remote.set_port(port);
+            trace!("Replacing site local address {} with {}", addr, remote);
+            Ok(remote)
         } else {
             Ok(addr)
         }

--- a/src/async_ftp/mod.rs
+++ b/src/async_ftp/mod.rs
@@ -183,6 +183,7 @@ impl FtpStream {
                 FtpStream {
                     reader: BufReader::new(DataStream::Tcp(stream)),
                     mode: Mode::Passive,
+                    nat_workaround: false,
                     welcome_msg: None,
                     tls_ctx: None,
                     domain: None,
@@ -198,6 +199,7 @@ impl FtpStream {
         let mut stream = FtpStream {
             reader: BufReader::new(DataStream::Ssl(stream.into())),
             mode: Mode::Passive,
+            nat_workaround: false,
             tls_ctx: Some(tls_connector),
             domain: Some(String::from(domain)),
             welcome_msg: None,
@@ -232,7 +234,7 @@ impl FtpStream {
     }
 
     /// Set NAT workaround for passive mode
-    pub fn set_nat_workaround(&mut self, nat_workaround: bool) {
+    pub fn set_passive_nat_workaround(&mut self, nat_workaround: bool) {
         self.nat_workaround = nat_workaround;
     }
 
@@ -907,6 +909,17 @@ mod test {
             stream.get_welcome_msg().unwrap(),
             "220 You will be disconnected after 15 minutes of inactivity."
         );
+        finalize_stream(stream).await;
+    }
+
+    #[async_attributes::test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_set_passive_nat_workaround() {
+        crate::log_init();
+        let mut stream: FtpStream = setup_stream().await;
+        stream.set_passive_nat_workaround();
+        assert!(stream.nat_workaround);
         finalize_stream(stream).await;
     }
 

--- a/src/async_ftp/mod.rs
+++ b/src/async_ftp/mod.rs
@@ -915,7 +915,7 @@ mod test {
     #[async_attributes::test]
     #[cfg(feature = "with-containers")]
     #[serial]
-    fn should_set_passive_nat_workaround() {
+    async fn should_set_passive_nat_workaround() {
         crate::log_init();
         let mut stream: FtpStream = setup_stream().await;
         stream.set_passive_nat_workaround(true);

--- a/src/sync_ftp/mod.rs
+++ b/src/sync_ftp/mod.rs
@@ -924,7 +924,7 @@ mod test {
     fn should_set_passive_nat_workaround() {
         crate::log_init();
         let mut stream: FtpStream = setup_stream();
-        stream.set_passive_nat_workaround();
+        stream.set_passive_nat_workaround(true);
         assert!(stream.nat_workaround);
         finalize_stream(stream);
     }

--- a/src/sync_ftp/mod.rs
+++ b/src/sync_ftp/mod.rs
@@ -20,8 +20,7 @@ use lazy_regex::{Lazy, Regex};
 #[cfg(feature = "secure")]
 use native_tls::TlsConnector;
 use std::io::{copy, BufRead, BufReader, Cursor, Read, Write};
-use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
-use std::str::FromStr;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::string::String;
 
 // This regex extracts IP and Port details from PASV command response.
@@ -747,26 +746,41 @@ impl FtpStream {
         self.perform(Command::Pasv)?;
         // PASV response format : 227 Entering Passive Mode (h1,h2,h3,h4,p1,p2).
         let response: Response = self.read_response(Status::PassiveMode)?;
-        PORT_RE
+        let caps = PORT_RE
             .captures(&response.body)
-            .ok_or_else(|| FtpError::UnexpectedResponse(response.clone()))
-            .and_then(|caps| {
-                // If the regex matches we can be sure groups contains numbers
-                let (oct1, oct2, oct3, oct4) = (
-                    caps[1].parse::<u8>().unwrap(),
-                    caps[2].parse::<u8>().unwrap(),
-                    caps[3].parse::<u8>().unwrap(),
-                    caps[4].parse::<u8>().unwrap(),
-                );
-                let (msb, lsb) = (
-                    caps[5].parse::<u8>().unwrap(),
-                    caps[6].parse::<u8>().unwrap(),
-                );
-                let port = ((msb as u16) << 8) + lsb as u16;
-                let addr = format!("{}.{}.{}.{}:{}", oct1, oct2, oct3, oct4, port);
-                trace!("Passive address: {}", addr);
-                SocketAddr::from_str(&addr).map_err(FtpError::InvalidAddress)
-            })
+            .ok_or_else(|| FtpError::UnexpectedResponse(response.clone()))?;
+        // If the regex matches we can be sure groups contains numbers
+        let (oct1, oct2, oct3, oct4) = (
+            caps[1].parse::<u8>().unwrap(),
+            caps[2].parse::<u8>().unwrap(),
+            caps[3].parse::<u8>().unwrap(),
+            caps[4].parse::<u8>().unwrap(),
+        );
+        let (msb, lsb) = (
+            caps[5].parse::<u8>().unwrap(),
+            caps[6].parse::<u8>().unwrap(),
+        );
+        let ip = Ipv4Addr::new(oct1, oct2, oct3, oct4);
+        let port = (u16::from(msb) << 8) | u16::from(lsb);
+        let addr = SocketAddr::new(ip.into(), port);
+        trace!("Passive address: {}", addr);
+        if cfg!(feature = "nat") {
+            if ip.is_private() {
+                let mut remote = self
+                    .reader
+                    .get_ref()
+                    .get_ref()
+                    .peer_addr()
+                    .map_err(FtpError::ConnectionError)?;
+                remote.set_port(port);
+                trace!("Replacing site local address {} with {}", addr, remote);
+                Ok(remote)
+            } else {
+                Ok(addr)
+            }
+        } else {
+            Ok(addr)
+        }
     }
 
     /// Execute a command which returns list of strings in a separate stream

--- a/src/sync_ftp/mod.rs
+++ b/src/sync_ftp/mod.rs
@@ -114,7 +114,7 @@ impl FtpStream {
     }
 
     /// Set NAT workaround for passive mode
-    pub fn set_nat_workaround(&mut self, nat_workaround: bool) {
+    pub fn set_passive_nat_workaround(&mut self, nat_workaround: bool) {
         self.nat_workaround = nat_workaround;
     }
 
@@ -193,6 +193,7 @@ impl FtpStream {
                 FtpStream {
                     reader: BufReader::new(DataStream::Tcp(stream)),
                     mode: Mode::Passive,
+                    nat_workaround: false,
                     welcome_msg: None,
                     tls_ctx: None,
                     domain: None,
@@ -207,6 +208,7 @@ impl FtpStream {
         let mut stream = FtpStream {
             reader: BufReader::new(DataStream::Ssl(stream.into())),
             mode: Mode::Passive,
+            nat_workaround: false,
             tls_ctx: Some(tls_connector),
             domain: Some(String::from(domain)),
             welcome_msg: None,
@@ -913,6 +915,17 @@ mod test {
             stream.get_welcome_msg().unwrap(),
             "220 You will be disconnected after 15 minutes of inactivity."
         );
+        finalize_stream(stream);
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(feature = "with-containers")]
+    fn should_set_passive_nat_workaround() {
+        crate::log_init();
+        let mut stream: FtpStream = setup_stream();
+        stream.set_passive_nat_workaround();
+        assert!(stream.nat_workaround);
         finalize_stream(stream);
     }
 


### PR DESCRIPTION
#16 [Feature Request] - support of FTP servers running behind a NAT/proxy

This pull request allows client to work with FTP servers running behind NAT in passive mode.

To enable the workaround call

```rust
    ftp_stream.set_nat_workaround(true);
```
