### PR TITLE
Feature/sync get ref tls

### DIFF
--- a/suppaftp/src/async_ftp/mod.rs
+++ b/suppaftp/src/async_ftp/mod.rs
@@ -284,7 +284,7 @@ where
     }
 
     /// Returns a reference to the underlying TcpStream.
-    pub async fn get_ref(&self) -> &TcpStream {
+    pub fn get_ref(&self) -> &TcpStream {
         self.reader.get_ref().get_ref()
     }
 
@@ -1119,7 +1119,7 @@ mod test {
 
     async fn get_ref() {
         let (stream, _container) = setup_stream().await;
-        assert!(stream.get_ref().await.set_ttl(255).is_ok());
+        assert!(stream.get_ref().set_ttl(255).is_ok());
         finalize_stream(stream).await;
     }
 


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Fixes #102 

## Description

Set `get_ref` function of asynchronous ftp connection to synchronous, because of there is no need to use `async`, and it allows to easily create pooled connection using `bb8`.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have introduced no *C-bindings*
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
