### PR TITLE
feat(list): FileType enum is now public; deprecated File::from...line in favour of `ListParser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,56 +1,67 @@
 # Changelog
 
 - [Changelog](#changelog)
-  - [7.0.7](#707)
-  - [7.0.6](#706)
-  - [7.0.5](#705)
-  - [7.0.4](#704)
-  - [7.0.3](#703)
-  - [7.0.1](#701)
-  - [7.0.0](#700)
-  - [6.3.0](#630)
-  - [6.2.1](#621)
-  - [6.2.0](#620)
-  - [6.1.1](#611)
-  - [6.1.0](#610)
-  - [6.0.7](#607)
-  - [6.0.6](#606)
-  - [6.0.5](#605)
-  - [6.0.4](#604)
-  - [6.0.3](#603)
-  - [6.0.2](#602)
-  - [6.0.1](#601)
-  - [6.0.0](#600)
-  - [5.4.0](#540)
-  - [5.3.1](#531)
-  - [5.3.0](#530)
-  - [5.2.2](#522)
-  - [5.2.1](#521)
-  - [5.2.0](#520)
-  - [5.1.2](#512)
-  - [5.1.1](#511)
-  - [5.1.0](#510)
-  - [5.0.1](#501)
-  - [5.0.0](#500)
-  - [4.7.0](#470)
-  - [4.6.1](#461)
-  - [4.6.0](#460)
-  - [4.5.3](#453)
-  - [4.5.2](#452)
-  - [4.5.1](#451)
-  - [4.5.0](#450)
-  - [4.4.0](#440)
-  - [4.3.0](#430)
-  - [4.2.0](#420)
-  - [4.1.3](#413)
-  - [4.1.2](#412)
-  - [4.1.1](#411)
-  - [4.1.0](#410)
-  - [4.0.2](#402)
-  - [4.0.1](#401)
-  - [4.0.0](#400)
+    - [7.0.7](#707)
+    - [7.0.6](#706)
+    - [7.0.5](#705)
+    - [7.0.4](#704)
+    - [7.0.3](#703)
+    - [7.0.1](#701)
+    - [7.0.0](#700)
+    - [6.3.0](#630)
+    - [6.2.1](#621)
+    - [6.2.0](#620)
+    - [6.1.1](#611)
+    - [6.1.0](#610)
+    - [6.0.7](#607)
+    - [6.0.6](#606)
+    - [6.0.5](#605)
+    - [6.0.4](#604)
+    - [6.0.3](#603)
+    - [6.0.2](#602)
+    - [6.0.1](#601)
+    - [6.0.0](#600)
+    - [5.4.0](#540)
+    - [5.3.1](#531)
+    - [5.3.0](#530)
+    - [5.2.2](#522)
+    - [5.2.1](#521)
+    - [5.2.0](#520)
+    - [5.1.2](#512)
+    - [5.1.1](#511)
+    - [5.1.0](#510)
+    - [5.0.1](#501)
+    - [5.0.0](#500)
+    - [4.7.0](#470)
+    - [4.6.1](#461)
+    - [4.6.0](#460)
+    - [4.5.3](#453)
+    - [4.5.2](#452)
+    - [4.5.1](#451)
+    - [4.5.0](#450)
+    - [4.4.0](#440)
+    - [4.3.0](#430)
+    - [4.2.0](#420)
+    - [4.1.3](#413)
+    - [4.1.2](#412)
+    - [4.1.1](#411)
+    - [4.1.0](#410)
+    - [4.0.2](#402)
+    - [4.0.1](#401)
+    - [4.0.0](#400)
 
 ---
+
+## 7.1.0
+
+Released on 07/01/2026
+
+- [Issue 128](https://github.com/veeso/suppaftp/issues/128)
+    - Made `FileType` enum public
+    - Added `File::file_type()` method to retrieve the file type
+    - Deprecated `File::from_dos_line`,  `File::from_mlsx_line`, and `File::from_posix_line` methods in favor of
+      `ListParser::parse_dos`, `ListParser::parse_mlst`, `ListParser::parse_mlsd`, and `ListParser::parse_posix`
+      respectively.
 
 ## 7.0.7
 
@@ -75,9 +86,9 @@ Released on 03/10/2025
 Released on 22/09/2025
 
 - Exported `TlsStream` types for implementing functions that use the retrieved stream.
-  - `TlsStream` for sync ftp.
-  - `AsyncStdTlsStream` for async-std ftp.
-  - `TokioTlsStream` for tokio ftp.
+    - `TlsStream` for sync ftp.
+    - `AsyncStdTlsStream` for async-std ftp.
+    - `TokioTlsStream` for tokio ftp.
 
 ## 7.0.3
 
@@ -96,30 +107,32 @@ Released on 31/08/2025
 Released on 31/08/2025
 
 - **Breaking changes**:
-  - Removed `async` feature; use either `async-std` or `tokio`.
-  - Removed `async-native-tls`; use either `async-std-async-native-tls` (for `async-std`) or `tokio-async-native-tls` (for `tokio`) instead.
-  - Renamed `async-native-tls-vendored` to `async-std-async-native-tls-vendored`.
-  - Removed `async-default-tls`.
-  - Removed `default-tls`
-  - Renamed `async-rustls` to `async-std-rustls`.
+    - Removed `async` feature; use either `async-std` or `tokio`.
+    - Removed `async-native-tls`; use either `async-std-async-native-tls` (for `async-std`) or
+      `tokio-async-native-tls` (for `tokio`) instead.
+    - Renamed `async-native-tls-vendored` to `async-std-async-native-tls-vendored`.
+    - Removed `async-default-tls`.
+    - Removed `default-tls`
+    - Renamed `async-rustls` to `async-std-rustls`.
 - **Higher MSRV requirements**
-  - Now requires Rust edition 2024 (before: 2021)
-  - Now requires Rust version 1.85.1 or later (before: 1.80.1)
+    - Now requires Rust edition 2024 (before: 2021)
+    - Now requires Rust version 1.85.1 or later (before: 1.80.1)
 - **Tokio support**:
-  - Added tokio support along with async-std.
-  - Use `tokio` feature to use tokio
-  - Use `tokio-rustls` feature to use tokio with rustls
-  - Use `tokio-async-native-tls` feature to use async-native-tls with tokio
+    - Added tokio support along with async-std.
+    - Use `tokio` feature to use tokio
+    - Use `tokio-rustls` feature to use tokio with rustls
+    - Use `tokio-async-native-tls` feature to use async-native-tls with tokio
 - **Custom Data commands**:
-  - Added `custom_data_command` to perform the execution of custom data commands.
-  - Added `close_data_connection` to close the `DataStream` once consumed after executing custom data commands.
-  - Made `get_lines_from_stream` public to easily read String lines from the `DataStream`.
+    - Added `custom_data_command` to perform the execution of custom data commands.
+    - Added `close_data_connection` to close the `DataStream` once consumed after executing custom data commands.
+    - Made `get_lines_from_stream` public to easily read String lines from the `DataStream`.
 
 ## 6.3.0
 
 Released on 05/06/2025
 
-- [Issue 85](https://github.com/veeso/suppaftp/issues/85): Fixed `retr` method signature on the `AsyncFtpStream` to allow passing a closure taking the stream reader.
+- [Issue 85](https://github.com/veeso/suppaftp/issues/85): Fixed `retr` method signature on the `AsyncFtpStream` to
+  allow passing a closure taking the stream reader.
 
     ```rust
     stream
@@ -139,7 +152,8 @@ Released on 05/06/2025
 
 Released on 13/05/2025
 
-- [Issue 106](https://github.com/veeso/suppaftp/issues/106): Fixed `list` related commands which failed if the file name contained non UTF-8 characters.
+- [Issue 106](https://github.com/veeso/suppaftp/issues/106): Fixed `list` related commands which failed if the file name
+  contained non UTF-8 characters.
 - MSRV updated to 1.80.1
 
 ## 6.2.0
@@ -158,12 +172,14 @@ Released on 17/03/2025
 
 Released on 10/03/2025
 
-- [Issue 100](https://github.com/veeso/suppaftp/issues/100): Migrated away from unmaintained `async-tls` to `futures-rustls`
+- [Issue 100](https://github.com/veeso/suppaftp/issues/100): Migrated away from unmaintained `async-tls` to
+  `futures-rustls`
 - [Issue 98](https://github.com/veeso/suppaftp/issues/98): doc: fixed minor typos that referenced `termscp`
 
 ## 6.0.7
 
-- [Issue 88](https://github.com/veeso/suppaftp/issues/88): Removed `ip.is_private()` check on NAT workaround, which prevented public IPs to be used for Natting.
+- [Issue 88](https://github.com/veeso/suppaftp/issues/88): Removed `ip.is_private()` check on NAT workaround, which
+  prevented public IPs to be used for Natting.
 
 ## 6.0.6
 
@@ -188,20 +204,23 @@ Released on 26/10/2024
 
 Released on 15/10/2024
 
-- Added `Send` marker to the Closure: `dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Output = FtpResult<TcpStream>> + Send>> + Send;`
+- Added `Send` marker to the Closure:
+  `dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Output = FtpResult<TcpStream>> + Send>> + Send;`
 - Added unit test to guarantee that FtpStream stays `Send`
 
 ## 6.0.2
 
 Released on 14/10/2024
 
-- [Issue 89](https://github.com/veeso/suppaftp/issues/89): added new `FtpStream::passive_stream_builder` to provide a function to build the Passive mode `TcpStream` with a custom builder. This is useful if you need to use some proxy.
+- [Issue 89](https://github.com/veeso/suppaftp/issues/89): added new `FtpStream::passive_stream_builder` to provide a
+  function to build the Passive mode `TcpStream` with a custom builder. This is useful if you need to use some proxy.
 
 ## 6.0.1
 
 Released on 24/05/2024
 
-- [PR 84](https://github.com/veeso/suppaftp/pull/84): LIST with DOS lines parsed `%d-%m` but the correct syntax is `%m-%d`
+- [PR 84](https://github.com/veeso/suppaftp/pull/84): LIST with DOS lines parsed `%d-%m` but the correct syntax is
+  `%m-%d`
 
 ## 6.0.0
 
@@ -231,7 +250,8 @@ Released on 28/01/2024
 Released on 06/01/2024
 
 - Fix [issue #64](https://github.com/veeso/suppaftp/issues/64): added active mode listener timeout
-- Fix [issue #66](https://github.com/veeso/suppaftp/issues/66): abort can be called without passing ownership to data_stream
+- Fix [issue #66](https://github.com/veeso/suppaftp/issues/66): abort can be called without passing ownership to
+  data_stream
 
 ## 5.2.2
 
@@ -253,8 +273,8 @@ Thanks to [@rye](https://github.com/rye)
 Released on 07/09/2023
 
 - Implemented [RFC 2389](https://www.rfc-editor.org/rfc/rfc2389)
-  - Added `FEAT` command
-  - Added `OPTS` command
+    - Added `FEAT` command
+    - Added `OPTS` command
 
 ## 5.1.2
 
@@ -285,22 +305,23 @@ Released on 26/02/2023
 Released on 24/02/2023
 
 - [Issue 33](https://github.com/veeso/suppaftp/issues/33) **‼️ BREAKING CHANGES ‼️**
-  - Features are now additive. This means that you can successfully build suppaftp with all the features enabled at the same time.
-  - Ftp stream has now been split into different types:
-    - `FtpStream`: sync no-tls stream
-    - `NativeTlsFtpStream`: ftp stream with TLS with native-tls
-    - `RustlsFtpStream`: ftp stream with TLS with rustls
-    - `AsyncFtpStream`: async no-tls stream
-    - `AsyncNativeTlsFtpStream`: async ftp stream with TLS with async-native-tls
-    - `AsyncRustlsFtpStream`: async ftp stream with TLS with async-rustls
+    - Features are now additive. This means that you can successfully build suppaftp with all the features enabled at
+      the same time.
+    - Ftp stream has now been split into different types:
+        - `FtpStream`: sync no-tls stream
+        - `NativeTlsFtpStream`: ftp stream with TLS with native-tls
+        - `RustlsFtpStream`: ftp stream with TLS with rustls
+        - `AsyncFtpStream`: async no-tls stream
+        - `AsyncNativeTlsFtpStream`: async ftp stream with TLS with async-native-tls
+        - `AsyncRustlsFtpStream`: async ftp stream with TLS with async-rustls
 
 ## 4.7.0
 
 Released on 01/02/2023
 
 - [RFC 2428](https://www.rfc-editor.org/rfc/rfc2428) implementation
-  - [Issue 28](https://github.com/veeso/suppaftp/issues/28): Implemented Extended Passive mode (**EPSV**)
-  - [Issue 30](https://github.com/veeso/suppaftp/issues/30): Implemented EPRT
+    - [Issue 28](https://github.com/veeso/suppaftp/issues/28): Implemented Extended Passive mode (**EPSV**)
+    - [Issue 30](https://github.com/veeso/suppaftp/issues/30): Implemented EPRT
 - Updated suppaftp-cli to suppaftp 4.7.0
 
 ## 4.6.1
@@ -343,11 +364,11 @@ Released on 08/10/2022
 - suppaftp-cli as a separate package.
 - Rustls support
 - **‼️ BREAKING CHANGE**: refactored secure features:
-  - **REMOVED** `secure`/`async-secure` feature
-  - Use `native-tls` to enable TLS support with native-tls crate
-  - Use `async-native-tls` to enable async TLS support with async-native-tls crate
-  - Use `rustls` to enable TLS support with rustls crate
-  - Use `async-rustls` to enable TLS support with async-tls crate
+    - **REMOVED** `secure`/`async-secure` feature
+    - Use `native-tls` to enable TLS support with native-tls crate
+    - Use `async-native-tls` to enable async TLS support with async-native-tls crate
+    - Use `rustls` to enable TLS support with rustls crate
+    - Use `async-rustls` to enable TLS support with async-tls crate
 
 ## 4.4.0
 
@@ -360,37 +381,39 @@ Released on 02/08/2022
 Released on 27/06/2022
 
 - Added implicit FTPS support
-  - Added `connect_secure_implicit()` method
-  - Added `deprecated` feature to enable deprecated methods (required for implicit FTPS)
+    - Added `connect_secure_implicit()` method
+    - Added `deprecated` feature to enable deprecated methods (required for implicit FTPS)
 
 ## 4.2.0
 
 Released on 07/12/2021
 
 - **Active mode**
-  - suppaftp now supports Active-mode (credit [@devbydav](https://github.com/devbydav))
-  - You can change mode with `set_mode(Mode::Passive) or set_mode(Mode::Active)` whenever you want
+    - suppaftp now supports Active-mode (credit [@devbydav](https://github.com/devbydav))
+    - You can change mode with `set_mode(Mode::Passive) or set_mode(Mode::Active)` whenever you want
 - **New commands**
-  - **Abort command**: implemented the `ABOR` FTP command
-  - **Append command**: implemented the `APPE` FTP command
-  - **Resume transfer command**: implemented the `REST` FTP command
+    - **Abort command**: implemented the `ABOR` FTP command
+    - **Append command**: implemented the `APPE` FTP command
+    - **Resume transfer command**: implemented the `REST` FTP command
 - **Logging**: `log` crate has been implemented for debugging. You can disable logging with `no-log` feature
 - Security
-  - **TlsStream shutdown**: fixed [issue 5](https://github.com/veeso/suppaftp/issues/5) (credit [@devbydav](https://github.com/devbydav))
+    - **TlsStream shutdown**: fixed [issue 5](https://github.com/veeso/suppaftp/issues/5) (
+      credit [@devbydav](https://github.com/devbydav))
 - ❗ Breaking changes:
-  - `Response.code` renamed to `status`.
-  - status is no more a `u32`: from now on it will be an enum named `Status`.
-    - The status enum implements the `code()` method which will return the `u32` representation
-    - The status enum can be displayed and converted to string: this will return the description of the error code
-  - Changed `into_insecure()` to `clear_command_channel()`: the implementation of into_insecure was wrong and inconsistent. What it actually does is to make the server not to encrypt the communication on the command channel.
-  - Removed `File::from_line`; use `File::try_from()` or `File::from_str()`
+    - `Response.code` renamed to `status`.
+    - status is no more a `u32`: from now on it will be an enum named `Status`.
+        - The status enum implements the `code()` method which will return the `u32` representation
+        - The status enum can be displayed and converted to string: this will return the description of the error code
+    - Changed `into_insecure()` to `clear_command_channel()`: the implementation of into_insecure was wrong and
+      inconsistent. What it actually does is to make the server not to encrypt the communication on the command channel.
+    - Removed `File::from_line`; use `File::try_from()` or `File::from_str()`
 
 ## 4.1.3
 
 Released on 01/12/2021
 
 - UNIX file parser:
-  - Fixed file parsing, which didn't allow any other characters than alphanumerics for groups, users and dates
+    - Fixed file parsing, which didn't allow any other characters than alphanumerics for groups, users and dates
 - `put_file()` will now return the amount of bytes written
 - Updated dependencies
 
@@ -414,14 +437,14 @@ Released on 22/08/2021
 Released on 22/08/2021
 
 - Added `Response` struct, which will be returned in case of `InvalidResponse` error.
-  - This adds the possibility to get the exact error code and the message
+    - This adds the possibility to get the exact error code and the message
 - Added **async** support
 - **API** changes
-  - renamed `simple_retr` to `retr_as_buffer`
-  - renamed `get` to `retr_as_stream`
-  - renamed `finalize_get_stream` to `finalize_retr_stream`
+    - renamed `simple_retr` to `retr_as_buffer`
+    - renamed `get` to `retr_as_stream`
+    - renamed `finalize_get_stream` to `finalize_retr_stream`
 - **LIST** command output parser
-  - Read more on [docs.rs](https://docs.rs/suppaftp/4.1.0/suppaftp/list/index.html)
+    - Read more on [docs.rs](https://docs.rs/suppaftp/4.1.0/suppaftp/list/index.html)
 - Optimized code to reuse stream functions as much as possible
 - `size()` and `mdtm()` methods will return an option no more.
 - Improved code with linter

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["suppaftp", "suppaftp-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "7.0.7"
+version = "7.1.0"
 edition = "2024"
 rust-version = "1.85.1"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -23,12 +23,15 @@ clippy_all() {
 }
 
 test_all() {
+  local test_name
+  test_name="${1:-}"
   for feature in $FEATURES; do
-    cargo test -p suppaftp --features $feature
+    cargo test -p suppaftp --features $feature $test_name
   done
 }
 
 COMMAND=${1:-x}
+shift
 
 case "$COMMAND" in
 
@@ -37,7 +40,7 @@ case "$COMMAND" in
     ;;
   
   "test")
-    test_all
+    test_all "$@"
     ;;
 
   "build")

--- a/suppaftp/src/list/file.rs
+++ b/suppaftp/src/list/file.rs
@@ -1,0 +1,244 @@
+use std::convert::TryFrom;
+use std::path::Path;
+use std::str::FromStr;
+use std::time::SystemTime;
+
+use super::{FileType, ListParser, ParseError, ParseResult, PosixPex, PosixPexQuery};
+
+/// Describes a file entry on the remote system.
+/// This data type is returned in a collection after parsing a LIST output
+///
+/// Each file comes with metadata such as name, type (file, directory, symlink),
+/// size, modification time, POSIX permissions and owner/group ids (if available).
+///
+/// # Parsing
+///
+/// You can parse a LIST line by using the [`ListParser`] by calling either
+///
+/// - [`ListParser::from_posix_line`]
+/// - [`ListParser::from_dos_line`]
+///
+/// or by using the generic implementation of [`FromStr`] or [`TryFrom<&str>`].
+/// In case you opt for the generic implementations, the parser will first try to parse the line
+/// as POSIX format and if it fails, it will try to parse it as DOS format.
+///
+/// So, if you know which format you are dealing with, it is better to use the specific functions.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct File {
+    /// File name
+    pub(crate) name: String,
+    /// File type describes whether it is a directory, a file or a symlink
+    pub(crate) file_type: FileType,
+    /// File size in bytes
+    pub(crate) size: usize,
+    /// Last time the file was modified
+    pub(crate) modified: SystemTime,
+    /// User id (POSIX only)
+    pub(crate) uid: Option<u32>,
+    /// Group id (POSIX only)
+    pub(crate) gid: Option<u32>,
+    /// POSIX permissions
+    pub(crate) posix_pex: (PosixPex, PosixPex, PosixPex),
+}
+
+impl File {
+    /// Get file name
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// Get whether file is a directory
+    pub fn is_directory(&self) -> bool {
+        self.file_type.is_directory()
+    }
+
+    /// Get whether file is a file
+    pub fn is_file(&self) -> bool {
+        self.file_type.is_file()
+    }
+
+    /// Get whether file is a symlink
+    pub fn is_symlink(&self) -> bool {
+        self.file_type.is_symlink()
+    }
+
+    /// Returns, if available, the file the symlink is pointing to
+    pub fn symlink(&self) -> Option<&Path> {
+        self.file_type.symlink()
+    }
+
+    /// Returns a reference to the file type
+    pub fn file_type(&self) -> &FileType {
+        &self.file_type
+    }
+
+    /// Returned file size in bytes
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    /// Returns the last time the file was modified
+    pub fn modified(&self) -> SystemTime {
+        self.modified
+    }
+
+    /// Returns when available the owner user of the file. (POSIX only)
+    pub fn uid(&self) -> Option<u32> {
+        self.uid.to_owned()
+    }
+
+    /// Returns when available the owner group of the file. (POSIX only)
+    pub fn gid(&self) -> Option<u32> {
+        self.gid.to_owned()
+    }
+
+    /// Returns whether `who` can read file
+    pub fn can_read(&self, who: PosixPexQuery) -> bool {
+        self.query_pex(who).can_read()
+    }
+
+    /// Returns whether `who` can write file
+    pub fn can_write(&self, who: PosixPexQuery) -> bool {
+        self.query_pex(who).can_write()
+    }
+
+    /// Returns whether `who` can execute file
+    pub fn can_execute(&self, who: PosixPexQuery) -> bool {
+        self.query_pex(who).can_execute()
+    }
+
+    /// Returns the pex structure for selected query
+    fn query_pex(&self, who: PosixPexQuery) -> &PosixPex {
+        match who {
+            PosixPexQuery::Group => &self.posix_pex.1,
+            PosixPexQuery::Others => &self.posix_pex.2,
+            PosixPexQuery::Owner => &self.posix_pex.0,
+        }
+    }
+
+    /// Parse an output line from a MLSD or MLST command
+    #[deprecated(
+        since = "7.1.0",
+        note = "Use `FileParser::parse_mlsd` or `FileParser::parse_mlst` instead"
+    )]
+    pub fn from_mlsx_line(line: &str) -> ParseResult<Self> {
+        super::ListParser::parse_mlsx(line)
+    }
+
+    /// Parse a POSIX LIST output line and if it is valid, return a [`File`] instance.
+    /// In case of error a [`ParseError`] is returned
+    #[deprecated(since = "7.1.0", note = "Use `FileParser::parse_posix` instead")]
+    pub fn from_posix_line(line: &str) -> ParseResult<Self> {
+        super::ListParser::parse_posix(line)
+    }
+
+    /// Try to parse a "LIST" output command line in DOS format.
+    /// Returns error if syntax is not DOS compliant.
+    /// DOS syntax has the following syntax:
+    ///
+    /// ```text
+    /// {DATE} {TIME} {<DIR> | SIZE} {FILENAME}
+    /// 10-19-20  03:19PM <DIR> pub
+    /// 04-08-14  03:09PM 403   readme.txt
+    /// ```
+    #[deprecated(since = "7.1.0", note = "Use `FileParser::parse_dos` instead")]
+    pub fn from_dos_line(line: &str) -> ParseResult<Self> {
+        super::ListParser::parse_dos(line)
+    }
+}
+
+impl FromStr for File {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s)
+    }
+}
+
+impl TryFrom<&str> for File {
+    type Error = ParseError;
+
+    fn try_from(line: &str) -> Result<Self, Self::Error> {
+        ListParser::parse_posix(line)
+            .or_else(|_| ListParser::parse_dos(line))
+            .or_else(|_| ListParser::parse_mlsd(line))
+            .or_else(|_| ListParser::parse_mlst(line))
+    }
+}
+
+impl TryFrom<&String> for File {
+    type Error = ParseError;
+
+    fn try_from(line: &String) -> Result<Self, Self::Error> {
+        Self::try_from(line.as_str())
+    }
+}
+
+impl TryFrom<String> for File {
+    type Error = ParseError;
+
+    fn try_from(line: String) -> Result<Self, Self::Error> {
+        File::try_from(line.as_str())
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn file_getters() {
+        let file: File = File {
+            name: String::from("provola.txt"),
+            file_type: FileType::File,
+            size: 2048,
+            modified: SystemTime::UNIX_EPOCH,
+            gid: Some(0),
+            uid: Some(0),
+            posix_pex: (PosixPex::from(7), PosixPex::from(5), PosixPex::from(4)),
+        };
+        assert_eq!(file.name(), "provola.txt");
+        assert_eq!(file.is_directory(), false);
+        assert_eq!(file.is_file(), true);
+        assert_eq!(file.is_symlink(), false);
+        assert_eq!(file.symlink(), None);
+        assert_eq!(file.size(), 2048);
+        assert_eq!(file.gid(), Some(0));
+        assert_eq!(file.uid(), Some(0));
+        assert_eq!(file.modified(), SystemTime::UNIX_EPOCH);
+        // -- posix pex
+        assert_eq!(file.can_read(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_write(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_execute(PosixPexQuery::Owner), true);
+        assert_eq!(file.can_read(PosixPexQuery::Group), true);
+        assert_eq!(file.can_write(PosixPexQuery::Group), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Group), true);
+        assert_eq!(file.can_read(PosixPexQuery::Others), true);
+        assert_eq!(file.can_write(PosixPexQuery::Others), false);
+        assert_eq!(file.can_execute(PosixPexQuery::Others), false);
+    }
+
+    #[test]
+    fn file_type() {
+        use std::path::PathBuf;
+
+        assert_eq!(FileType::Directory.is_directory(), true);
+        assert_eq!(FileType::Directory.is_file(), false);
+        assert_eq!(FileType::Directory.is_symlink(), false);
+        assert_eq!(FileType::Directory.symlink(), None);
+        assert_eq!(FileType::File.is_directory(), false);
+        assert_eq!(FileType::File.is_file(), true);
+        assert_eq!(FileType::File.is_symlink(), false);
+        assert_eq!(FileType::File.symlink(), None);
+        assert_eq!(FileType::Symlink(PathBuf::default()).is_directory(), false);
+        assert_eq!(FileType::Symlink(PathBuf::default()).is_file(), false);
+        assert_eq!(FileType::Symlink(PathBuf::default()).is_symlink(), true);
+        assert_eq!(
+            FileType::Symlink(PathBuf::default()).symlink(),
+            Some(PathBuf::default().as_path())
+        );
+    }
+}

--- a/suppaftp/src/list/file_type.rs
+++ b/suppaftp/src/list/file_type.rs
@@ -1,0 +1,38 @@
+use std::path::{Path, PathBuf};
+
+/// Describes the kind of file. Can be `Directory`, `File` or `Symlink`.
+/// If `Symlink` the path to the pointed file is provided.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum FileType {
+    /// Directory type
+    Directory,
+    /// Regular file type
+    File,
+    /// Symlink type with the path to the pointed file
+    Symlink(PathBuf),
+}
+
+impl FileType {
+    /// Returns whether the file is a directory
+    pub fn is_directory(&self) -> bool {
+        matches!(self, &FileType::Directory)
+    }
+
+    /// Returns whether the file is a file
+    pub fn is_file(&self) -> bool {
+        matches!(self, &FileType::File)
+    }
+
+    /// Returns whether the file is a symlink
+    pub fn is_symlink(&self) -> bool {
+        matches!(self, &FileType::Symlink(_))
+    }
+
+    /// get symlink if any
+    pub fn symlink(&self) -> Option<&Path> {
+        match self {
+            FileType::Symlink(p) => Some(p.as_path()),
+            _ => None,
+        }
+    }
+}

--- a/suppaftp/src/list/pex.rs
+++ b/suppaftp/src/list/pex.rs
@@ -1,0 +1,78 @@
+/// This enum is used to query about posix permissions on a file
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PosixPexQuery {
+    Owner,
+    Group,
+    Others,
+}
+
+/// Describes the permissions on POSIX system.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct PosixPex {
+    read: bool,
+    write: bool,
+    execute: bool,
+}
+
+impl PosixPex {
+    /// Returns whether read permission is true
+    pub(crate) fn can_read(&self) -> bool {
+        self.read
+    }
+
+    /// Returns whether write permission is true
+    pub(crate) fn can_write(&self) -> bool {
+        self.write
+    }
+
+    /// Returns whether execute permission is true
+    pub(crate) fn can_execute(&self) -> bool {
+        self.execute
+    }
+}
+
+impl Default for PosixPex {
+    fn default() -> Self {
+        Self {
+            read: true,
+            write: true,
+            execute: true,
+        }
+    }
+}
+
+impl From<u8> for PosixPex {
+    fn from(bits: u8) -> Self {
+        Self {
+            read: ((bits >> 2) & 0x01) != 0,
+            write: ((bits >> 1) & 0x01) != 0,
+            execute: (bits & 0x01) != 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn posix_pex_from_bits() {
+        let pex: PosixPex = PosixPex::from(4);
+        pretty_assertions::assert_eq!(pex.can_read(), true);
+        pretty_assertions::assert_eq!(pex.can_write(), false);
+        pretty_assertions::assert_eq!(pex.can_execute(), false);
+        let pex: PosixPex = PosixPex::from(0);
+        pretty_assertions::assert_eq!(pex.can_read(), false);
+        pretty_assertions::assert_eq!(pex.can_write(), false);
+        pretty_assertions::assert_eq!(pex.can_execute(), false);
+        let pex: PosixPex = PosixPex::from(3);
+        pretty_assertions::assert_eq!(pex.can_read(), false);
+        pretty_assertions::assert_eq!(pex.can_write(), true);
+        pretty_assertions::assert_eq!(pex.can_execute(), true);
+        let pex: PosixPex = PosixPex::from(7);
+        pretty_assertions::assert_eq!(pex.can_read(), true);
+        pretty_assertions::assert_eq!(pex.can_write(), true);
+        pretty_assertions::assert_eq!(pex.can_execute(), true);
+    }
+}


### PR DESCRIPTION
It is now possible to retrieve the `FileType` from a file using `File::file_type()`.

[Issue 128](https://github.com/veeso/suppaftp/issues/128)

- Made `FileType` enum public
- Added `File::file_type()` method to retrieve the file type
- Deprecated `File::from_dos_line`,  `File::from_mlsx_line`, and `File::from_posix_line` methods in favor of `ListParser::parse_dos`, `ListParser::parse_mlst`, `ListParser::parse_mlsd`, and `ListParser::parse_posix` respectively.

closes #128
