### PR TITLE
Fixed async example

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ fn main() {
 ```rust
 use suppaftp::{AsyncNativeTlsFtpStream, AsyncNativeTlsConnector};
 use suppaftp::async_native_tls::{TlsConnector, TlsStream};
-let ftp_stream = AsyncNativeFtpStream::connect("test.rebex.net:21").await.unwrap();
+let ftp_stream = AsyncNativeTlsFtpStream::connect("test.rebex.net:21").await.unwrap();
 // Switch to the secure mode
 let mut ftp_stream = ftp_stream.into_secure(AsyncNativeTlsConnector::from(TlsConnector::new()), "test.rebex.net").await.unwrap();
 ftp_stream.login("demo", "password").await.unwrap();


### PR DESCRIPTION
I die

Fixes # Incorrect Async example

## Description
Changed the documentation for the Async example on the projects home page, it was using a incorrect import.

- I fixed the AsyncTLS example code

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no *C-bindings*
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
