### PR TITLE
connect_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [5.1.0](#510)
   - [5.0.1](#501)
   - [5.0.0](#500)
   - [4.7.0](#470)
@@ -22,6 +23,12 @@
   - [4.0.0](#400)
 
 ---
+
+## 5.1.0
+
+Released on 02/03/2023
+
+- Implemented new connection method `connect_timeout` with the possibility to specify a timeout on connect
 
 ## 5.0.1
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ SuppaFTP is the main FTP/FTPS client library for Rust, with both support for syn
 To get started, first add **suppaftp** to your dependencies:
 
 ```toml
-suppaftp = "^5.0.0"
+suppaftp = "^5.1.0"
 ```
 
 ### Features
@@ -126,9 +126,9 @@ suppaftp = "^5.0.0"
 If you want to enable **support for FTPS**, you must enable the `native-tls` or `rustls` feature in your cargo dependencies, based on the TLS provider you prefer.
 
 ```toml
-suppaftp = { version = "^5.0.0", features = ["native-tls"] }
+suppaftp = { version = "^5.1.0", features = ["native-tls"] }
 # or
-suppaftp = { version = "^5.0.0", features = ["rustls"] }
+suppaftp = { version = "^5.1.0", features = ["rustls"] }
 ```
 
 > 💡 If you don't know what to choose, `native-tls` should be preferred for compatibility reasons.  
@@ -139,7 +139,7 @@ suppaftp = { version = "^5.0.0", features = ["rustls"] }
 If you want to enable **async** support, you must enable `async` feature in your cargo dependencies.
 
 ```toml
-suppaftp = { version = "^5.0.0", features = ["async"] }
+suppaftp = { version = "^5.1.0", features = ["async"] }
 ```
 
 > ⚠️ If you want to enable both **native-tls** and **async** you must use the **async-native-tls** feature ⚠️  

--- a/suppaftp/Cargo.toml
+++ b/suppaftp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suppaftp"
-version = "5.0.1"
+version = "5.1.0"
 authors = ["Christian Visintin <christian.visintin1997@gmail.com>", "Matt McCoy <mattnenterprise@yahoo.com>"]
 edition = "2021" 
 documentation = "https://docs.rs/suppaftp/"

--- a/suppaftp/src/lib.rs
+++ b/suppaftp/src/lib.rs
@@ -21,7 +21,7 @@
 //! To get started, first add **suppaftp** to your dependencies:
 //!
 //! ```toml
-//! suppaftp = "^5.0.0"
+//! suppaftp = "^5.1.0"
 //! ```
 //!
 //! ### Features
@@ -31,9 +31,9 @@
 //! If you want to enable **support for FTPS**, you must enable the `native-tls` or `rustls` feature in your cargo dependencies, based on the TLS provider you prefer.
 //!
 //! ```toml
-//! suppaftp = { version = "^5.0.0", features = ["native-tls"] }
+//! suppaftp = { version = "^5.1.0", features = ["native-tls"] }
 //! # or
-//! suppaftp = { version = "^5.0.0", features = ["rustls"] }
+//! suppaftp = { version = "^5.1.0", features = ["rustls"] }
 //! ```
 //!
 //! > 💡 If you don't know what to choose, `native-tls` should be preferred for compatibility reasons.
@@ -43,7 +43,7 @@
 //! If you want to enable **async** support, you must enable `async` feature in your cargo dependencies.
 //!
 //! ```toml
-//! suppaftp = { version = "^5.0.0", features = ["async"] }
+//! suppaftp = { version = "^5.1.0", features = ["async"] }
 //! ```
 //!
 //! > ⚠️ If you want to enable both **native-tls** and **async** you must use the **async-native-tls** feature ⚠️


### PR DESCRIPTION
# 37 - connect timeout method

Fixes #37

## Description

- Implemented new connection method `connect_timeout` with the possibility to specify a timeout on connect

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

