### PR TITLE
33 bug features are not additive

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -42,31 +42,19 @@ jobs:
         with:
           command: build
           args: --features async-native-tls,deprecated --package suppaftp
-      - name: Run tests (native-tls)
+      - name: Build all features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features --package suppaftp
+      - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --package suppaftp --no-default-features --features native-tls,async-native-tls,with-containers --no-fail-fast
-        env:
-          RUST_LOG: trace
-      - name: Run tests (rustls)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib --package suppaftp --no-default-features --features rustls,async-rustls,with-containers --no-fail-fast
+          args: --lib --package suppaftp  --all-features --no-fail-fast
         env:
           RUST_LOG: trace
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --package suppaftp --features deprecated -- -Dwarnings
-      - name: Clippy (async)
-        run: cargo clippy --package suppaftp --features async,deprecated -- -Dwarnings
-      - name: Clippy (native-tls)
-        run: cargo clippy --package suppaftp --features native-tls,deprecated -- -Dwarnings
-      - name: Clippy (async-native-tls)
-        run: cargo clippy --package suppaftp --features async-native-tls,deprecated -- -Dwarnings
-      - name: Clippy (rustls)
-        run: cargo clippy --package suppaftp --features rustls,deprecated -- -Dwarnings
-      - name: Clippy (async-rustls)
-        run: cargo clippy --package suppaftp --features async-rustls,deprecated -- -Dwarnings
+        run: cargo clippy --package suppaftp  --all-features -- -Dwarnings

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -46,15 +46,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-features --package suppaftp
+          args: --features deprecated,native-tls,rustls,async-native-tls,async-rustls --package suppaftp
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --package suppaftp  --all-features --no-fail-fast
+          args: --lib --package suppaftp --no-default-features --features rustls,native-tls,async-native-tls,async-rustls,with-containers --no-fail-fast
         env:
           RUST_LOG: trace
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --package suppaftp  --all-features -- -Dwarnings
+        run: cargo clippy --package suppaftp --features deprecated,native-tls,rustls,async-native-tls,async-rustls -- -Dwarnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [5.0.0](#500)
   - [4.7.0](#470)
   - [4.6.1](#461)
   - [4.6.0](#460)
@@ -20,6 +21,20 @@
   - [4.0.0](#400)
 
 ---
+
+## 5.0.0
+
+Released on 24/02/2023
+
+- [Issue 33](https://github.com/veeso/suppaftp/issues/33) **‼️ BREAKING CHANGES ‼️**
+  - Features are now additive. This means that you can successfully build suppaftp with all the features enabled at the same time.
+  - Ftp stream has now been split into different types:
+    - `FtpStream`: sync no-tls stream
+    - `NativeTlsFtpStream`: ftp stream with TLS with native-tls
+    - `RustlsFtpStream`: ftp stream with TLS with rustls
+    - `AsyncFtpStream`: async no-tls stream
+    - `AsyncNativeTlsFtpStream`: async ftp stream with TLS with async-native-tls
+    - `AsyncRustlsFtpStream`: async ftp stream with TLS with async-rustls
 
 ## 4.7.0
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">Developed by <a href="https://veeso.github.io/">veeso</a> and <a href="https://github.com/mattnenterprise">Matt McCoy</a></p>
-<p align="center">Current version: 4.7.0 (01/02/2023)</p>
+<p align="center">Current version: 5.0.0 (24/02/2023)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"
@@ -116,7 +116,7 @@ SuppaFTP is the main FTP/FTPS client library for Rust, with both support for syn
 To get started, first add **suppaftp** to your dependencies:
 
 ```toml
-suppaftp = "^4.7.0"
+suppaftp = "^5.0.0"
 ```
 
 ### Features
@@ -126,12 +126,12 @@ suppaftp = "^4.7.0"
 If you want to enable **support for FTPS**, you must enable the `native-tls` or `rustls` feature in your cargo dependencies, based on the TLS provider you prefer.
 
 ```toml
-suppaftp = { version = "^4.7.0", features = ["native-tls"] }
+suppaftp = { version = "^5.0.0", features = ["native-tls"] }
 # or
-suppaftp = { version = "^4.7.0", features = ["rustls"] }
+suppaftp = { version = "^5.0.0", features = ["rustls"] }
 ```
 
-> 💡 If you don't know what to choose, `native-tls` should be preferred for compatibility reasons.
+> 💡 If you don't know what to choose, `native-tls` should be preferred for compatibility reasons.  
 > ❗ If you want to link libssl statically, enable feature `native-tls-vendored`
 
 #### Async support
@@ -139,11 +139,11 @@ suppaftp = { version = "^4.7.0", features = ["rustls"] }
 If you want to enable **async** support, you must enable `async` feature in your cargo dependencies.
 
 ```toml
-suppaftp = { version = "^4.7.0", features = ["async"] }
+suppaftp = { version = "^5.0.0", features = ["async"] }
 ```
 
-> ⚠️ If you want to enable both **native-tls** and **async** you must use the **async-native-tls** feature ⚠️
-> ⚠️ If you want to enable both **rustls** and **async** you must use the **async-rustls** feature ⚠️
+> ⚠️ If you want to enable both **native-tls** and **async** you must use the **async-native-tls** feature ⚠️  
+> ⚠️ If you want to enable both **rustls** and **async** you must use the **async-rustls** feature ⚠️  
 > ❗ If you want to link libssl statically, enable feature `async-native-tls-vendored`
 
 #### Deprecated methods
@@ -194,18 +194,16 @@ fn main() {
 #### Ftp with TLS (native-tls)
 
 ```rust
-use std::str;
-use std::io::Cursor;
-use suppaftp::{FtpStream};
-use suppaftp::native_tls::TlsConnector;
+use suppaftp::{NativeTlsFtpStream, NativeTlsConnector};
+use suppaftp::native_tls::{TlsConnector, TlsStream};
 
 fn main() {
-    // Create a connection to an FTP server and authenticate to it.
-    let mut ftp_stream = FtpStream::connect("127.0.0.1:21")
-        .into_secure(NativeTlsConnector::new().unwrap().into(), "domain-name")
-        .unwrap();
-    // Terminate the connection to the server.
-    let _ = ftp_stream.quit();
+    let ftp_stream = NativeTlsFtpStream::connect("test.rebex.net:21").unwrap();
+    // Switch to the secure mode
+    let mut ftp_stream = ftp_stream.into_secure(NativeTlsConnector::from(TlsConnector::new().unwrap()), "test.rebex.net").unwrap();
+    ftp_stream.login("demo", "password").unwrap();
+    // Do other secret stuff
+    assert!(ftp_stream.quit().is_ok());
 }
 ```
 
@@ -215,7 +213,7 @@ fn main() {
 use std::str;
 use std::io::Cursor;
 use std::sync::Arc;
-use suppaftp::{FtpStream};
+use suppaftp::{RustlsFtpStream, RustlsConnector};
 use suppaftp::rustls::ClientConfig;
 
 fn main() {
@@ -233,9 +231,9 @@ fn main() {
         .with_no_client_auth();
     // Create a connection to an FTP server and authenticate to it.
     let config = Arc::new(rustls_config());
-    let mut ftp_stream = FtpStream::connect("test.rebex.net:21")
+    let mut ftp_stream = RustlsFtpStream::connect("test.rebex.net:21")
         .unwrap()
-        .into_secure(Arc::clone(&config).into(), "test.rebex.net")
+        .into_secure(RustlsConnector::from(Arc::clone(&config)), "test.rebex.net")
         .unwrap();
     // Terminate the connection to the server.
     let _ = ftp_stream.quit();
@@ -245,14 +243,13 @@ fn main() {
 #### Going Async
 
 ```rust
-use suppaftp::FtpStream;
+use suppaftp::{AsyncFtpStream, AsyncNativeTlsConnector};
 use suppaftp::async_native_tls::{TlsConnector, TlsStream};
-let ftp_stream = FtpStream::connect("test.rebex.net:21").await.unwrap();
+let ftp_stream = AsyncFtpStream::connect("test.rebex.net:21").await.unwrap();
 // Switch to the secure mode
-let mut ftp_stream = ftp_stream.into_secure(TlsConnector::new().into(), "test.rebex.net").await.unwrap();
+let mut ftp_stream = ftp_stream.into_secure(AsyncNativeTlsConnector::from(TlsConnector::new()), "test.rebex.net").await.unwrap();
 ftp_stream.login("demo", "password").await.unwrap();
 // Do other secret stuff
-// Do all public stuff
 assert!(ftp_stream.quit().await.is_ok());
 ```
 

--- a/suppaftp-cli/Cargo.toml
+++ b/suppaftp-cli/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "suppaftp-cli"
 readme = "../README.md"
 repository = "https://github.com/veeso/suppaftp"
-version = "4.7.0"
+version = "5.0.0"
 
 [[bin]]
 name = "suppaftp"
@@ -21,4 +21,4 @@ argh = "^0.1"
 env_logger = "^0.10"
 log = "^0.4"
 rpassword = "^7.2"
-suppaftp = { path = "../suppaftp", version = "^4.7", features = [ "native-tls" ] }
+suppaftp = { path = "../suppaftp", version = "^5.0", features = [ "native-tls" ] }

--- a/suppaftp-cli/src/actions.rs
+++ b/suppaftp-cli/src/actions.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::path::Path;
 use suppaftp::native_tls::TlsConnector;
 use suppaftp::types::FileType;
-use suppaftp::Mode;
+use suppaftp::{Mode, NativeTlsConnector};
 
 pub fn quit(mut ftp: Option<FtpStream>) {
     if let Some(mut ftp) = ftp.take() {
@@ -60,7 +60,7 @@ pub fn connect(remote: &str, secure: bool) -> Option<FtpStream> {
         };
         // Get address without port
         let address: &str = remote.split(':').next().unwrap();
-        stream = match stream.into_secure(ctx.into(), address) {
+        stream = match stream.into_secure(NativeTlsConnector::from(ctx), address) {
             Ok(s) => s,
             Err(err) => {
                 eprintln!("Failed to setup TLS stream: {err}");

--- a/suppaftp-cli/src/main.rs
+++ b/suppaftp-cli/src/main.rs
@@ -17,7 +17,7 @@ use log::LevelFilter;
 use std::io;
 use std::io::Write;
 use std::str::FromStr;
-use suppaftp::{FtpError, FtpStream};
+use suppaftp::{FtpError, NativeTlsFtpStream as FtpStream};
 
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 const APP_AUTHORS: &str = env!("CARGO_PKG_AUTHORS");

--- a/suppaftp/Cargo.toml
+++ b/suppaftp/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "^1"
 # async
 async-std = { version = "^1.10", optional = true }
 async-native-tls-crate = { package = "async-native-tls", version = "^0.4", optional = true }
+async-trait = { version = "0.1.64", optional = true }
 async-tls = { version = "^0.11", optional = true }
 pin-project = { version = "^1", optional = true }
 # secure
@@ -41,7 +42,7 @@ webpki-roots = "0.22.5"
 [features]
 default = [ ]
 # Enable async support for suppaftp
-async = ["async-std", "pin-project"]
+async = ["async-std", "async-trait", "pin-project"]
 async-default-tls = [ "async-native-tls" ]
 async-native-tls = [ "async-native-tls-crate", "async-secure" ]
 async-rustls = [ "async-tls", "async-secure" ]

--- a/suppaftp/Cargo.toml
+++ b/suppaftp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suppaftp"
-version = "4.7.0"
+version = "5.0.0"
 authors = ["Christian Visintin <christian.visintin1997@gmail.com>", "Matt McCoy <mattnenterprise@yahoo.com>"]
 edition = "2021" 
 documentation = "https://docs.rs/suppaftp/"

--- a/suppaftp/src/async_ftp/tls.rs
+++ b/suppaftp/src/async_ftp/tls.rs
@@ -2,12 +2,92 @@
 //!
 //! Tls wrappers
 
+use async_std::io::{Read, Write};
+use async_std::net::TcpStream;
+use async_trait::async_trait;
+use std::fmt::Debug;
+
+use crate::FtpResult;
+
 #[cfg(feature = "async-native-tls")]
 mod native_tls;
 #[cfg(feature = "async-native-tls")]
-pub use self::native_tls::TlsConnector;
+pub use self::native_tls::{AsyncNativeTlsConnector, AsyncNativeTlsStream};
 
 #[cfg(feature = "async-rustls")]
 mod rustls;
 #[cfg(feature = "async-rustls")]
-pub use self::rustls::TlsConnector;
+pub use self::rustls::{AsyncRustlsConnector, AsyncRustlsStream};
+
+#[async_trait]
+pub trait AsyncTlsConnector: Debug {
+    type Stream: AsyncTlsStream;
+
+    async fn connect(&self, domain: &str, stream: TcpStream) -> FtpResult<Self::Stream>;
+}
+
+pub trait AsyncTlsStream: Debug + Read + Write + Unpin {
+    type InnerStream: Read + Write;
+
+    /// Get underlying tcp stream
+    fn tcp_stream(self) -> TcpStream;
+
+    /// Get ref to underlying tcp stream
+    fn get_ref(&self) -> &TcpStream;
+
+    /// Get mutable reference to tls stream
+    fn mut_ref(&mut self) -> &mut Self::InnerStream;
+}
+
+#[derive(Debug)]
+pub struct AsyncNoTlsStream;
+
+impl Read for AsyncNoTlsStream {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        _buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        panic!()
+    }
+}
+
+impl Write for AsyncNoTlsStream {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        _buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        panic!()
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        panic!()
+    }
+
+    fn poll_close(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        panic!()
+    }
+}
+
+impl AsyncTlsStream for AsyncNoTlsStream {
+    type InnerStream = TcpStream;
+
+    fn tcp_stream(self) -> TcpStream {
+        panic!()
+    }
+
+    fn get_ref(&self) -> &TcpStream {
+        panic!()
+    }
+
+    fn mut_ref(&mut self) -> &mut Self::InnerStream {
+        panic!()
+    }
+}

--- a/suppaftp/src/async_ftp/tls/native_tls.rs
+++ b/suppaftp/src/async_ftp/tls/native_tls.rs
@@ -2,27 +2,102 @@
 //!
 //! Native tls types for suppaftp
 
-use async_native_tls::{Error as TlsError, TlsConnector as NativeTlsConnector, TlsStream};
-use async_std::net::TcpStream;
+use async_native_tls::{TlsConnector, TlsStream};
+use async_std::{
+    io::{Read, Write},
+    net::TcpStream,
+};
+use async_trait::async_trait;
+use pin_project::pin_project;
+use std::pin::Pin;
+
+use super::{AsyncTlsConnector, AsyncTlsStream};
+use crate::{FtpError, FtpResult};
 
 #[derive(Debug)]
 /// A Wrapper for the tls connector
-pub struct TlsConnector {
-    connector: NativeTlsConnector,
+pub struct AsyncNativeTlsConnector {
+    connector: TlsConnector,
 }
 
-impl From<NativeTlsConnector> for TlsConnector {
-    fn from(connector: NativeTlsConnector) -> Self {
+impl From<TlsConnector> for AsyncNativeTlsConnector {
+    fn from(connector: TlsConnector) -> Self {
         Self { connector }
     }
 }
 
-impl TlsConnector {
-    pub async fn connect(
-        &self,
-        domain: &str,
-        stream: TcpStream,
-    ) -> Result<TlsStream<TcpStream>, TlsError> {
-        self.connector.connect(domain, stream).await
+#[async_trait]
+impl AsyncTlsConnector for AsyncNativeTlsConnector {
+    type Stream = AsyncNativeTlsStream;
+
+    async fn connect(&self, domain: &str, stream: TcpStream) -> FtpResult<Self::Stream> {
+        self.connector
+            .connect(domain, stream)
+            .await
+            .map(AsyncNativeTlsStream::from)
+            .map_err(|e| FtpError::SecureError(e.to_string()))
+    }
+}
+
+#[derive(Debug)]
+#[pin_project(project = AsyncNativeTlsStreamProj)]
+pub struct AsyncNativeTlsStream {
+    #[pin]
+    stream: TlsStream<TcpStream>,
+}
+
+impl From<TlsStream<TcpStream>> for AsyncNativeTlsStream {
+    fn from(stream: TlsStream<TcpStream>) -> Self {
+        Self { stream }
+    }
+}
+
+impl Read for AsyncNativeTlsStream {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        self.project().stream.poll_read(cx, buf)
+    }
+}
+
+impl Write for AsyncNativeTlsStream {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        self.project().stream.poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        self.project().stream.poll_flush(cx)
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        self.project().stream.poll_close(cx)
+    }
+}
+
+impl AsyncTlsStream for AsyncNativeTlsStream {
+    type InnerStream = TlsStream<TcpStream>;
+
+    fn get_ref(&self) -> &TcpStream {
+        self.stream.get_ref()
+    }
+
+    fn mut_ref(&mut self) -> &mut Self::InnerStream {
+        &mut self.stream
+    }
+
+    fn tcp_stream(self) -> TcpStream {
+        self.stream.get_ref().clone()
     }
 }

--- a/suppaftp/src/async_ftp/tls/rustls.rs
+++ b/suppaftp/src/async_ftp/tls/rustls.rs
@@ -2,33 +2,107 @@
 //!
 //! rustls types for suppaftp
 
-use async_std::io::Error as IoError;
-use async_std::net::TcpStream;
+use async_std::{
+    io::{Read, Write},
+    net::TcpStream,
+};
 use async_tls::{client::TlsStream, TlsConnector as RustlsTlsConnector};
+use async_trait::async_trait;
+use pin_project::pin_project;
+use std::pin::Pin;
+
+use super::{AsyncTlsConnector, AsyncTlsStream};
+use crate::{FtpError, FtpResult};
 
 /// A Wrapper for the tls connector
-pub struct TlsConnector {
+pub struct AsyncRustlsConnector {
     connector: RustlsTlsConnector,
 }
 
-impl std::fmt::Debug for TlsConnector {
+impl std::fmt::Debug for AsyncRustlsConnector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "<?>")
     }
 }
 
-impl From<RustlsTlsConnector> for TlsConnector {
+impl From<RustlsTlsConnector> for AsyncRustlsConnector {
     fn from(connector: RustlsTlsConnector) -> Self {
         Self { connector }
     }
 }
 
-impl TlsConnector {
-    pub async fn connect(
-        &self,
-        domain: &str,
-        stream: TcpStream,
-    ) -> Result<TlsStream<TcpStream>, IoError> {
-        self.connector.connect(domain, stream).await
+#[async_trait]
+impl AsyncTlsConnector for AsyncRustlsConnector {
+    type Stream = AsyncRustlsStream;
+
+    async fn connect(&self, domain: &str, stream: TcpStream) -> FtpResult<Self::Stream> {
+        self.connector
+            .connect(domain, stream)
+            .await
+            .map(AsyncRustlsStream::from)
+            .map_err(|e| FtpError::SecureError(e.to_string()))
+    }
+}
+
+#[derive(Debug)]
+#[pin_project(project = AsyncRustlsStreamProj)]
+pub struct AsyncRustlsStream {
+    #[pin]
+    stream: TlsStream<TcpStream>,
+}
+
+impl From<TlsStream<TcpStream>> for AsyncRustlsStream {
+    fn from(stream: TlsStream<TcpStream>) -> Self {
+        Self { stream }
+    }
+}
+
+impl Read for AsyncRustlsStream {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        self.project().stream.poll_read(cx, buf)
+    }
+}
+
+impl Write for AsyncRustlsStream {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        self.project().stream.poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        self.project().stream.poll_flush(cx)
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        self.project().stream.poll_close(cx)
+    }
+}
+
+impl AsyncTlsStream for AsyncRustlsStream {
+    type InnerStream = TlsStream<TcpStream>;
+
+    fn get_ref(&self) -> &TcpStream {
+        self.stream.get_ref()
+    }
+
+    fn mut_ref(&mut self) -> &mut Self::InnerStream {
+        &mut self.stream
+    }
+
+    fn tcp_stream(self) -> TcpStream {
+        self.stream.get_ref().clone()
     }
 }

--- a/suppaftp/src/lib.rs
+++ b/suppaftp/src/lib.rs
@@ -108,12 +108,12 @@
 //! ```rust
 //! extern crate suppaftp;
 //!
-//! use suppaftp::FtpStream;
+//! use suppaftp::{AsyncFtpStream, AsyncNativeTlsConnector};
 //! use suppaftp::async_native_tls::{TlsConnector, TlsStream};
 //!
-//! let ftp_stream = FtpStream::connect("test.rebex.net:21").await.unwrap();
+//! let ftp_stream = AsyncFtpStream::connect("test.rebex.net:21").await.unwrap();
 //! // Switch to the secure mode
-//! let mut ftp_stream = ftp_stream.into_secure(TlsConnector::new().into(), "test.rebex.net").await.unwrap();
+//! let mut ftp_stream = ftp_stream.into_secure(AsyncNativeTlsConnector::from(TlsConnector::new()), "test.rebex.net").await.unwrap();
 //! ftp_stream.login("demo", "password").await.unwrap();
 //! // Do other secret stuff
 //! // Do all public stuff
@@ -136,12 +136,11 @@ extern crate lazy_regex;
 extern crate log;
 
 // -- private
-#[cfg(any(feature = "async", feature = "async-secure"))]
+#[cfg(feature = "async")]
 mod async_ftp;
 pub(crate) mod command;
 mod regex;
 mod status;
-#[cfg(any(test, not(any(feature = "async", feature = "async-secure"))))]
 mod sync_ftp;
 
 // -- public
@@ -181,10 +180,25 @@ pub type RustlsFtpStream = ImplFtpStream<RustlsStream>;
 
 // -- export async
 #[cfg(feature = "async")]
-pub use async_ftp::FtpStream;
-// -- export async secure
-#[cfg(feature = "async-secure")]
-pub use async_ftp::TlsConnector;
+use async_ftp::AsyncNoTlsStream;
+#[cfg(feature = "async")]
+use async_ftp::ImplAsyncFtpStream;
+#[cfg(feature = "async")]
+pub type AsyncFtpStream = ImplAsyncFtpStream<AsyncNoTlsStream>;
+// -- export async secure (native-tls)
+#[cfg(feature = "async-native-tls")]
+pub use async_ftp::AsyncNativeTlsConnector;
+#[cfg(feature = "async-native-tls")]
+use async_ftp::AsyncNativeTlsStream;
+#[cfg(feature = "async-native-tls")]
+pub type AsyncNativeTlsFtpStream = ImplAsyncFtpStream<AsyncNativeTlsStream>;
+// -- export async secure (rustls)
+#[cfg(feature = "async-rustls")]
+pub use async_ftp::AsyncRustlsConnector;
+#[cfg(feature = "async-rustls")]
+use async_ftp::AsyncRustlsStream;
+#[cfg(feature = "async-rustls")]
+pub type AsyncRustlsFtpStream = ImplAsyncFtpStream<AsyncRustlsStream>;
 
 // -- test logging
 #[cfg(test)]

--- a/suppaftp/src/lib.rs
+++ b/suppaftp/src/lib.rs
@@ -21,7 +21,7 @@
 //! To get started, first add **suppaftp** to your dependencies:
 //!
 //! ```toml
-//! suppaftp = "^4.7.0"
+//! suppaftp = "^5.0.0"
 //! ```
 //!
 //! ### Features
@@ -31,9 +31,9 @@
 //! If you want to enable **support for FTPS**, you must enable the `native-tls` or `rustls` feature in your cargo dependencies, based on the TLS provider you prefer.
 //!
 //! ```toml
-//! suppaftp = { version = "^4.7.0", features = ["native-tls"] }
+//! suppaftp = { version = "^5.0.0", features = ["native-tls"] }
 //! # or
-//! suppaftp = { version = "^4.7.0", features = ["rustls"] }
+//! suppaftp = { version = "^5.0.0", features = ["rustls"] }
 //! ```
 //!
 //! > 💡 If you don't know what to choose, `native-tls` should be preferred for compatibility reasons.
@@ -43,7 +43,7 @@
 //! If you want to enable **async** support, you must enable `async` feature in your cargo dependencies.
 //!
 //! ```toml
-//! suppaftp = { version = "^4.7.0", features = ["async"] }
+//! suppaftp = { version = "^5.0.0", features = ["async"] }
 //! ```
 //!
 //! > ⚠️ If you want to enable both **native-tls** and **async** you must use the **async-native-tls** feature ⚠️
@@ -86,8 +86,6 @@
 //! ### FTPS Usage
 //!
 //! ```rust
-//! extern crate suppaftp;
-//!
 //! use suppaftp::{NativeTlsFtpStream, NativeTlsConnector};
 //! use suppaftp::native_tls::{TlsConnector, TlsStream};
 //!
@@ -106,8 +104,6 @@
 //! Let's quickly see in the example how it works
 //!
 //! ```rust
-//! extern crate suppaftp;
-//!
 //! use suppaftp::{AsyncFtpStream, AsyncNativeTlsConnector};
 //! use suppaftp::async_native_tls::{TlsConnector, TlsStream};
 //!
@@ -116,7 +112,6 @@
 //! let mut ftp_stream = ftp_stream.into_secure(AsyncNativeTlsConnector::from(TlsConnector::new()), "test.rebex.net").await.unwrap();
 //! ftp_stream.login("demo", "password").await.unwrap();
 //! // Do other secret stuff
-//! // Do all public stuff
 //! assert!(ftp_stream.quit().await.is_ok());
 //! ```
 //!

--- a/suppaftp/src/sync_ftp/mod.rs
+++ b/suppaftp/src/sync_ftp/mod.rs
@@ -12,17 +12,16 @@ use crate::command::Command;
 #[cfg(feature = "secure")]
 use crate::command::ProtectionLevel;
 use data_stream::DataStream;
-
 use tls::TlsStream;
 
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
-
 use std::fmt::Debug;
 use std::io::{copy, BufRead, BufReader, Cursor, Read, Write};
 #[cfg(not(feature = "secure"))]
 use std::marker::PhantomData;
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 
+// export
 pub use tls::NoTlsStream;
 #[cfg(feature = "secure")]
 pub use tls::TlsConnector;
@@ -404,7 +403,8 @@ where
         match self.retr_as_stream(file_name) {
             Ok(mut stream) => {
                 let result = reader(&mut stream)?;
-                self.finalize_retr_stream(stream).map(|_| result)
+                self.finalize_retr_stream(stream)?;
+                Ok(result)
             }
             Err(err) => Err(err),
         }

--- a/suppaftp/src/sync_ftp/mod.rs
+++ b/suppaftp/src/sync_ftp/mod.rs
@@ -13,59 +13,46 @@ use crate::command::Command;
 use crate::command::ProtectionLevel;
 use data_stream::DataStream;
 
-#[cfg(feature = "secure")]
 use tls::TlsStream;
 
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
+use std::fmt::Debug;
 use std::io::{copy, BufRead, BufReader, Cursor, Read, Write};
+#[cfg(not(feature = "secure"))]
+use std::marker::PhantomData;
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 
+pub use tls::NoTlsStream;
 #[cfg(feature = "secure")]
 pub use tls::TlsConnector;
+#[cfg(feature = "native-tls")]
+pub use tls::{NativeTlsConnector, NativeTlsStream};
+#[cfg(feature = "rustls")]
+pub use tls::{RustlsConnector, RustlsStream};
 
 /// Stream to interface with the FTP server. This interface is only for the command stream.
 #[derive(Debug)]
-pub struct FtpStream {
-    reader: BufReader<DataStream>,
+pub struct ImplFtpStream<T>
+where
+    T: TlsStream,
+{
+    reader: BufReader<DataStream<T>>,
     mode: Mode,
     nat_workaround: bool,
     welcome_msg: Option<String>,
+    #[cfg(not(feature = "secure"))]
+    marker: PhantomData<T>,
     #[cfg(feature = "secure")]
-    tls_ctx: Option<TlsConnector>,
+    tls_ctx: Option<Box<dyn TlsConnector<Stream = T>>>,
     #[cfg(feature = "secure")]
     domain: Option<String>,
 }
 
-impl FtpStream {
-    /// Creates an FTP Stream.
-    #[cfg(not(feature = "secure"))]
-    pub fn connect<A: ToSocketAddrs>(addr: A) -> FtpResult<Self> {
-        debug!("Connecting to server");
-        TcpStream::connect(addr)
-            .map_err(FtpError::ConnectionError)
-            .and_then(|stream| {
-                debug!("Established connection with server");
-                let mut ftp_stream = FtpStream {
-                    reader: BufReader::new(DataStream::Tcp(stream)),
-                    mode: Mode::Passive,
-                    nat_workaround: false,
-                    welcome_msg: None,
-                };
-                debug!("Reading server response...");
-                match ftp_stream.read_response(Status::Ready) {
-                    Ok(response) => {
-                        let welcome_msg = response.as_string().ok();
-                        debug!("Server READY; response: {:?}", welcome_msg);
-                        ftp_stream.welcome_msg = welcome_msg;
-                        Ok(ftp_stream)
-                    }
-                    Err(err) => Err(err),
-                }
-            })
-    }
-
-    /// Creates an FTP Stream.
+impl<T> ImplFtpStream<T>
+where
+    T: TlsStream,
+{
     #[cfg(feature = "secure")]
     pub fn connect<A: ToSocketAddrs>(addr: A) -> FtpResult<Self> {
         debug!("Connecting to server");
@@ -73,7 +60,7 @@ impl FtpStream {
             .map_err(FtpError::ConnectionError)
             .and_then(|stream| {
                 debug!("Established connection with server");
-                let mut ftp_stream = FtpStream {
+                let mut ftp_stream = Self {
                     reader: BufReader::new(DataStream::Tcp(stream)),
                     mode: Mode::Passive,
                     nat_workaround: false,
@@ -94,6 +81,33 @@ impl FtpStream {
             })
     }
 
+    #[cfg(not(feature = "secure"))]
+    /// Creates an FTP Stream.
+    pub fn connect<A: ToSocketAddrs>(addr: A) -> FtpResult<Self> {
+        debug!("Connecting to server");
+        TcpStream::connect(addr)
+            .map_err(FtpError::ConnectionError)
+            .and_then(|stream| {
+                debug!("Established connection with server");
+                let mut ftp_stream = Self {
+                    reader: BufReader::new(DataStream::Tcp(stream)),
+                    mode: Mode::Passive,
+                    nat_workaround: false,
+                    welcome_msg: None,
+                    marker: PhantomData {},
+                };
+                debug!("Reading server response...");
+                match ftp_stream.read_response(Status::Ready) {
+                    Ok(response) => {
+                        let welcome_msg = response.as_string().ok();
+                        debug!("Server READY; response: {:?}", welcome_msg);
+                        ftp_stream.welcome_msg = welcome_msg;
+                        Ok(ftp_stream)
+                    }
+                    Err(err) => Err(err),
+                }
+            })
+    }
     /// Enable active mode for data channel
     pub fn active_mode(mut self) -> Self {
         self.mode = Mode::Active;
@@ -117,18 +131,22 @@ impl FtpStream {
     /// ## Example
     ///
     /// ```rust,no_run
-    /// use suppaftp::FtpStream;
+    /// use suppaftp::{NativeTlsFtpStream, NativeTlsConnector};
     /// use suppaftp::native_tls::{TlsConnector, TlsStream};
     /// use std::path::Path;
     ///
     /// // Create a TlsConnector
     /// // NOTE: For custom options see <https://docs.rs/native-tls/0.2.6/native_tls/struct.TlsConnectorBuilder.html>
-    /// let mut ctx = TlsConnector::new().unwrap();
-    /// let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap();
+    /// let mut ctx = NativeTlsConnector::from(TlsConnector::new().unwrap());
+    /// let mut ftp_stream = NativeTlsFtpStream::connect("127.0.0.1:21").unwrap();
     /// let mut ftp_stream = ftp_stream.into_secure(ctx, "localhost").unwrap();
     /// ```
     #[cfg(feature = "secure")]
-    pub fn into_secure(mut self, tls_connector: TlsConnector, domain: &str) -> FtpResult<Self> {
+    pub fn into_secure(
+        mut self,
+        tls_connector: impl TlsConnector<Stream = T> + 'static,
+        domain: &str,
+    ) -> FtpResult<Self> {
         // Ask the server to start securing data.
         debug!("Initializing TLS auth");
         self.perform(Command::Auth)?;
@@ -138,11 +156,11 @@ impl FtpStream {
             .connect(domain, self.reader.into_inner().into_tcp_stream())
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
-        let mut secured_ftp_tream = FtpStream {
+        let mut secured_ftp_tream = Self {
             reader: BufReader::new(DataStream::Ssl(Box::new(stream))),
             mode: self.mode,
             nat_workaround: self.nat_workaround,
-            tls_ctx: Some(tls_connector),
+            tls_ctx: Some(Box::new(tls_connector)),
             domain: Some(String::from(domain)),
             welcome_msg: self.welcome_msg,
         };
@@ -175,7 +193,7 @@ impl FtpStream {
     #[cfg(all(feature = "secure", feature = "deprecated"))]
     pub fn connect_secure_implicit<A: ToSocketAddrs>(
         addr: A,
-        tls_connector: TlsConnector,
+        tls_connector: impl TlsConnector<Stream = T> + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Connecting to server (secure)");
@@ -183,7 +201,7 @@ impl FtpStream {
             .map_err(FtpError::ConnectionError)
             .map(|stream| {
                 debug!("Established connection with server");
-                FtpStream {
+                Self {
                     reader: BufReader::new(DataStream::Tcp(stream)),
                     mode: Mode::Passive,
                     nat_workaround: false,
@@ -198,11 +216,11 @@ impl FtpStream {
             .connect(domain, stream.reader.into_inner().into_tcp_stream())
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
-        let mut stream = FtpStream {
+        let mut stream = Self {
             reader: BufReader::new(DataStream::Ssl(Box::new(stream))),
             mode: Mode::Passive,
             nat_workaround: false,
-            tls_ctx: Some(tls_connector),
+            tls_ctx: Some(Box::new(tls_connector)),
             domain: Some(String::from(domain)),
             welcome_msg: None,
         };
@@ -379,9 +397,9 @@ impl FtpStream {
     /// }).is_ok());
     /// # assert!(conn.rm("retr.txt").is_ok());
     /// ```
-    pub fn retr<F, T>(&mut self, file_name: &str, mut reader: F) -> FtpResult<T>
+    pub fn retr<F, D>(&mut self, file_name: &str, mut reader: F) -> FtpResult<D>
     where
-        F: FnMut(&mut dyn Read) -> FtpResult<T>,
+        F: FnMut(&mut dyn Read) -> FtpResult<D>,
     {
         match self.retr_as_stream(file_name) {
             Ok(mut stream) => {
@@ -423,7 +441,7 @@ impl FtpStream {
     /// The reader returned should be dropped.
     /// Also you will have to read the response to make sure it has the correct value.
     /// Once file has been read, call `finalize_retr_stream()`
-    pub fn retr_as_stream<S: AsRef<str>>(&mut self, file_name: S) -> FtpResult<DataStream> {
+    pub fn retr_as_stream<S: AsRef<str>>(&mut self, file_name: S) -> FtpResult<DataStream<T>> {
         debug!("Retrieving '{}'", file_name.as_ref());
         let data_stream = self.data_command(Command::Retr(file_name.as_ref().to_string()))?;
         self.read_response_in(&[Status::AboutToSend, Status::AlreadyOpen])?;
@@ -472,7 +490,7 @@ impl FtpStream {
     /// The returned stream must be then correctly manipulated to write the content of the source file to the remote destination
     /// The stream must be then correctly dropped.
     /// Once you've finished the write, YOU MUST CALL THIS METHOD: `finalize_put_stream`
-    pub fn put_with_stream<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<DataStream> {
+    pub fn put_with_stream<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<DataStream<T>> {
         debug!("Put file {}", filename.as_ref());
         let stream = self.data_command(Command::Store(filename.as_ref().to_string()))?;
         self.read_response_in(&[Status::AlreadyOpen, Status::AboutToSend])?;
@@ -494,7 +512,7 @@ impl FtpStream {
 
     /// Open specified file for appending data. Returns the stream to append data to specified file.
     /// Once you've finished the write, YOU MUST CALL THIS METHOD: `finalize_put_stream`
-    pub fn append_with_stream<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<DataStream> {
+    pub fn append_with_stream<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<DataStream<T>> {
         debug!("Appending to file {}", filename.as_ref());
         let stream = self.data_command(Command::Appe(filename.as_ref().to_string()))?;
         self.read_response_in(&[Status::AlreadyOpen, Status::AboutToSend])?;
@@ -633,7 +651,7 @@ impl FtpStream {
     // -- private
 
     /// Retrieve stream "message"
-    fn get_lines_from_stream(data_stream: &mut BufReader<DataStream>) -> FtpResult<Vec<String>> {
+    fn get_lines_from_stream(data_stream: &mut BufReader<DataStream<T>>) -> FtpResult<Vec<String>> {
         let mut lines: Vec<String> = Vec::new();
 
         loop {
@@ -729,7 +747,7 @@ impl FtpStream {
     }
 
     /// Execute command which send data back in a separate stream
-    fn data_command(&mut self, cmd: Command) -> FtpResult<DataStream> {
+    fn data_command(&mut self, cmd: Command) -> FtpResult<DataStream<T>> {
         let stream = match self.mode {
             Mode::Active => self
                 .active()
@@ -755,7 +773,6 @@ impl FtpStream {
         match self.tls_ctx {
             Some(ref tls_ctx) => tls_ctx
                 .connect(self.domain.as_ref().unwrap(), stream)
-                .map(TlsStream::from)
                 .map(|x| DataStream::Ssl(Box::new(x)))
                 .map_err(|e| FtpError::SecureError(format!("{e}"))),
             None => Ok(DataStream::Tcp(stream)),
@@ -772,7 +789,6 @@ impl FtpStream {
 
         let ip = match self.reader.get_mut() {
             DataStream::Tcp(stream) => stream.local_addr().unwrap().ip(),
-            #[cfg(feature = "secure")]
             DataStream::Ssl(stream) => stream.get_ref().local_addr().unwrap().ip(),
         };
 
@@ -865,12 +881,13 @@ impl FtpStream {
 mod test {
 
     use super::*;
+    use crate::FtpStream;
 
     #[cfg(feature = "with-containers")]
     use crate::types::FormatControl;
 
     #[cfg(feature = "native-tls")]
-    use native_tls::TlsConnector as NativeTlsConnector;
+    use native_tls::TlsConnector;
     #[cfg(any(feature = "with-containers", feature = "secure"))]
     use pretty_assertions::assert_eq;
     #[cfg(feature = "with-containers")]
@@ -895,9 +912,12 @@ mod test {
     fn should_connect_ssl_native_tls() {
         crate::log_init();
         use std::time::Duration;
-        let ftp_stream = FtpStream::connect("test.rebex.net:21").unwrap();
+        let ftp_stream = crate::NativeTlsFtpStream::connect("test.rebex.net:21").unwrap();
         let mut ftp_stream = ftp_stream
-            .into_secure(NativeTlsConnector::new().unwrap().into(), "test.rebex.net")
+            .into_secure(
+                NativeTlsConnector::from(TlsConnector::new().unwrap()),
+                "test.rebex.net",
+            )
             .unwrap();
         // Set timeout (to test ref to ssl)
         assert!(ftp_stream
@@ -917,9 +937,12 @@ mod test {
     #[cfg(feature = "native-tls")]
     fn should_work_after_clear_command_channel_native_tls() {
         crate::log_init();
-        let mut ftp_stream = FtpStream::connect("test.rebex.net:21")
+        let mut ftp_stream = crate::NativeTlsFtpStream::connect("test.rebex.net:21")
             .unwrap()
-            .into_secure(NativeTlsConnector::new().unwrap().into(), "test.rebex.net")
+            .into_secure(
+                NativeTlsConnector::from(TlsConnector::new().unwrap()),
+                "test.rebex.net",
+            )
             .unwrap()
             .clear_command_channel()
             .unwrap();
@@ -937,9 +960,9 @@ mod test {
     fn should_connect_ssl_implicit_native_tls() {
         use std::time::Duration;
         crate::log_init();
-        let mut ftp_stream = FtpStream::connect_secure_implicit(
+        let mut ftp_stream = crate::NativeTlsFtpStream::connect_secure_implicit(
             "test.rebex.net:990",
-            NativeTlsConnector::new().unwrap().into(),
+            NativeTlsConnector::from(TlsConnector::new().unwrap()),
             "test.rebex.net",
         )
         .unwrap();
@@ -960,11 +983,16 @@ mod test {
     #[serial]
     #[cfg(feature = "rustls")]
     fn should_connect_ssl_rustls() {
+        use super::tls::RustlsConnector;
+
         crate::log_init();
         let config = Arc::new(rustls_config());
-        let mut ftp_stream = FtpStream::connect("ftp.uni-bayreuth.de:21")
+        let mut ftp_stream = crate::RustlsFtpStream::connect("ftp.uni-bayreuth.de:21")
             .unwrap()
-            .into_secure(Arc::clone(&config).into(), "ftp.uni-bayreuth.de")
+            .into_secure(
+                RustlsConnector::from(Arc::clone(&config)),
+                "ftp.uni-bayreuth.de",
+            )
             .unwrap();
         // Quit
         assert!(ftp_stream.quit().is_ok());

--- a/suppaftp/src/sync_ftp/tls.rs
+++ b/suppaftp/src/sync_ftp/tls.rs
@@ -2,12 +2,56 @@
 //!
 //! Tls wrappers
 
+use std::io::Write;
+use std::net::TcpStream;
+use std::{fmt::Debug, io::Read};
+
 #[cfg(feature = "native-tls")]
 mod native_tls;
+use crate::FtpResult;
+
 #[cfg(feature = "native-tls")]
-pub use self::native_tls::{TlsConnector, TlsStream};
+pub use self::native_tls::{NativeTlsConnector, NativeTlsStream};
 
 #[cfg(feature = "rustls")]
 mod rustls;
 #[cfg(feature = "rustls")]
-pub use self::rustls::{TlsConnector, TlsStream};
+pub use self::rustls::{RustlsConnector, RustlsStream};
+
+pub trait TlsConnector: Debug {
+    type Stream: TlsStream;
+
+    fn connect(&self, domain: &str, stream: TcpStream) -> FtpResult<Self::Stream>;
+}
+
+pub trait TlsStream: Debug {
+    type InnerStream: Read + Write;
+
+    /// Get underlying tcp stream
+    fn tcp_stream(self) -> TcpStream;
+
+    /// Get ref to underlying tcp stream
+    fn get_ref(&self) -> &TcpStream;
+
+    /// Get mutable reference to tls stream
+    fn mut_ref(&mut self) -> &mut Self::InnerStream;
+}
+
+#[derive(Debug)]
+pub struct NoTlsStream;
+
+impl TlsStream for NoTlsStream {
+    type InnerStream = TcpStream;
+
+    fn tcp_stream(self) -> TcpStream {
+        panic!()
+    }
+
+    fn get_ref(&self) -> &TcpStream {
+        panic!()
+    }
+
+    fn mut_ref(&mut self) -> &mut Self::InnerStream {
+        panic!()
+    }
+}


### PR DESCRIPTION
# ISSUE 33 - Additive features

Fixes #33

## Description

- [Issue 33](https://github.com/veeso/suppaftp/issues/33) **‼️ BREAKING CHANGES ‼️**
  - Features are now additive. This means that you can successfully build suppaftp with all the features enabled at the same time.
  - Ftp stream has now been split into different types:
    - `FtpStream`: sync no-tls stream
    - `NativeTlsFtpStream`: ftp stream with TLS with native-tls
    - `RustlsFtpStream`: ftp stream with TLS with rustls
    - `AsyncFtpStream`: async no-tls stream
    - `AsyncNativeTlsFtpStream`: async ftp stream with TLS with async-native-tls
    - `AsyncRustlsFtpStream`: async ftp stream with TLS with async-rustls

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

