### PR TITLE
Fix typo in Readme, put -> put_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ fn main() {
 
     // Store (PUT) a file from the client to the current working directory of the server.
     let mut reader = Cursor::new("Hello from the Rust \"ftp\" crate!".as_bytes());
-    let _ = ftp_stream.put("greeting.txt", &mut reader);
+    let _ = ftp_stream.put_file("greeting.txt", &mut reader);
     println!("Successfully wrote greeting.txt");
 
     // Terminate the connection to the server.


### PR DESCRIPTION
## Description

Brand new to this crate and was trying the sample code and had an error.

Fixes typo in example code in the README.

```
no method named `put` found for struct `ImplFtpStream`
```

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I formatted the code with `cargo fmt`
- [ ] I linted my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have introduced no *C-bindings*
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
