### PR TITLE
fix: Passive mode with custom provided TcpStream

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build all features
         run: cargo build --features deprecated,native-tls,rustls,async-native-tls,async-rustls --package suppaftp
       - name: Run tests
-        run: cargo test --package suppaftp --no-default-features --features rustls,native-tls,async-native-tls,async-rustls,with-containers --no-fail-fast
+        run: cargo test --lib --package suppaftp --no-default-features --features rustls,native-tls,async-native-tls,async-rustls,with-containers --no-fail-fast
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           override: true
@@ -18,42 +18,19 @@ jobs:
       - name: Setup containers
         run: docker-compose -f "tests/docker-compose.yml" up -d --build
       - name: Build simple
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --package suppaftp
+        run: cargo build --package suppaftp
       - name: Build secure (native-tls)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features native-tls,deprecated --package suppaftp
+        run: cargo build --features native-tls,deprecated --package suppaftp
       - name: Build secure (rustls)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features rustls,deprecated --package suppaftp
+        run: cargo build --features rustls,deprecated --package suppaftp
       - name: Build async
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features async,deprecated --package suppaftp
+        run: cargo build --features async,deprecated --package suppaftp
       - name: Build async-native-tls
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features async-native-tls,deprecated --package suppaftp
+        run: cargo build --features async-native-tls,deprecated --package suppaftp
       - name: Build all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features deprecated,native-tls,rustls,async-native-tls,async-rustls --package suppaftp
+        run: cargo build --features deprecated,native-tls,rustls,async-native-tls,async-rustls --package suppaftp
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib --package suppaftp --no-default-features --features rustls,native-tls,async-native-tls,async-rustls,with-containers --no-fail-fast
-        env:
-          RUST_LOG: trace
+        run: cargo test --package suppaftp --no-default-features --features rustls,native-tls,async-native-tls,async-rustls,with-containers --no-fail-fast
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -16,7 +16,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Setup containers
-        run: docker-compose -f "tests/docker-compose.yml" up -d --build
+        run: docker compose -f "tests/docker-compose.yml" up -d --build
       - name: Build simple
         run: cargo build --package suppaftp
       - name: Build secure (native-tls)

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -13,16 +13,13 @@ jobs:
         working-directory: ./suppaftp-cli
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           override: true
           components: rustfmt, clippy
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --package suppaftp-cli
+        run: cargo build --package suppaftp-cli
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
           toolchain: nightly
           override: true
       - name: Run tests (nightly)
-        run: cargo test --package suppaftp --no-default-features --features native-tls,deprecated,async-native-tls,with-containers --no-fail-fast
+        run: cargo test --lib --package suppaftp --no-default-features --features native-tls,deprecated,async-native-tls,with-containers --no-fail-fast
         env:
           RUST_LOG: trace
           CARGO_INCREMENTAL: "0"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup containers
-        run: docker-compose -f "tests/docker-compose.yml" up -d --build
+        run: docker compose -f "tests/docker-compose.yml" up -d --build
       - name: Setup nightly toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,15 +14,12 @@ jobs:
       - name: Setup containers
         run: docker-compose -f "tests/docker-compose.yml" up -d --build
       - name: Setup nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
           override: true
       - name: Run tests (nightly)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib --no-default-features --features native-tls,deprecated,async-native-tls,with-containers --no-fail-fast
+        run: cargo test --package suppaftp --no-default-features --features native-tls,deprecated,async-native-tls,with-containers --no-fail-fast
         env:
           RUST_LOG: trace
           CARGO_INCREMENTAL: "0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [6.0.2](#602)
   - [6.0.1](#601)
   - [6.0.0](#600)
   - [5.4.0](#540)
@@ -33,6 +34,12 @@
   - [4.0.0](#400)
 
 ---
+
+## 6.0.2
+
+Released on 14/10/2024
+
+- [Issue 89](https://github.com/veeso/suppaftp/issues/89): added new `FtpStream::passive_stream_builder` to provide a function to build the Passive mode `TcpStream` with a custom builder. This is useful if you need to use some proxy.
 
 ## 6.0.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["suppaftp", "suppaftp-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "6.0.1"
+version = "6.0.2"
 edition = "2021"
 authors = [
   "Christian Visintin <christian.visintin@veeso.dev>",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">Developed by <a href="https://veeso.github.io/">veeso</a> and <a href="https://github.com/mattnenterprise">Matt McCoy</a></p>
-<p align="center">Current version: 6.0.1 (24/05/2024)</p>
+<p align="center">Current version: 6.0.2 (14/10/2024)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"

--- a/suppaftp/Cargo.toml
+++ b/suppaftp/Cargo.toml
@@ -36,7 +36,7 @@ async-tls = { version = "^0.13", optional = true }
 pin-project = { version = "^1", optional = true }
 # secure
 native-tls-crate = { package = "native-tls", version = "^0.2", optional = true }
-rustls-crate = { package = "rustls", version = "^0.21", optional = true }
+rustls-crate = { package = "rustls", version = "^0.23", optional = true }
 futures-lite = "2.0.0"
 
 [dev-dependencies]

--- a/suppaftp/src/sync_ftp/tls/rustls.rs
+++ b/suppaftp/src/sync_ftp/tls/rustls.rs
@@ -6,7 +6,8 @@ use std::io::Write;
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls::{ClientConfig, ClientConnection, ServerName, StreamOwned};
+use rustls::pki_types::ServerName;
+use rustls::{ClientConfig, ClientConnection, StreamOwned};
 
 use super::{TlsConnector, TlsStream};
 use crate::{FtpError, FtpResult};
@@ -32,8 +33,8 @@ impl TlsConnector for RustlsConnector {
     type Stream = RustlsStream;
 
     fn connect(&self, domain: &str, stream: TcpStream) -> FtpResult<Self::Stream> {
-        let server_name =
-            ServerName::try_from(domain).map_err(|e| FtpError::SecureError(e.to_string()))?;
+        let server_name = ServerName::try_from(domain.to_string())
+            .map_err(|e| FtpError::SecureError(e.to_string()))?;
         let connection = ClientConnection::new(Arc::clone(&self.connector), server_name)
             .map_err(|e| FtpError::SecureError(e.to_string()))?;
         let stream = StreamOwned::new(connection, stream);


### PR DESCRIPTION
> Hi, i'm trying to connect to a FTP server over a SOCKS5 proxy. Connecting works fine.
> I just connect with `FtpStream::connect_with_stream(stream.into_inner())?` where `stream` is my SOCKS5 `TcpStream`.
> The problem is now:  In passive mode, when i want to retrieve a file, the connection to the server is not done via the proxy (provided `TcpStream`).
> It instantiates a new `TcpStream` internally.
> Is there a way to achieve connecting over a custom provided `TcpStream` when doing `retr_as_stream`?
> Best regards,
> Mark

The implementation consists in being able to provide a `Fn` to set the `TcpStream` from the `SocketAddr` when passive mode is initialized.