### PR TITLE
feat(deps): migrated from async-tls to futures-rustls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
-  - [6.0.8](#608)
+  - [6.1.0](#610)
   - [6.0.7](#607)
   - [6.0.6](#606)
   - [6.0.5](#605)
@@ -41,10 +41,11 @@
 
 ---
 
-## 6.0.8
+## 6.1.0
 
-Released on ??? (TBD)
+Released on 10/03/2025
 
+- [Issue 100](https://github.com/veeso/suppaftp/issues/100): Migrated away from unmaintained `async-tls` to `futures-rustls`
 - [Issue 98](https://github.com/veeso/suppaftp/issues/98): doc: fixed minor typos that referenced `termscp`
 
 ## 6.0.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["suppaftp", "suppaftp-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "6.0.7"
+version = "6.1.0"
 edition = "2021"
 rust-version = "1.71.1"
 authors = [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">Developed by <a href="https://veeso.github.io/">veeso</a> and <a href="https://github.com/mattnenterprise">Matt McCoy</a></p>
-<p align="center">Current version: 6.0.7 (18/01/2025)</p>
+<p align="center">Current version: 6.1.0 (10/03/2025)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"

--- a/suppaftp/Cargo.toml
+++ b/suppaftp/Cargo.toml
@@ -33,8 +33,9 @@ thiserror = "^2"
 async-std = { version = "^1.10", optional = true }
 async-native-tls-crate = { package = "async-native-tls", version = "^0.5", optional = true }
 async-trait = { version = "0.1.64", optional = true }
-async-tls = { version = "^0.13", optional = true }
+futures-rustls = { version = "^0.26", optional = true }
 pin-project = { version = "^1", optional = true }
+rustls-pki-types = { version = "1", optional = true, features = ["alloc"] }
 # secure
 native-tls-crate = { package = "native-tls", version = "^0.2", optional = true }
 rustls-crate = { package = "rustls", version = "^0.23", default-features = false, features = [
@@ -43,7 +44,7 @@ rustls-crate = { package = "rustls", version = "^0.23", default-features = false
   "std",
   "tls12",
 ], optional = true }
-futures-lite = "2.0.0"
+futures-lite = "2"
 
 [dev-dependencies]
 async-attributes = "1.1.2"
@@ -57,10 +58,10 @@ webpki-roots = "0.26"
 [features]
 default = []
 # Enable async support for suppaftp
-async = ["async-std", "async-trait", "pin-project"]
+async = ["dep:async-std", "dep:async-trait", "dep:pin-project"]
 async-default-tls = ["async-native-tls"]
-async-native-tls = ["async-native-tls-crate", "async-secure"]
-async-rustls = ["async-tls", "async-secure"]
+async-native-tls = ["dep:async-native-tls-crate", "async-secure"]
+async-rustls = ["dep:futures-rustls", "dep:rustls-pki-types", "async-secure"]
 async-secure = ["async"]
 
 # Enable deprecated FTP/FTPS methods


### PR DESCRIPTION
async-tls is unmaintained and rustls has actually released an official version for async tls, so we should use that instead

fix #100