### PR TITLE
feat: Send + Sync trait to AsyncFtpStream/FtpStream

### DIFF
--- a/suppaftp/src/async_ftp/mod.rs
+++ b/suppaftp/src/async_ftp/mod.rs
@@ -179,7 +179,7 @@ where
     )]
     pub async fn connect_secure_implicit<A: ToSocketAddrs>(
         addr: A,
-        tls_connector: impl AsyncTlsConnector<Stream = T> + 'static,
+        tls_connector: impl AsyncTlsConnector<Stream = T> + Send + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Connecting to server (secure)");

--- a/suppaftp/src/async_ftp/mod.rs
+++ b/suppaftp/src/async_ftp/mod.rs
@@ -46,7 +46,7 @@ where
     #[cfg(not(feature = "async-secure"))]
     marker: PhantomData<T>,
     #[cfg(feature = "async-secure")]
-    tls_ctx: Option<Box<dyn AsyncTlsConnector<Stream = T>>>,
+    tls_ctx: Option<Box<dyn AsyncTlsConnector<Stream = T> + Send + 'static>>,
     #[cfg(feature = "async-secure")]
     domain: Option<String>,
 }
@@ -121,7 +121,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "async-secure")))]
     pub async fn into_secure(
         mut self,
-        tls_connector: impl AsyncTlsConnector<Stream = T> + 'static,
+        tls_connector: impl AsyncTlsConnector<Stream = T> + Send + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Initializing TLS auth");

--- a/suppaftp/src/async_ftp/mod.rs
+++ b/suppaftp/src/async_ftp/mod.rs
@@ -46,7 +46,7 @@ where
     #[cfg(not(feature = "async-secure"))]
     marker: PhantomData<T>,
     #[cfg(feature = "async-secure")]
-    tls_ctx: Option<Box<dyn AsyncTlsConnector<Stream = T> + Send + 'static>>,
+    tls_ctx: Option<Box<dyn AsyncTlsConnector<Stream = T> + Send + Sync + 'static>>,
     #[cfg(feature = "async-secure")]
     domain: Option<String>,
 }
@@ -121,7 +121,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "async-secure")))]
     pub async fn into_secure(
         mut self,
-        tls_connector: impl AsyncTlsConnector<Stream = T> + Send + 'static,
+        tls_connector: impl AsyncTlsConnector<Stream = T> + Send + Sync + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Initializing TLS auth");
@@ -179,7 +179,7 @@ where
     )]
     pub async fn connect_secure_implicit<A: ToSocketAddrs>(
         addr: A,
-        tls_connector: impl AsyncTlsConnector<Stream = T> + Send + 'static,
+        tls_connector: impl AsyncTlsConnector<Stream = T> + Send + Sync + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Connecting to server (secure)");

--- a/suppaftp/src/sync_ftp/mod.rs
+++ b/suppaftp/src/sync_ftp/mod.rs
@@ -184,7 +184,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(all(feature = "secure", feature = "deprecated"))))]
     pub fn connect_secure_implicit<A: ToSocketAddrs>(
         addr: A,
-        tls_connector: impl TlsConnector<Stream = T> + 'static,
+        tls_connector: impl TlsConnector<Stream = T> + Send + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Connecting to server (secure)");

--- a/suppaftp/src/sync_ftp/mod.rs
+++ b/suppaftp/src/sync_ftp/mod.rs
@@ -45,7 +45,7 @@ where
     #[cfg(not(feature = "secure"))]
     marker: PhantomData<T>,
     #[cfg(feature = "secure")]
-    tls_ctx: Option<Box<dyn TlsConnector<Stream = T>>>,
+    tls_ctx: Option<Box<dyn TlsConnector<Stream = T> + Send + 'static>>,
     #[cfg(feature = "secure")]
     domain: Option<String>,
 }
@@ -134,7 +134,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "secure")))]
     pub fn into_secure(
         mut self,
-        tls_connector: impl TlsConnector<Stream = T> + 'static,
+        tls_connector: impl TlsConnector<Stream = T> + Send + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         // Ask the server to start securing data.

--- a/suppaftp/src/sync_ftp/mod.rs
+++ b/suppaftp/src/sync_ftp/mod.rs
@@ -45,7 +45,7 @@ where
     #[cfg(not(feature = "secure"))]
     marker: PhantomData<T>,
     #[cfg(feature = "secure")]
-    tls_ctx: Option<Box<dyn TlsConnector<Stream = T> + Send + 'static>>,
+    tls_ctx: Option<Box<dyn TlsConnector<Stream = T> + Send + Sync + 'static>>,
     #[cfg(feature = "secure")]
     domain: Option<String>,
 }
@@ -134,7 +134,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "secure")))]
     pub fn into_secure(
         mut self,
-        tls_connector: impl TlsConnector<Stream = T> + Send + 'static,
+        tls_connector: impl TlsConnector<Stream = T> + Send + Sync + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         // Ask the server to start securing data.
@@ -184,7 +184,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(all(feature = "secure", feature = "deprecated"))))]
     pub fn connect_secure_implicit<A: ToSocketAddrs>(
         addr: A,
-        tls_connector: impl TlsConnector<Stream = T> + Send + 'static,
+        tls_connector: impl TlsConnector<Stream = T> + Send + Sync +'static,
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Connecting to server (secure)");


### PR DESCRIPTION
45 - Send + Sync traits to AsyncFtpStream/FtpStream

Fixes #45 

## Description

To make AsyncFtpStream/FtpStream Send+Sync, tls_ctx should be declared as Send+Sync. AsyncTlsConnector and TlsConnector already satisfay Send+Sync traits so no breaking change is expected

List here your changes

- `tls_ctx: Option<Box<dyn AsyncTlsConnector<Stream = T>>>` to `tls_ctx: Option<Box<dyn AsyncTlsConnector<Stream = T> + Send + Sync + 'static>`

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
