### PR TITLE
fix: handle 200 (command OK) as success in cwd()

### DIFF
--- a/crates/suppaftp/src/async_ftp/async_std_ftp/mod.rs
+++ b/crates/suppaftp/src/async_ftp/async_std_ftp/mod.rs
@@ -338,7 +338,7 @@ where
         debug!("Changing working directory to {}", path.as_ref());
         self.perform(Command::Cwd(path.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestedFileActionOk)
+        self.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
             .await
             .map(|_| ())
     }

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/mod.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/mod.rs
@@ -332,7 +332,7 @@ where
         debug!("Changing working directory to {}", path.as_ref());
         self.perform(Command::Cwd(path.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestedFileActionOk)
+        self.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
             .await
             .map(|_| ())
     }

--- a/crates/suppaftp/src/sync_ftp/mod.rs
+++ b/crates/suppaftp/src/sync_ftp/mod.rs
@@ -319,7 +319,7 @@ where
     pub fn cwd<S: AsRef<str>>(&mut self, path: S) -> FtpResult<()> {
         debug!("Changing working directory to {}", path.as_ref());
         self.perform(Command::Cwd(path.as_ref().to_string()))?;
-        self.read_response(Status::RequestedFileActionOk)
+        self.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
             .map(|_| ())
     }
 


### PR DESCRIPTION
#  

Fixes #

## Description

RFC 959 specifies 250 as the standard response code when changing the working directory successfully, but some FTP servers return 200 instead.