### PR TITLE
Allow using rustls instead of native-tls

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -22,36 +22,56 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-      - name: Build secure
+      - name: Build secure (native-tls)
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features secure,deprecated
+          args: --features native-tls,deprecated
+      - name: Build secure (rustls)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features rustls,deprecated
       - name: Build async
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --features async,deprecated
-      - name: Build async-secure
+      - name: Build async-native-tls
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features async-secure,deprecated
+          args: --features async-native-tls,deprecated
       - name: Build suppaftp-cli
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features secure --features cli-bin --bin suppaftp
-      - name: Run tests
+          args: --features native-tls --features cli-bin --bin suppaftp
+      - name: Run tests (native-tls)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --no-default-features --features secure,async-secure,with-containers --no-fail-fast
+          args: --lib --no-default-features --features native-tls,async-native-tls,with-containers --no-fail-fast
+        env:
+          RUST_LOG: trace
+      - name: Run tests (rustls)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --lib --no-default-features --features rustls,async-rustls,with-containers --no-fail-fast
         env:
           RUST_LOG: trace
       - name: Format
         run: cargo fmt --all -- --check
-      - name: Clippy without secure
-        run: cargo clippy --features async -- -Dwarnings
-      - name: Clippy with secure feature
-        run: cargo clippy --features secure --features async-secure -- -Dwarnings
+      - name: Clippy
+        run: cargo clippy --features deprecated -- -Dwarnings
+      - name: Clippy (async)
+        run: cargo clippy --features async,deprecated -- -Dwarnings
+      - name: Clippy (native-tls)
+        run: cargo clippy --features native-tls,deprecated -- -Dwarnings
+      - name: Clippy (async-native-tls)
+        run: cargo clippy --features async-native-tls,deprecated -- -Dwarnings
+      - name: Clippy (rustls)
+        run: cargo clippy --features rustls,deprecated -- -Dwarnings
+      - name: Clippy (async-rustls)
+        run: cargo clippy --features async-rustls,deprecated -- -Dwarnings

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --no-default-features --features secure,deprecated,async-secure,with-containers --no-fail-fast
+          args: --lib --no-default-features --features native-tls,deprecated,async-native-tls,with-containers --no-fail-fast
         env:
           RUST_LOG: trace
           CARGO_INCREMENTAL: "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,15 @@ lazy-regex = "^2.3.0"
 log = "^0.4.0"
 thiserror = "^1.0.0"
 # async
-async-std = { version = "^1.10.0", optional = true }
-async-native-tls = { version = "^0.4.0", optional = true }
-native-tls = { version = "^0.2", optional = true }
-pin-project = { version = "^1.0.8", optional = true }
+async-std = { version = "^1.10", optional = true }
+async-native-tls-crate = { package = "async-native-tls", version = "^0.4", optional = true }
+async-tls = { version = "^0.11", optional = true }
+pin-project = { version = "^1", optional = true }
+# secure
+native-tls-crate = { package = "native-tls", version = "^0.2", optional = true }
+rustls-crate = { package = "rustls", version = "^0.20", optional = true }
 # cli-bin
-env_logger = { version = "^0.9.0", optional = true }
+env_logger = { version = "^0.9", optional = true }
 rpassword = { version = "5.0.1", optional = true }
 
 [dev-dependencies]
@@ -41,17 +44,24 @@ env_logger = "^0.9.0"
 pretty_assertions = "^1.0.0"
 rand = "^0.8.4"
 serial_test = "^0.8.0"
+webpki-roots = "0.22.5"
 
 [features]
 # Enable async support for suppaftp
 async = ["async-std", "pin-project"]
-async-secure = ["async-std", "async-native-tls", "pin-project"]
+async-default-tls = [ "async-native-tls" ]
+async-native-tls = [ "async-native-tls-crate", "async-secure" ]
+async-rustls = [ "async-tls", "async-secure" ]
+async-secure = [ "async" ]
 
 # Enable deprecated FTP/FTPS methods
 deprecated = []
 
-# Enable support of FTPS which requires native-tls (openssl is required on Linux)
-secure = ["native-tls"]
+# Enable support for FTPS which requires native-tls (openssl is required on Linux) or RustTLS
+default-tls = [ "native-tls" ]
+native-tls = [ "native-tls-crate", "secure" ]
+rustls = [ "rustls-crate", "secure" ]
+secure = []
 
 # Disable logging
 no-log = [ "log/max_level_off" ]

--- a/cli/actions.rs
+++ b/cli/actions.rs
@@ -60,7 +60,7 @@ pub fn connect(remote: &str, secure: bool) -> Option<FtpStream> {
         };
         // Get address without port
         let address: &str = remote.split(':').next().unwrap();
-        stream = match stream.into_secure(ctx, address) {
+        stream = match stream.into_secure(ctx.into(), address) {
             Ok(s) => s,
             Err(err) => {
                 eprintln!("Failed to setup TLS stream: {}", err);

--- a/src/async_ftp/data_stream.rs
+++ b/src/async_ftp/data_stream.rs
@@ -2,12 +2,14 @@
 //!
 //! This module exposes the async data stream implementation where bytes must be written to/read from
 
-#[cfg(feature = "async-secure")]
+#[cfg(feature = "async-native-tls")]
 use async_native_tls::TlsStream;
 #[cfg(any(feature = "async", feature = "async-secure"))]
 use async_std::io::{Read, Result, Write};
 #[cfg(any(feature = "async", feature = "async-secure"))]
 use async_std::net::TcpStream;
+#[cfg(feature = "async-rustls")]
+use async_tls::client::TlsStream;
 use pin_project::pin_project;
 use std::pin::Pin;
 
@@ -16,7 +18,7 @@ use std::pin::Pin;
 pub enum DataStream {
     Tcp(#[pin] TcpStream),
     #[cfg(feature = "async-secure")]
-    Ssl(#[pin] TlsStream<TcpStream>),
+    Ssl(#[pin] Box<TlsStream<TcpStream>>),
 }
 
 #[cfg(feature = "async-secure")]

--- a/src/async_ftp/tls.rs
+++ b/src/async_ftp/tls.rs
@@ -1,0 +1,13 @@
+//! # Tls
+//!
+//! Tls wrappers
+
+#[cfg(feature = "async-native-tls")]
+mod native_tls;
+#[cfg(feature = "async-native-tls")]
+pub use self::native_tls::TlsConnector;
+
+#[cfg(feature = "async-rustls")]
+mod rustls;
+#[cfg(feature = "async-rustls")]
+pub use self::rustls::TlsConnector;

--- a/src/async_ftp/tls/native_tls.rs
+++ b/src/async_ftp/tls/native_tls.rs
@@ -1,0 +1,28 @@
+//! # Native TLS
+//!
+//! Native tls types for suppaftp
+
+use async_native_tls::{Error as TlsError, TlsConnector as NativeTlsConnector, TlsStream};
+use async_std::net::TcpStream;
+
+#[derive(Debug)]
+/// A Wrapper for the tls connector
+pub struct TlsConnector {
+    connector: NativeTlsConnector,
+}
+
+impl From<NativeTlsConnector> for TlsConnector {
+    fn from(connector: NativeTlsConnector) -> Self {
+        Self { connector }
+    }
+}
+
+impl TlsConnector {
+    pub async fn connect(
+        &self,
+        domain: &str,
+        stream: TcpStream,
+    ) -> Result<TlsStream<TcpStream>, TlsError> {
+        self.connector.connect(domain, stream).await
+    }
+}

--- a/src/async_ftp/tls/rustls.rs
+++ b/src/async_ftp/tls/rustls.rs
@@ -1,0 +1,34 @@
+//! # Rustls
+//!
+//! rustls types for suppaftp
+
+use async_std::io::Error as IoError;
+use async_std::net::TcpStream;
+use async_tls::{client::TlsStream, TlsConnector as RustlsTlsConnector};
+
+/// A Wrapper for the tls connector
+pub struct TlsConnector {
+    connector: RustlsTlsConnector,
+}
+
+impl std::fmt::Debug for TlsConnector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<?>")
+    }
+}
+
+impl From<RustlsTlsConnector> for TlsConnector {
+    fn from(connector: RustlsTlsConnector) -> Self {
+        Self { connector }
+    }
+}
+
+impl TlsConnector {
+    pub async fn connect(
+        &self,
+        domain: &str,
+        stream: TcpStream,
+    ) -> Result<TlsStream<TcpStream>, IoError> {
+        self.connector.connect(domain, stream).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 //!
 //! let ftp_stream = FtpStream::connect("test.rebex.net:21").unwrap();
 //! // Switch to the secure mode
-//! let mut ftp_stream = ftp_stream.into_secure(TlsConnector::new().unwrap(), "test.rebex.net").unwrap();
+//! let mut ftp_stream = ftp_stream.into_secure(TlsConnector::new().unwrap().into(), "test.rebex.net").unwrap();
 //! ftp_stream.login("demo", "password").unwrap();
 //! // Do other secret stuff
 //! // Switch back to the insecure mode (if required)
@@ -99,7 +99,7 @@
 //!
 //! let ftp_stream = FtpStream::connect("test.rebex.net:21").await.unwrap();
 //! // Switch to the secure mode
-//! let mut ftp_stream = ftp_stream.into_secure(TlsConnector::new(), "test.rebex.net").await.unwrap();
+//! let mut ftp_stream = ftp_stream.into_secure(TlsConnector::new().into(), "test.rebex.net").await.unwrap();
 //! ftp_stream.login("demo", "password").await.unwrap();
 //! // Do other secret stuff
 //! // Do all public stuff
@@ -134,11 +134,13 @@ pub mod list;
 pub mod types;
 
 // -- secure deps
-#[cfg(feature = "secure")]
-pub extern crate native_tls;
+#[cfg(feature = "native-tls")]
+pub extern crate native_tls_crate as native_tls;
+#[cfg(feature = "rustls")]
+pub extern crate rustls_crate as rustls;
 // -- async deps
-#[cfg(feature = "async-secure")]
-pub extern crate async_native_tls;
+#[cfg(feature = "async-native-tls")]
+pub extern crate async_native_tls_crate as async_native_tls;
 
 // -- export async
 #[cfg(any(feature = "async", feature = "async-secure"))]
@@ -146,6 +148,9 @@ pub use async_ftp::FtpStream;
 // -- export sync
 #[cfg(not(any(feature = "async", feature = "async-secure")))]
 pub use sync_ftp::FtpStream;
+// -- export secure
+#[cfg(feature = "secure")]
+pub use sync_ftp::TlsConnector;
 // -- export (common)
 pub use status::Status;
 pub use types::{FtpError, FtpResult, Mode};

--- a/src/list.rs
+++ b/src/list.rs
@@ -350,7 +350,7 @@ impl File {
     /// Returns from a `ls -l` command output file name token, the name of the file and the symbolic link (if there is any)
     fn get_name_and_link(token: &str) -> (String, Option<PathBuf>) {
         let tokens: Vec<&str> = token.split(" -> ").collect();
-        let filename: String = String::from(*tokens.get(0).unwrap());
+        let filename: String = String::from(*tokens.first().unwrap());
         let symlink: Option<PathBuf> = tokens.get(1).map(PathBuf::from);
         (filename, symlink)
     }

--- a/src/sync_ftp/tls.rs
+++ b/src/sync_ftp/tls.rs
@@ -1,0 +1,13 @@
+//! # Tls
+//!
+//! Tls wrappers
+
+#[cfg(feature = "native-tls")]
+mod native_tls;
+#[cfg(feature = "native-tls")]
+pub use self::native_tls::{TlsConnector, TlsStream};
+
+#[cfg(feature = "rustls")]
+mod rustls;
+#[cfg(feature = "rustls")]
+pub use self::rustls::{TlsConnector, TlsStream};

--- a/src/sync_ftp/tls/native_tls.rs
+++ b/src/sync_ftp/tls/native_tls.rs
@@ -1,0 +1,87 @@
+//! # Native tls
+//!
+//! Native tls implementation of TLS types
+
+use native_tls::{
+    HandshakeError, TlsConnector as NativeTlsConnector, TlsStream as NativeTlsStream,
+};
+use std::io::Write;
+use std::net::TcpStream;
+
+#[derive(Debug)]
+/// A Wrapper for the tls connector
+pub struct TlsConnector {
+    connector: NativeTlsConnector,
+}
+
+impl From<NativeTlsConnector> for TlsConnector {
+    fn from(connector: NativeTlsConnector) -> Self {
+        Self { connector }
+    }
+}
+
+impl TlsConnector {
+    pub fn connect(
+        &self,
+        domain: &str,
+        stream: TcpStream,
+    ) -> Result<TlsStream, HandshakeError<TcpStream>> {
+        self.connector.connect(domain, stream).map(TlsStream::from)
+    }
+}
+
+// -- tls stream wrapper to implement drop...
+
+/// Tls stream wrapper. This type is a garbage data type used to impl the drop trait for the tls stream.
+/// This allows me to keep returning `Read` and `Write` traits in stream methods
+#[derive(Debug)]
+pub struct TlsStream {
+    stream: NativeTlsStream<TcpStream>,
+    ssl_shutdown: bool,
+}
+
+impl TlsStream {
+    /// Get underlying tcp stream
+    pub(crate) fn tcp_stream(mut self) -> TcpStream {
+        let mut stream = self.stream.get_ref().try_clone().unwrap();
+        // Don't perform shutdown later
+        self.ssl_shutdown = false;
+        // flush stream (otherwise can cause bad chars on channel)
+        if let Err(err) = stream.flush() {
+            error!("Error in flushing tcp stream: {}", err);
+        }
+        trace!("TLS stream terminated");
+        stream
+    }
+
+    /// Get ref to underlying tcp stream
+    pub(crate) fn get_ref(&self) -> &TcpStream {
+        self.stream.get_ref()
+    }
+
+    /// Get mutable reference to tls stream
+    pub(crate) fn mut_ref(&mut self) -> &mut NativeTlsStream<TcpStream> {
+        &mut self.stream
+    }
+}
+
+impl From<NativeTlsStream<TcpStream>> for TlsStream {
+    fn from(stream: NativeTlsStream<TcpStream>) -> Self {
+        Self {
+            stream,
+            ssl_shutdown: true,
+        }
+    }
+}
+
+impl Drop for TlsStream {
+    fn drop(&mut self) {
+        if self.ssl_shutdown {
+            if let Err(err) = self.stream.shutdown() {
+                error!("Failed to shutdown stream: {}", err);
+            } else {
+                debug!("TLS Stream shut down");
+            }
+        }
+    }
+}

--- a/src/sync_ftp/tls/rustls.rs
+++ b/src/sync_ftp/tls/rustls.rs
@@ -1,0 +1,70 @@
+//! # Rustls
+//!
+//! Rustls implementation of tls types
+
+use crate::{FtpError, FtpResult};
+
+use rustls::{ClientConfig, ClientConnection, ServerName, StreamOwned};
+use std::io::Write;
+use std::net::TcpStream;
+use std::sync::Arc;
+
+/// A Wrapper for the tls connector
+pub struct TlsConnector {
+    connector: Arc<ClientConfig>,
+}
+
+impl std::fmt::Debug for TlsConnector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<?>")
+    }
+}
+
+impl From<Arc<ClientConfig>> for TlsConnector {
+    fn from(connector: Arc<ClientConfig>) -> Self {
+        Self { connector }
+    }
+}
+
+impl TlsConnector {
+    pub fn connect(&self, domain: &str, stream: TcpStream) -> FtpResult<TlsStream> {
+        let server_name =
+            ServerName::try_from(domain).map_err(|e| FtpError::SecureError(e.to_string()))?;
+        let connection = ClientConnection::new(Arc::clone(&self.connector), server_name)
+            .map_err(|e| FtpError::SecureError(e.to_string()))?;
+        let stream = StreamOwned::new(connection, stream);
+        Ok(TlsStream { stream })
+    }
+}
+
+// -- tls stream wrapper to implement drop...
+
+/// Tls stream wrapper. This type is a garbage data type used to impl the drop trait for the tls stream.
+/// This allows me to keep returning `Read` and `Write` traits in stream methods
+#[derive(Debug)]
+pub struct TlsStream {
+    stream: StreamOwned<ClientConnection, TcpStream>,
+}
+
+impl TlsStream {
+    /// Get underlying tcp stream
+    pub(crate) fn tcp_stream(self) -> TcpStream {
+        let mut stream = self.get_ref().try_clone().unwrap();
+        // flush stream (otherwise can cause bad chars on channel)
+        if let Err(err) = stream.flush() {
+            error!("Error in flushing tcp stream: {}", err);
+        }
+        trace!("TLS stream terminated");
+        stream
+    }
+
+    /// Get ref to underlying tcp stream
+    pub(crate) fn get_ref(&self) -> &TcpStream {
+        self.stream.get_ref()
+    }
+
+    /// Get mutable reference to tls stream
+    pub(crate) fn mut_ref(&mut self) -> &mut StreamOwned<ClientConnection, TcpStream> {
+        &mut self.stream
+    }
+}


### PR DESCRIPTION
# ISSUE 19 - Allow using rustls instead of native-tls

Fixes #19

## Description

- todo

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no *C-bindings*
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [x] regression test: native-tls
- [x] regression test: async-native-tls
- [ ] rustls secure
- [ ] rustls async
- [x] default secure uses native-tls

