### PR TITLE
chore: release 8.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+    - [8.0.3](#803)
     - [8.0.2](#802)
     - [8.0.1](#801)
     - [7.0.7](#707)
@@ -53,6 +54,12 @@
     - [4.0.0](#400)
 
 ---
+
+## 8.0.3
+
+Released on 23/04/2026
+
+- [PR 153](https://github.com/veeso/suppaftp/pull/153): Fixed `cwd()` to accept `200 Command OK` in addition to `250` as success, for compatibility with servers that deviate from RFC 959.
 
 ## 8.0.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/suppaftp", "crates/suppaftp-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "8.0.2"
+version = "8.0.3"
 edition = "2024"
 rust-version = "1.85.1"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]


### PR DESCRIPTION
Release 8.0.3 — includes #153 (cwd 200 handling).