### PR TITLE
fix: async TlsConnector not exported

### DIFF
--- a/suppaftp/src/lib.rs
+++ b/suppaftp/src/lib.rs
@@ -162,6 +162,9 @@ pub extern crate async_native_tls_crate as async_native_tls;
 // -- export async
 #[cfg(any(feature = "async", feature = "async-secure"))]
 pub use async_ftp::FtpStream;
+// -- export async secure
+#[cfg(feature = "async-secure")]
+pub use async_ftp::TlsConnector;
 // -- export sync
 #[cfg(not(any(feature = "async", feature = "async-secure")))]
 pub use sync_ftp::FtpStream;


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

## Description

TlsConnector is not exported. Makes it impossible to call `into_secure`.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no *C-bindings*
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
