### PR TITLE
Update chrono version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [7.0.5](#705)
   - [7.0.4](#704)
   - [7.0.3](#703)
   - [7.0.1](#701)
@@ -48,6 +49,12 @@
   - [4.0.0](#400)
 
 ---
+
+## 7.0.5
+
+Released on 03/10/2025
+
+- Update `chrono` version to `0.4.25` to guarantee compatibility with `and_utc` method.
 
 ## 7.0.4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["suppaftp", "suppaftp-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "7.0.4"
+version = "7.0.5"
 edition = "2024"
 rust-version = "1.85.1"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">Developed by <a href="https://veeso.me/">veeso</a></p>
-<p align="center">Current version: 7.0.4 (22/09/2025)</p>
+<p align="center">Current version: 7.0.5 (03/10/2025)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"

--- a/suppaftp/Cargo.toml
+++ b/suppaftp/Cargo.toml
@@ -26,7 +26,7 @@ name = "suppaftp"
 path = "src/lib.rs"
 
 [dependencies]
-chrono = { version = "^0.4", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.25", default-features = false, features = ["clock"] }
 lazy-regex = "^3"
 log = "^0.4"
 thiserror = "^2"


### PR DESCRIPTION
`suppaftp` uses `and_utc` method on `NaiveDateTime`, which was only added in [chrono v0.4.25](https://github.com/chronotope/chrono/releases/tag/v0.4.25). Fix dependency version in `Cargo.toml` to ensure that this method is actually present.