### PR TITLE
fix: remove is_private check for nat workaround

### DIFF
--- a/suppaftp/src/async_ftp/mod.rs
+++ b/suppaftp/src/async_ftp/mod.rs
@@ -869,7 +869,7 @@ where
         let port = (u16::from(msb) << 8) | u16::from(lsb);
         let addr = SocketAddr::new(ip.into(), port);
         trace!("Passive address: {}", addr);
-        if self.nat_workaround && ip.is_private() {
+        if self.nat_workaround {
             let mut remote = self
                 .reader
                 .get_ref()

--- a/suppaftp/src/sync_ftp/mod.rs
+++ b/suppaftp/src/sync_ftp/mod.rs
@@ -989,7 +989,7 @@ where
         let port = (u16::from(msb) << 8) | u16::from(lsb);
         let addr = SocketAddr::new(ip.into(), port);
         trace!("Passive address: {}", addr);
-        if self.nat_workaround && ip.is_private() {
+        if self.nat_workaround {
             let mut remote = self
                 .reader
                 .get_ref()


### PR DESCRIPTION
https://github.com/veeso/suppaftp/issues/88

removed `ip.is_private()` check for NAT workaround