### PR TITLE
fix:ms-dos date format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [6.0.1](#601)
   - [6.0.0](#600)
   - [5.4.0](#540)
   - [5.3.1](#531)
@@ -32,6 +33,12 @@
   - [4.0.0](#400)
 
 ---
+
+## 6.0.1
+
+Released on 24/05/2024
+
+- [PR 84](https://github.com/veeso/suppaftp/pull/84): LIST with DOS lines parsed `%d-%m` but the correct syntax is `%m-%d`
 
 ## 6.0.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["suppaftp", "suppaftp-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "6.0.0"
+version = "6.0.1"
 edition = "2021"
 authors = [
   "Christian Visintin <christian.visintin@veeso.dev>",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">Developed by <a href="https://veeso.github.io/">veeso</a> and <a href="https://github.com/mattnenterprise">Matt McCoy</a></p>
-<p align="center">Current version: 6.0.0 (20/05/2024)</p>
+<p align="center">Current version: 6.0.1 (24/05/2024)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"

--- a/suppaftp/src/list.rs
+++ b/suppaftp/src/list.rs
@@ -478,7 +478,7 @@ impl File {
             .unwrap_or(SystemTime::UNIX_EPOCH))
     }
 
-    /// Parse date time string in DOS representation ("%d-%m-%y %I:%M%p")
+    /// Parse date time string in DOS representation ("%m-%d-%y %I:%M%p")
     fn parse_dostime(tm: &str) -> Result<SystemTime, ParseError> {
         NaiveDateTime::parse_from_str(tm, "%m-%d-%y %I:%M%p")
             .map(|dt| {
@@ -810,7 +810,7 @@ mod test {
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .ok()
                 .unwrap(),
-            Duration::from_secs(1407164940)
+            Duration::from_secs(1396969740)
         );
         // Parse directory
         let dir: File = File::try_from("04-08-14  03:09PM  <DIR> docs")
@@ -834,7 +834,7 @@ mod test {
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .ok()
                 .unwrap(),
-            Duration::from_secs(1407164940)
+            Duration::from_secs(1396969740)
         );
         // Error
         assert_eq!(
@@ -942,7 +942,7 @@ mod test {
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .ok()
                 .unwrap(),
-            Duration::from_secs(1407164940)
+            Duration::from_secs(1396969740)
         );
         // Not enough argument for datetime
         assert!(File::parse_dostime("04-08-14").is_err());

--- a/suppaftp/src/list.rs
+++ b/suppaftp/src/list.rs
@@ -480,7 +480,7 @@ impl File {
 
     /// Parse date time string in DOS representation ("%d-%m-%y %I:%M%p")
     fn parse_dostime(tm: &str) -> Result<SystemTime, ParseError> {
-        NaiveDateTime::parse_from_str(tm, "%d-%m-%y %I:%M%p")
+        NaiveDateTime::parse_from_str(tm, "%m-%d-%y %I:%M%p")
             .map(|dt| {
                 SystemTime::UNIX_EPOCH
                     .checked_add(Duration::from_secs(dt.and_utc().timestamp() as u64))


### PR DESCRIPTION
My Windows FTP server responds to the LIST command with data formatted like this : 
"12-20-22  02:45PM       <DIR>          games"
This causes a date parsing error, According to Microsoft documentations, the standard dateformat should be month-day-year .
Reference : https://learn.microsoft.com/en-us/windows/win32/sysinfo/ms-dos-date-and-time