### PR TITLE
Allow to access async_native_tls when using tokio

### DIFF
--- a/suppaftp/src/lib.rs
+++ b/suppaftp/src/lib.rs
@@ -167,8 +167,17 @@ pub extern crate native_tls_crate as native_tls;
 #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
 pub extern crate rustls_crate as rustls;
 // -- async deps
-#[cfg(feature = "async-std-async-native-tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async-std-async-native-tls")))]
+#[cfg(any(
+    feature = "tokio-async-native-tls",
+    feature = "async-std-async-native-tls"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "tokio-async-native-tls",
+        feature = "async-std-async-native-tls"
+    )))
+)]
 pub extern crate async_native_tls_crate as async_native_tls;
 
 // -- export (common)


### PR DESCRIPTION
# Allow to access async_native_tls when using tokio

Fixes a minor problem when trying to use tls with the tokio runtime.

## Description

Just added an cfg condition to also enable re-export of async_native_tls when tokio is used via tokio-async-native-tls.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I linted my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no *C-bindings*
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
