### PR TITLE
fix: Build badge was using an incorrect path resulting in false "failed" status

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 <p align="center">
   <a href="https://github.com/veeso/suppaftp/actions"
     ><img
-      src="https://github.com/veeso/suppaftp/workflows/Build/badge.svg"
+      src="https://github.com/veeso/suppaftp/actions/workflows/cargo.yml/badge.svg"
       alt="Lib-CI"
   /></a>
   <a href="https://github.com/veeso/suppaftp/actions"


### PR DESCRIPTION
I think it was using and outdated format.

New: https://github.com/veeso/suppaftp/actions/workflows/cargo.yml/badge.svg

Old: https://github.com/veeso/suppaftp/workflows/Build/badge.svg

## Description

The build badge was reporting previous builds as if they were failing. The Actions page says otherwise. With builds being incorrectly reported as failed, it might deter people from using suppaftp.

List here your changes

- Updated the SVG path for the build badge on the projects readme

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no *C-bindings*
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
