### PR TITLE
chore: Add executable rustls example

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ fn main() {
 
 #### Ftp with TLS (rustls)
 
+You can also find and run this example in the `suppaftp/examples/` directory (`cargo run --example rustls --features rustls`).
+
 ```rust
 use std::str;
 use std::io::Cursor;

--- a/suppaftp/Cargo.toml
+++ b/suppaftp/Cargo.toml
@@ -88,3 +88,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "rustls"
+required-features = ["rustls"]

--- a/suppaftp/Cargo.toml
+++ b/suppaftp/Cargo.toml
@@ -85,3 +85,6 @@ no-log = ["log/max_level_off"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[[example]]
+name = "rustls"

--- a/suppaftp/examples/rustls.rs
+++ b/suppaftp/examples/rustls.rs
@@ -5,16 +5,13 @@
 //! rustls).
 
 use std::sync::Arc;
-use suppaftp::{RustlsFtpStream, RustlsConnector};
-use suppaftp::rustls;
+
 use suppaftp::rustls::ClientConfig;
+use suppaftp::{rustls, RustlsConnector, RustlsFtpStream};
 
 fn main() {
-    let root_store = rustls::RootCertStore::from_iter(
-        webpki_roots::TLS_SERVER_ROOTS
-            .iter()
-            .cloned(),
-    );
+    let root_store =
+        rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
     let config = ClientConfig::builder()
         .with_root_certificates(root_store)

--- a/suppaftp/examples/rustls.rs
+++ b/suppaftp/examples/rustls.rs
@@ -1,0 +1,31 @@
+//! To run this example enable the rustls feature (--features rustls).
+//! If you use this code in your own project you need to enable suppaftp's
+//! rustls feature through Cargo.toml and also include the webpki-roots crate
+//! as a dependency (this includes Mozilla's root certificates for use with
+//! rustls).
+
+use std::sync::Arc;
+use suppaftp::{RustlsFtpStream, RustlsConnector};
+use suppaftp::rustls;
+use suppaftp::rustls::ClientConfig;
+
+fn main() {
+    let root_store = rustls::RootCertStore::from_iter(
+        webpki_roots::TLS_SERVER_ROOTS
+            .iter()
+            .cloned(),
+    );
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    // Create a connection to an FTP server and authenticate to it.
+    let mut ftp_stream = RustlsFtpStream::connect("test.rebex.net:21")
+        .unwrap()
+        .into_secure(RustlsConnector::from(Arc::new(config)), "test.rebex.net")
+        .unwrap();
+
+    // Terminate the connection to the server.
+    let _ = ftp_stream.quit();
+}


### PR DESCRIPTION
# Add executable rustls example

This is a companion PR to https://github.com/veeso/suppaftp/pull/104, adding the updated rustls example also as an executable example in the codebase (with some added inline docs). I'm providing this as a separate PR in case you don't want to provide any examples like that. :)

## Description

While working with suppaftp I was looking for (stand-alone executable) examples but didnt' find any. On the occasion of updating the rustls example I thought it'd be a good occasion to also offer a stand-alone example of it (this also helped me test the code for the README and might help others to do so in the future).
