### PR TITLE
fix: Exported `TlsStream` types for implementing functions that use the retrieved stream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [7.0.4](#704)
   - [7.0.3](#703)
   - [7.0.1](#701)
   - [7.0.0](#700)
@@ -47,6 +48,15 @@
   - [4.0.0](#400)
 
 ---
+
+## 7.0.4
+
+Released on 22/09/2025
+
+- Exported `TlsStream` types for implementing functions that use the retrieved stream.
+  - `TlsStream` for sync ftp.
+  - `AsyncStdTlsStream` for async-std ftp.
+  - `TokioTlsStream` for tokio ftp.
 
 ## 7.0.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["suppaftp", "suppaftp-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "7.0.3"
+version = "7.0.4"
 edition = "2024"
 rust-version = "1.85.1"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">Developed by <a href="https://veeso.me/">veeso</a></p>
-<p align="center">Current version: 7.0.3 (31/08/2025)</p>
+<p align="center">Current version: 7.0.4 (22/09/2025)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"

--- a/suppaftp/src/async_ftp.rs
+++ b/suppaftp/src/async_ftp.rs
@@ -15,7 +15,7 @@ pub mod async_std {
     pub use crate::async_ftp::async_std_ftp::AsyncStdPassiveStreamBuilder;
     #[cfg(feature = "async-std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-std")))]
-    pub use crate::async_ftp::async_std_ftp::ImplAsyncFtpStream;
+    pub use crate::async_ftp::async_std_ftp::{AsyncStdTlsStream, ImplAsyncFtpStream};
 
     #[cfg(feature = "async-std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-std")))]
@@ -81,7 +81,9 @@ pub mod tokio {
         doc(cfg(all(feature = "tokio", feature = "tokio-async-native-tls")))
     )]
     use super::tokio_ftp::AsyncNativeTlsStream;
-    pub use super::tokio_ftp::{DataStream as AsyncDataStream, TokioPassiveStreamBuilder};
+    pub use super::tokio_ftp::{
+        DataStream as AsyncDataStream, TokioPassiveStreamBuilder, TokioTlsStream,
+    };
 
     #[cfg(feature = "tokio-async-native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio-async-native-tls")))]

--- a/suppaftp/src/async_ftp/async_std_ftp/data_stream.rs
+++ b/suppaftp/src/async_ftp/async_std_ftp/data_stream.rs
@@ -10,13 +10,13 @@ use async_std::io::{Read, Result, Write};
 use async_std::net::TcpStream;
 use pin_project::pin_project;
 
-use super::AsyncTlsStream;
+use super::AsyncStdTlsStream;
 
 /// Data Stream used for communications. It can be both of type Tcp in case of plain communication or Ssl in case of FTPS
 #[pin_project(project = DataStreamProj)]
 pub enum DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: AsyncStdTlsStream + Send,
 {
     Tcp(#[pin] TcpStream),
     Ssl(#[pin] Box<T>),
@@ -25,7 +25,7 @@ where
 #[cfg(feature = "async-secure")]
 impl<T> DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: AsyncStdTlsStream + Send,
 {
     /// Unwrap the stream into TcpStream. This method is only used in secure connection.
     pub fn into_tcp_stream(self) -> TcpStream {
@@ -38,7 +38,7 @@ where
 
 impl<T> DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: AsyncStdTlsStream + Send,
 {
     /// Returns a reference to the underlying TcpStream.
     pub fn get_ref(&self) -> &TcpStream {
@@ -53,7 +53,7 @@ where
 
 impl<T> Read for DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: AsyncStdTlsStream + Send,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -69,7 +69,7 @@ where
 
 impl<T> Write for DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: AsyncStdTlsStream + Send,
 {
     fn poll_write(
         self: Pin<&mut Self>,

--- a/suppaftp/src/async_ftp/async_std_ftp/mod.rs
+++ b/suppaftp/src/async_ftp/async_std_ftp/mod.rs
@@ -20,12 +20,11 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 // export
 pub use data_stream::DataStream;
 use futures_lite::AsyncWriteExt;
-pub use tls::AsyncNoTlsStream;
 #[cfg(feature = "async-secure")]
 pub use tls::AsyncTlsConnector;
-use tls::AsyncTlsStream;
 #[cfg(feature = "async-std-async-native-tls")]
 pub use tls::{AsyncNativeTlsConnector, AsyncNativeTlsStream};
+pub use tls::{AsyncNoTlsStream, AsyncStdTlsStream};
 #[cfg(feature = "async-std-rustls")]
 pub use tls::{AsyncRustlsConnector, AsyncRustlsStream};
 
@@ -48,7 +47,7 @@ pub type AsyncStdPassiveStreamBuilder = dyn Fn(SocketAddr) -> Pin<Box<dyn Future
 /// Stream to interface with the FTP server. This interface is only for the command stream.
 pub struct ImplAsyncFtpStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: AsyncStdTlsStream + Send,
 {
     reader: BufReader<DataStream<T>>,
     mode: Mode,
@@ -66,7 +65,7 @@ where
 
 impl<T> ImplAsyncFtpStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: AsyncStdTlsStream + Send,
 {
     pub async fn connect<A: ToSocketAddrs>(addr: A) -> FtpResult<Self> {
         debug!("Connecting to server");

--- a/suppaftp/src/async_ftp/async_std_ftp/tls.rs
+++ b/suppaftp/src/async_ftp/async_std_ftp/tls.rs
@@ -20,12 +20,15 @@ pub use self::rustls::{AsyncRustlsConnector, AsyncRustlsStream};
 #[cfg(feature = "async-secure")]
 #[async_trait::async_trait]
 pub trait AsyncTlsConnector: Debug {
-    type Stream: AsyncTlsStream;
+    type Stream: AsyncStdTlsStream;
 
     async fn connect(&self, domain: &str, stream: TcpStream) -> crate::FtpResult<Self::Stream>;
 }
 
-pub trait AsyncTlsStream: Debug + Read + Write + Unpin {
+/// A trait for a Async-std based TLS stream.
+///
+/// This kind of stream is returned when using a data connection in FTP.
+pub trait AsyncStdTlsStream: Debug + Read + Write + Unpin {
     type InnerStream: Read + Write;
 
     /// Get underlying tcp stream
@@ -75,7 +78,7 @@ impl Write for AsyncNoTlsStream {
     }
 }
 
-impl AsyncTlsStream for AsyncNoTlsStream {
+impl AsyncStdTlsStream for AsyncNoTlsStream {
     type InnerStream = TcpStream;
 
     fn tcp_stream(self) -> TcpStream {

--- a/suppaftp/src/async_ftp/async_std_ftp/tls/native_tls.rs
+++ b/suppaftp/src/async_ftp/async_std_ftp/tls/native_tls.rs
@@ -10,7 +10,7 @@ use async_std::net::TcpStream;
 use async_trait::async_trait;
 use pin_project::pin_project;
 
-use super::{AsyncTlsConnector, AsyncTlsStream};
+use super::{AsyncStdTlsStream, AsyncTlsConnector};
 use crate::{FtpError, FtpResult};
 
 #[derive(Debug)]
@@ -85,7 +85,7 @@ impl Write for AsyncNativeTlsStream {
     }
 }
 
-impl AsyncTlsStream for AsyncNativeTlsStream {
+impl AsyncStdTlsStream for AsyncNativeTlsStream {
     type InnerStream = TlsStream<TcpStream>;
 
     fn get_ref(&self) -> &TcpStream {

--- a/suppaftp/src/async_ftp/async_std_ftp/tls/rustls.rs
+++ b/suppaftp/src/async_ftp/async_std_ftp/tls/rustls.rs
@@ -12,7 +12,7 @@ use futures_rustls::client::TlsStream;
 use pin_project::pin_project;
 use rustls_pki_types::{DnsName, ServerName};
 
-use super::{AsyncTlsConnector, AsyncTlsStream};
+use super::{AsyncStdTlsStream, AsyncTlsConnector};
 use crate::{FtpError, FtpResult};
 
 /// A Wrapper for the tls connector
@@ -97,7 +97,7 @@ impl Write for AsyncRustlsStream {
     }
 }
 
-impl AsyncTlsStream for AsyncRustlsStream {
+impl AsyncStdTlsStream for AsyncRustlsStream {
     type InnerStream = TlsStream<TcpStream>;
 
     fn get_ref(&self) -> &TcpStream {

--- a/suppaftp/src/async_ftp/tokio_ftp/data_stream.rs
+++ b/suppaftp/src/async_ftp/tokio_ftp/data_stream.rs
@@ -11,13 +11,13 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 #[cfg(feature = "tokio")]
 use tokio::net::TcpStream;
 
-use super::AsyncTlsStream;
+use super::TokioTlsStream;
 
 /// Data Stream used for communications. It can be both of type Tcp in case of plain communication or Ssl in case of FTPS
 #[pin_project(project = DataStreamProj)]
 pub enum DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: TokioTlsStream + Send,
 {
     Tcp(#[pin] TcpStream),
     Ssl(#[pin] Box<T>),
@@ -26,7 +26,7 @@ where
 #[cfg(feature = "async-secure")]
 impl<T> DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: TokioTlsStream + Send,
 {
     /// Unwrap the stream into TcpStream. This method is only used in secure connection.
     pub fn into_tcp_stream(self) -> TcpStream {
@@ -39,7 +39,7 @@ where
 
 impl<T> DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: TokioTlsStream + Send,
 {
     /// Returns a reference to the underlying TcpStream.
     pub fn get_ref(&self) -> &TcpStream {
@@ -54,7 +54,7 @@ where
 
 impl<T> AsyncRead for DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: TokioTlsStream + Send,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -70,7 +70,7 @@ where
 
 impl<T> AsyncWrite for DataStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: TokioTlsStream + Send,
 {
     fn poll_write(
         self: Pin<&mut Self>,

--- a/suppaftp/src/async_ftp/tokio_ftp/mod.rs
+++ b/suppaftp/src/async_ftp/tokio_ftp/mod.rs
@@ -16,12 +16,11 @@ use std::time::Duration;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 // export
 pub use data_stream::DataStream;
-pub use tls::AsyncNoTlsStream;
 #[cfg(feature = "async-secure")]
 pub use tls::AsyncTlsConnector;
-use tls::AsyncTlsStream;
 #[cfg(feature = "tokio-async-native-tls")]
 pub use tls::{AsyncNativeTlsConnector, AsyncNativeTlsStream};
+pub use tls::{AsyncNoTlsStream, TokioTlsStream};
 #[cfg(feature = "tokio-rustls")]
 pub use tls::{AsyncRustlsConnector, AsyncRustlsStream};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader, copy};
@@ -46,7 +45,7 @@ pub type TokioPassiveStreamBuilder = dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Ou
 /// Stream to interface with the FTP server. This interface is only for the command stream.
 pub struct ImplAsyncFtpStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: TokioTlsStream + Send,
 {
     reader: BufReader<DataStream<T>>,
     mode: Mode,
@@ -64,7 +63,7 @@ where
 
 impl<T> ImplAsyncFtpStream<T>
 where
-    T: AsyncTlsStream + Send,
+    T: TokioTlsStream + Send,
 {
     pub async fn connect<A: ToSocketAddrs>(addr: A) -> FtpResult<Self> {
         debug!("Connecting to server");

--- a/suppaftp/src/async_ftp/tokio_ftp/tls.rs
+++ b/suppaftp/src/async_ftp/tokio_ftp/tls.rs
@@ -20,12 +20,15 @@ pub use self::rustls::{AsyncRustlsConnector, AsyncRustlsStream};
 #[cfg(feature = "async-secure")]
 #[async_trait::async_trait]
 pub trait AsyncTlsConnector: Debug {
-    type Stream: AsyncTlsStream;
+    type Stream: TokioTlsStream;
 
     async fn connect(&self, domain: &str, stream: TcpStream) -> crate::FtpResult<Self::Stream>;
 }
 
-pub trait AsyncTlsStream: Debug + AsyncRead + AsyncWrite + Unpin {
+/// A trait for a Tokio based TLS stream.
+///
+/// This kind of stream is returned when using a data connection in FTP.
+pub trait TokioTlsStream: Debug + AsyncRead + AsyncWrite + Unpin {
     type InnerStream: AsyncRead + AsyncWrite;
 
     /// Get underlying tcp stream
@@ -75,7 +78,7 @@ impl AsyncWrite for AsyncNoTlsStream {
     }
 }
 
-impl AsyncTlsStream for AsyncNoTlsStream {
+impl TokioTlsStream for AsyncNoTlsStream {
     type InnerStream = TcpStream;
 
     fn tcp_stream(self) -> TcpStream {

--- a/suppaftp/src/async_ftp/tokio_ftp/tls/native_tls.rs
+++ b/suppaftp/src/async_ftp/tokio_ftp/tls/native_tls.rs
@@ -10,7 +10,7 @@ use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 
-use super::{AsyncTlsConnector, AsyncTlsStream};
+use super::{AsyncTlsConnector, TokioTlsStream};
 use crate::{FtpError, FtpResult};
 
 #[derive(Debug)]
@@ -85,7 +85,7 @@ impl AsyncWrite for AsyncNativeTlsStream {
     }
 }
 
-impl AsyncTlsStream for AsyncNativeTlsStream {
+impl TokioTlsStream for AsyncNativeTlsStream {
     type InnerStream = TlsStream<TcpStream>;
 
     fn get_ref(&self) -> &TcpStream {

--- a/suppaftp/src/async_ftp/tokio_ftp/tls/rustls.rs
+++ b/suppaftp/src/async_ftp/tokio_ftp/tls/rustls.rs
@@ -12,7 +12,7 @@ use tokio::net::TcpStream;
 use tokio_rustls::TlsConnector as RustlsTlsConnector;
 use tokio_rustls::client::TlsStream;
 
-use super::{AsyncTlsConnector, AsyncTlsStream};
+use super::{AsyncTlsConnector, TokioTlsStream};
 use crate::{FtpError, FtpResult};
 
 /// A Wrapper for the tls connector
@@ -96,7 +96,7 @@ impl AsyncWrite for AsyncRustlsStream {
     }
 }
 
-impl AsyncTlsStream for AsyncRustlsStream {
+impl TokioTlsStream for AsyncRustlsStream {
     type InnerStream = TlsStream<TcpStream>;
 
     fn get_ref(&self) -> &TcpStream {

--- a/suppaftp/src/lib.rs
+++ b/suppaftp/src/lib.rs
@@ -175,7 +175,7 @@ pub extern crate async_native_tls_crate as async_native_tls;
 pub use status::Status;
 use sync_ftp::NoTlsStream;
 // -- export sync
-pub use sync_ftp::{ImplFtpStream, PassiveStreamBuilder};
+pub use sync_ftp::{ImplFtpStream, PassiveStreamBuilder, TlsStream};
 pub use types::{FtpError, FtpResult, Mode};
 pub type FtpStream = ImplFtpStream<NoTlsStream>;
 pub use sync_ftp::DataStream;

--- a/suppaftp/src/sync_ftp/mod.rs
+++ b/suppaftp/src/sync_ftp/mod.rs
@@ -14,12 +14,11 @@ use std::time::{Duration, Instant};
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 // export
 pub use data_stream::DataStream;
-pub use tls::NoTlsStream;
 #[cfg(feature = "secure")]
 pub use tls::TlsConnector;
-use tls::TlsStream;
 #[cfg(feature = "native-tls")]
 pub use tls::{NativeTlsConnector, NativeTlsStream};
+pub use tls::{NoTlsStream, TlsStream};
 #[cfg(feature = "rustls")]
 pub use tls::{RustlsConnector, RustlsStream};
 

--- a/suppaftp/src/sync_ftp/tls.rs
+++ b/suppaftp/src/sync_ftp/tls.rs
@@ -23,6 +23,9 @@ pub trait TlsConnector: Debug {
     fn connect(&self, domain: &str, stream: TcpStream) -> crate::FtpResult<Self::Stream>;
 }
 
+/// A trait for a TLS stream.
+///
+/// This kind of stream is returned when using a data connection in FTP.
 pub trait TlsStream: Debug {
     type InnerStream: Read + Write;
 
@@ -43,14 +46,14 @@ impl TlsStream for NoTlsStream {
     type InnerStream = TcpStream;
 
     fn tcp_stream(self) -> TcpStream {
-        panic!()
+        unimplemented!("NoTlsStream has no underlying TcpStream")
     }
 
     fn get_ref(&self) -> &TcpStream {
-        panic!()
+        unimplemented!("NoTlsStream has no underlying TcpStream")
     }
 
     fn mut_ref(&mut self) -> &mut Self::InnerStream {
-        panic!()
+        unimplemented!("NoTlsStream has no underlying TcpStream")
     }
 }


### PR DESCRIPTION
`TlsStream` for sync ftp.
`AsyncStdTlsStream` for async-std ftp.


closes #121