### PR TITLE
Improve example from async on readme and avoid errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ suppaftp = { version = "^5.2.0", features = ["native-tls"] }
 suppaftp = { version = "^5.2.0", features = ["rustls"] }
 ```
 
-> 💡 If you don't know what to choose, `native-tls` should be preferred for compatibility reasons.  
+> 💡 If you don't know what to choose, `native-tls` should be preferred for compatibility reasons.
 > ❗ If you want to link libssl statically, enable feature `native-tls-vendored`
 
 #### Async support
@@ -148,8 +148,8 @@ If you want to enable **async** support, you must enable `async` feature in your
 suppaftp = { version = "^5.2.0", features = ["async"] }
 ```
 
-> ⚠️ If you want to enable both **native-tls** and **async** you must use the **async-native-tls** feature ⚠️  
-> ⚠️ If you want to enable both **rustls** and **async** you must use the **async-rustls** feature ⚠️  
+> ⚠️ If you want to enable both **native-tls** and **async** you must use the **async-native-tls** feature ⚠️
+> ⚠️ If you want to enable both **rustls** and **async** you must use the **async-rustls** feature ⚠️
 > ❗ If you want to link libssl statically, enable feature `async-native-tls-vendored`
 
 #### Deprecated methods
@@ -249,9 +249,9 @@ fn main() {
 #### Going Async
 
 ```rust
-use suppaftp::{AsyncFtpStream, AsyncNativeTlsConnector};
+use suppaftp::{AsyncNativeTlsFtpStream, AsyncNativeTlsConnector};
 use suppaftp::async_native_tls::{TlsConnector, TlsStream};
-let ftp_stream = AsyncFtpStream::connect("test.rebex.net:21").await.unwrap();
+let ftp_stream = AsyncNativeFtpStream::connect("test.rebex.net:21").await.unwrap();
 // Switch to the secure mode
 let mut ftp_stream = ftp_stream.into_secure(AsyncNativeTlsConnector::from(TlsConnector::new()), "test.rebex.net").await.unwrap();
 ftp_stream.login("demo", "password").await.unwrap();


### PR DESCRIPTION
# 52 - expected `AsyncNoTlsStream`, found `AsyncNativeTlsStream`

Fixes #52 

## Description

After digging a little bit, I've found the docs are wrong and this PR fixes it.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update