### PR TITLE
fix: Fixed `list` related commands which failed if the file name contained non UTF8 characters

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build all features
         run: cargo build --features deprecated,native-tls,rustls,async-native-tls,async-rustls --package suppaftp
       - name: Run tests
-        run: cargo test --lib --package suppaftp --no-default-features --features rustls,native-tls,async-native-tls,async-rustls --no-fail-fast
+        run: cargo test --package suppaftp --no-default-features --features rustls,native-tls,async-native-tls,async-rustls --no-fail-fast
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [6.2.1](#621)
   - [6.2.0](#620)
   - [6.1.1](#611)
   - [6.1.0](#610)
@@ -42,6 +43,13 @@
   - [4.0.0](#400)
 
 ---
+
+## 6.2.1
+
+Released on 13/05/2025
+
+- [Issue 106](https://github.com/veeso/suppaftp/issues/106): Fixed `list` related commands which failed if the file name contained non UTF-8 characters.
+- MSRV updated to 1.80.1
 
 ## 6.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ members = ["suppaftp", "suppaftp-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "6.2.0"
+version = "6.2.1"
 edition = "2021"
-rust-version = "1.71.1"
+rust-version = "1.80.1"
 authors = [
   "Christian Visintin <christian.visintin@veeso.dev>",
   "Matt McCoy <mattnenterprise@yahoo.com>",

--- a/suppaftp/src/lib.rs
+++ b/suppaftp/src/lib.rs
@@ -62,7 +62,7 @@
 //!
 //! Here is a basic usage example:
 //!
-//! ```rust
+//! ```rust,ignore
 //! use suppaftp::FtpStream;
 //! let mut ftp_stream = FtpStream::connect("127.0.0.1:10021").unwrap_or_else(|err|
 //!     panic!("{}", err)
@@ -86,7 +86,7 @@
 //!
 //! ### FTPS Usage
 //!
-//! ```rust
+//! ```rust,ignore
 //! use suppaftp::{NativeTlsFtpStream, NativeTlsConnector};
 //! use suppaftp::native_tls::{TlsConnector, TlsStream};
 //!
@@ -104,7 +104,7 @@
 //! Basically there's no difference in the function you can use when using the async version of suppaftp.
 //! Let's quickly see in the example how it works
 //!
-//! ```rust
+//! ```rust,ignore
 //! use suppaftp::{AsyncFtpStream, AsyncNativeTlsConnector};
 //! use suppaftp::async_native_tls::{TlsConnector, TlsStream};
 //!

--- a/suppaftp/src/list.rs
+++ b/suppaftp/src/list.rs
@@ -12,7 +12,7 @@
 //! Whenever you receive the output for your LIST command, all you have to do is to iterate over lines and
 //! call `File::from_line()` function as shown in the example.
 //!
-//! ```rust
+//! ```rust,ignore
 //! use std::convert::TryFrom;
 //! use suppaftp::{FtpStream, list::File};
 //!
@@ -511,6 +511,14 @@ impl TryFrom<&str> for File {
                 Err(err) => Err(err),
             },
         }
+    }
+}
+
+impl TryFrom<&String> for File {
+    type Error = ParseError;
+
+    fn try_from(line: &String) -> Result<Self, Self::Error> {
+        Self::try_from(line.as_str())
     }
 }
 


### PR DESCRIPTION
Changed the logic of get stream lines: use read_until and then convert to UTF8 lossy

closes #106