### PR TITLE
fix: tls::TlsConnector should be pub use

### DIFF
--- a/suppaftp/src/async_ftp/mod.rs
+++ b/suppaftp/src/async_ftp/mod.rs
@@ -13,7 +13,7 @@ use crate::command::Command;
 use crate::command::ProtectionLevel;
 use data_stream::DataStream;
 #[cfg(feature = "async-secure")]
-use tls::TlsConnector;
+pub use tls::TlsConnector;
 
 use async_std::io::{copy, BufReader, Read, Write};
 use async_std::net::ToSocketAddrs;


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

## Description

`tls::TlsConnector` should be pub use.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no *C-bindings*
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
