### PR TITLE
Mention MSRV changes in 7.0.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ Released on 31/08/2025
   - Removed `async-default-tls`.
   - Removed `default-tls`
   - Renamed `async-rustls` to `async-std-rustls`.
+- **Higher MSRV requirements**
+  - Now requires Rust edition 2024 (before: 2021)
+  - Now requires Rust version 1.85.1 or later (before: 1.80.1)
 - **Tokio support**:
   - Added tokio support along with async-std.
   - Use `tokio` feature to use tokio


### PR DESCRIPTION
Hi,

I just carefully updated a few dependencies for one of my projects and got surprised that my MSRV guarantee (1.82) was suddenly not upheld anymore, and I tracked it down to suppaftp's 7.0.0 update.

I can only speak for myself but I think it's generally a good idea to mention MSRV bumps in the changelogs, especially when it's a jump that now requires a <6 months old rust version (before: <12 months old) - I'm trying my best to keep system requirements and disruptions to a minimum for people who package my projects, and such a sudden jump is not ideal (I'll probably downgrade suppaftp now and wait a few months, unless there is something super critical that forces an update).

Anyhow, to save others from running into this without warning, I'm proposing a mention in the changelog with this PR.

Thank you for taking care of suppaftp, it's really quite fantastic. Cheers!