### PR TITLE
Add POSIX setgid/setuid/sticky bit support

### DIFF
--- a/suppaftp/src/list.rs
+++ b/suppaftp/src/list.rs
@@ -194,7 +194,7 @@ impl File {
         match POSIX_LS_RE.captures(line) {
             // String matches regex
             Some(metadata) => {
-                trace!("Parsed POXIS line {}", line);
+                trace!("Parsed POSIX line {}", line);
                 // NOTE: metadata fmt: (regex, file_type, permissions, link_count, uid, gid, filesize, mtime, filename)
                 // Expected 7 + 1 (8) values: + 1 cause regex is repeated at 0
                 if metadata.len() < 8 {
@@ -414,10 +414,11 @@ impl TryFrom<&str> for File {
     type Error = ParseError;
 
     fn try_from(line: &str) -> Result<Self, Self::Error> {
+        // First try to parse the line in POSIX format (vast majority case).
         match Self::from_posix_line(line) {
             Ok(entry) => Ok(entry),
+            // If POSIX parsing fails, try with DOS parser.
             Err(_) => match Self::from_dos_line(line) {
-                // If POSIX parsing fails, try with DOS parser
                 Ok(entry) => Ok(entry),
                 Err(err) => Err(err),
             },

--- a/suppaftp/src/list.rs
+++ b/suppaftp/src/list.rs
@@ -214,7 +214,7 @@ impl File {
                     let mut count: u8 = 0;
                     for (i, c) in metadata.get(2).unwrap().as_str()[range].chars().enumerate() {
                         match c {
-                            '-' => {}
+                            '-' | 'S' | 'T' => {}
                             _ => {
                                 count += match i {
                                     0 => 4,
@@ -586,6 +586,94 @@ mod test {
                 .unwrap(),
             Duration::from_secs(1541376000)
         );
+        // Setuid bit
+        let file: File =
+            File::from_str("drws------    2 u-redacted g-redacted      3864 Feb 17  2023 sas")
+                .ok()
+                .unwrap();
+        assert_eq!(file.is_directory(), true);
+        assert_eq!(file.can_read(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_write(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_execute(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_read(PosixPexQuery::Group), false);
+        assert_eq!(file.can_write(PosixPexQuery::Group), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Group), false);
+        assert_eq!(file.can_read(PosixPexQuery::Others), false);
+        assert_eq!(file.can_write(PosixPexQuery::Others), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Others), false);
+        let file: File =
+            File::from_str("drwS------    2 u-redacted g-redacted      3864 Feb 17  2023 sas")
+                .ok()
+                .unwrap();
+        assert_eq!(file.is_directory(), true);
+        assert_eq!(file.can_read(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_write(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_execute(PosixPexQuery::Owner), false);
+        assert_eq!(file.can_read(PosixPexQuery::Group), false);
+        assert_eq!(file.can_write(PosixPexQuery::Group), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Group), false);
+        assert_eq!(file.can_read(PosixPexQuery::Others), false);
+        assert_eq!(file.can_write(PosixPexQuery::Others), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Others), false);
+        // Setgid bit
+        let file: File =
+            File::from_str("drwx--s---    2 u-redacted g-redacted      3864 Feb 17  2023 sas")
+                .ok()
+                .unwrap();
+        assert_eq!(file.is_directory(), true);
+        assert_eq!(file.can_read(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_write(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_execute(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_read(PosixPexQuery::Group), false);
+        assert_eq!(file.can_write(PosixPexQuery::Group), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Group), true);
+        assert_eq!(file.can_read(PosixPexQuery::Others), false);
+        assert_eq!(file.can_write(PosixPexQuery::Others), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Others), false);
+        let file: File =
+            File::from_str("drwx--S---    2 u-redacted g-redacted      3864 Feb 17  2023 sas")
+                .ok()
+                .unwrap();
+        assert_eq!(file.is_directory(), true);
+        assert_eq!(file.can_read(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_write(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_execute(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_read(PosixPexQuery::Group), false);
+        assert_eq!(file.can_write(PosixPexQuery::Group), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Group), false);
+        assert_eq!(file.can_read(PosixPexQuery::Others), false);
+        assert_eq!(file.can_write(PosixPexQuery::Others), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Others), false);
+        // Sticky bit
+        let file: File =
+            File::from_str("drwx-----t    2 u-redacted g-redacted      3864 Feb 17  2023 sas")
+                .ok()
+                .unwrap();
+        assert_eq!(file.is_directory(), true);
+        assert_eq!(file.can_read(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_write(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_execute(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_read(PosixPexQuery::Group), false);
+        assert_eq!(file.can_write(PosixPexQuery::Group), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Group), false);
+        assert_eq!(file.can_read(PosixPexQuery::Others), false);
+        assert_eq!(file.can_write(PosixPexQuery::Others), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Others), true);
+        let file: File =
+            File::from_str("drwx--S--T    2 u-redacted g-redacted      3864 Feb 17  2023 sas")
+                .ok()
+                .unwrap();
+        assert_eq!(file.is_directory(), true);
+        assert_eq!(file.can_read(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_write(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_execute(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_read(PosixPexQuery::Group), false);
+        assert_eq!(file.can_write(PosixPexQuery::Group), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Group), false);
+        assert_eq!(file.can_read(PosixPexQuery::Others), false);
+        assert_eq!(file.can_write(PosixPexQuery::Others), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Others), false);
+
         // Error
         assert_eq!(
             File::from_posix_line("drwxrwxr-x 1 0  9  Nov 5 2018 docs")

--- a/suppaftp/src/list.rs
+++ b/suppaftp/src/list.rs
@@ -47,7 +47,7 @@ use thiserror::Error;
 
 /// POSIX system regex to parse list output
 static POSIX_LS_RE: Lazy<Regex> = lazy_regex!(
-    r#"^([\-ld])([\-rwxs]{9})\s+(\d+)\s+(.+)\s+(.+)\s+(\d+)\s+(.+\s+\d{1,2}\s+(?:\d{1,2}:\d{1,2}|\d{4}))\s+(.+)$"#
+    r#"^([\-ld])([\-rwxsStT]{9})\s+(\d+)\s+(.+)\s+(.+)\s+(\d+)\s+(.+\s+\d{1,2}\s+(?:\d{1,2}:\d{1,2}|\d{4}))\s+(.+)$"#
 );
 /// DOS system regex to parse list output
 static DOS_LS_RE: Lazy<Regex> =


### PR DESCRIPTION
# ISSUE #58 - Add POSIX setgid/setuid/sticky bit support

Fixes #58 

## Description

- Here, I adjust the `POSIX_LS_RE` to account for `s`, `S`, `t`, and `T` in the "pex"-y positions, by adding them to the set of characters we scan for 9 of. Now, the following characters are included in the scan:
  
  `-rwxsStT`, where previously only `-rwxs` were supported. Off-hand, it appears the `s` was an attempt to support setuid/setgid, but it did not cover the case where the `x` bit is _not_ set, which renders as a `S`.

  Because this regex did not previously validate for the correct ordering (i.e., refuting strange combos like `rxw`), I did not add them in this PR.
  
- The `pex` parsing closure, which does some simple arithmetic to determine the "pex" value, needed some updates.

  `S` and `T` indicate the presence of a setuid/setgid bit, or a sticky bit, but _without_ `x`. (If `x` is set, then the `S` instead is typically reported as `s`.)
  
  So, I added `S` and `T` as exceptions in addition to `-`. They will be treated the same. With this change, no information is recorded about the setuid/setgid bits, and I don't think the interpretation of them is of great importance at this time given they are interpreted locally by the operating system and they have different meanings.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no *C-bindings*
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
