### PR TITLE
Derive hash trait for `File` and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [PR27](#pr27)
   - [4.6.0](#460)
   - [4.5.3](#453)
   - [4.5.2](#452)
@@ -18,6 +19,9 @@
   - [4.0.0](#400)
 
 ---
+## PR27
+
+- `suppaftp::list::File` now derives the `core::hash::Hash` trait
 
 ## 4.6.0
 

--- a/suppaftp/src/list.rs
+++ b/suppaftp/src/list.rs
@@ -56,7 +56,7 @@ static DOS_LS_RE: Lazy<Regex> =
 
 /// Describes a file entry on the remote system.
 /// This data type is returned in a collection after parsing a LIST output
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct File {
     /// File name
     name: String,
@@ -75,7 +75,7 @@ pub struct File {
 }
 
 /// Describes the kind of file. Can be `Directory`, `File` or `Symlink`. If `Symlink` the path to the pointed file must be provided
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 enum FileType {
     Directory,
     File,
@@ -93,7 +93,7 @@ pub enum PosixPexQuery {
 }
 
 /// Describes the permissions on POSIX system.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 struct PosixPex {
     read: bool,
     write: bool,


### PR DESCRIPTION
## Description

`suppaftp::list::File` now derives the hash trait. For that also `PosixPex` and `FileType` now derives the hash trait.
That is useful for creating a Hashmap out of the response of `FtpStream::list` call so that the responses can be easily compared / subtracted from each other.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] My code follows the contribution guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I formatted the code with `cargo fmt`
- [X] I linted my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have introduced no *C-bindings*
- [X] I increased or maintained the code coverage for the project, compared to the previous commit
