### PR TITLE
fix(async): Fixed `retr` method signature on the `AsyncFtpStream` to allow passing a closure taking the stream reader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@
 
 Released on 05/06/2025
 
+- [Issue 85](https://github.com/veeso/suppaftp/issues/85): Fixed `retr` method signature on the `AsyncFtpStream` to allow passing a closure taking the stream reader.
+
+    ```rust
+    stream
+      .retr("test.txt", |mut reader| {
+            Box::pin(async move {
+                let mut buf = Vec::new();
+                reader.read_to_end(&mut buf).await.expect("failed to read stream");
+                Ok((buf, reader))
+            })
+        })
+        .await
+    ```
+
 - [Issue 108](https://github.com/veeso/suppaftp/issues/108): fixed FEAT command response parser
 
 ## 6.2.1

--- a/suppaftp/src/async_ftp/data_stream.rs
+++ b/suppaftp/src/async_ftp/data_stream.rs
@@ -16,7 +16,7 @@ use super::AsyncTlsStream;
 #[pin_project(project = DataStreamProj)]
 pub enum DataStream<T>
 where
-    T: AsyncTlsStream,
+    T: AsyncTlsStream + Send,
 {
     Tcp(#[pin] TcpStream),
     Ssl(#[pin] Box<T>),
@@ -25,7 +25,7 @@ where
 #[cfg(feature = "async-secure")]
 impl<T> DataStream<T>
 where
-    T: AsyncTlsStream,
+    T: AsyncTlsStream + Send,
 {
     /// Unwrap the stream into TcpStream. This method is only used in secure connection.
     pub fn into_tcp_stream(self) -> TcpStream {
@@ -38,7 +38,7 @@ where
 
 impl<T> DataStream<T>
 where
-    T: AsyncTlsStream,
+    T: AsyncTlsStream + Send,
 {
     /// Returns a reference to the underlying TcpStream.
     pub fn get_ref(&self) -> &TcpStream {
@@ -53,7 +53,7 @@ where
 
 impl<T> Read for DataStream<T>
 where
-    T: AsyncTlsStream,
+    T: AsyncTlsStream + Send,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -69,7 +69,7 @@ where
 
 impl<T> Write for DataStream<T>
 where
-    T: AsyncTlsStream,
+    T: AsyncTlsStream + Send,
 {
     fn poll_write(
         self: Pin<&mut Self>,


### PR DESCRIPTION
The signature of the `retr` method was not allowing any argument, because the dyn Read needs to be Unpin, but it's a mutable reference at the same time and this with Async causes several issues. The mutable reference is required by the finalize_retr_stream which is called immediately after calling the closure. Because of this, the signature has been changed to return both the result and the stream back to be able to finalize it.

closes #88