### PR TITLE
Fix abort() getting stuck when being passed a reference

### DIFF
--- a/suppaftp/src/async_ftp/mod.rs
+++ b/suppaftp/src/async_ftp/mod.rs
@@ -523,7 +523,7 @@ where
     /// abort the previous FTP service command
     pub async fn abort<R>(&mut self, data_stream: R) -> FtpResult<()>
     where
-        R: Read + std::marker::Unpin,
+        R: Read + std::marker::Unpin + 'static,
     {
         debug!("Aborting active file transfer");
         self.perform(Command::Abor).await?;

--- a/suppaftp/src/sync_ftp/mod.rs
+++ b/suppaftp/src/sync_ftp/mod.rs
@@ -522,7 +522,7 @@ where
     }
 
     /// abort the previous FTP service command
-    pub fn abort(&mut self, data_stream: impl Read) -> FtpResult<()> {
+    pub fn abort(&mut self, data_stream: impl Read + 'static) -> FtpResult<()> {
         debug!("Aborting active file transfer");
         self.perform(Command::Abor)?;
         // Drop stream NOTE: must be done first, otherwise server won't return any response


### PR DESCRIPTION
# ISSUE 66 - Fix abort() getting stuck when being passed a reference

Fixes #66 

## Description

- It was possible to pass a reference to data_stream, instead of ownership, which the code intended.
- Require 'static, ie. normal references cannot be passed anymore.
- Could stop old, buggy code from compiling.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] **not really** it only stops previously broken code from compiling
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
   - [x] the tests still compile
- [x] I have introduced no *C-bindings*
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
