### PR TITLE
fix: reset data_connection_open flag when a data command fails

### DIFF
--- a/.github/workflows/all-features.yml
+++ b/.github/workflows/all-features.yml
@@ -5,12 +5,17 @@ on: [ push, pull_request ]
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: rustfmt, clippy

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -5,12 +5,17 @@ on: [ push, pull_request ]
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: rustfmt, clippy

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -2,16 +2,20 @@ name: codeberg-mirror
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   mirror:
     if: github.repository_owner == 'veeso'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Mirror to Codeberg"
-        uses: yesolutions/mirror-action@v0.7.0
+        uses: yesolutions/mirror-action@1708f16cdb28634fd3ba10c5c79abc91f5578a14 # v0.7.0
         with:
           REMOTE: 'ssh://git@codeberg.org/veeso/suppaftp.git'
           GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on: [ push, pull_request ]
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (${{ matrix.features }})
@@ -28,15 +31,17 @@ jobs:
           ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with:
           tool: cargo-llvm-cov
 
@@ -47,7 +52,7 @@ jobs:
         run: cargo llvm-cov --no-fail-fast --no-default-features --features ${{ matrix.features }} --workspace --lcov --output-path lcov-${{ matrix.features }}.info
 
       - name: Upload to Coveralls
-        uses: coverallsapp/github-action@v2.3.6
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
@@ -59,7 +64,7 @@ jobs:
     needs: test
     steps:
       - name: Wait for coveralls
-        uses: coverallsapp/github-action@v2.3.6
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+    - [8.0.4](#804)
     - [8.0.3](#803)
     - [8.0.2](#802)
     - [8.0.1](#801)
@@ -54,6 +55,10 @@
     - [4.0.0](#400)
 
 ---
+
+## 8.0.4
+
+- [Issue 155](https://github.com/veeso/suppaftp/issues/155): Fixed data commands (`retr_as_stream`, `retr_as_buffer`, `put_with_stream`, `append_with_stream`, `custom_data_command`, `list`, `nlst`) leaving the `data_connection_open` flag set when the server rejected the command, which made every subsequent data command wrongly fail with `DataConnectionAlreadyOpen`.
 
 ## 8.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 ## 8.0.4
 
 - [Issue 155](https://github.com/veeso/suppaftp/issues/155): Fixed data commands (`retr_as_stream`, `retr_as_buffer`, `put_with_stream`, `append_with_stream`, `custom_data_command`, `list`, `nlst`) leaving the `data_connection_open` flag set when the server rejected the command, which made every subsequent data command wrongly fail with `DataConnectionAlreadyOpen`.
+- Upgraded `async-native-tls` to 0.6. The async-std FTPS backend now uses the `runtime-smol` feature of `async-native-tls` (the crate dropped its `runtime-async-std` feature in 0.6).
 
 ## 8.0.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/suppaftp", "crates/suppaftp-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "8.0.3"
+version = "8.0.4"
 edition = "2024"
 rust-version = "1.85.1"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]

--- a/crates/suppaftp/Cargo.toml
+++ b/crates/suppaftp/Cargo.toml
@@ -31,11 +31,12 @@ lazy-regex = "3"
 log = "0.4"
 thiserror = "2"
 # async
-async-native-tls-crate = { package = "async-native-tls", version = "^0.5", default-features = false, optional = true }
+async-native-tls-crate = { package = "async-native-tls", version = "0.5", default-features = false, optional = true }
 async-std = { version = "1", optional = true }
 async-trait = { version = "0.1", optional = true }
 futures-rustls = { version = "0.26", optional = true, default-features = false, features = [
-  "tls12", "logging"
+  "tls12",
+  "logging",
 ] }
 pin-project = { version = "1", optional = true }
 rustls-pki-types = { version = "1", optional = true, features = ["alloc"] }
@@ -46,7 +47,8 @@ tokio = { version = "1", features = [
   "time",
 ], optional = true }
 tokio-rustls-crate = { package = "tokio-rustls", version = "0.26", optional = true, default-features = false, features = [
-  "logging", "tls12"
+  "logging",
+  "tls12",
 ] }
 # secure
 native-tls-crate = { package = "native-tls", version = "0.2", optional = true }
@@ -61,8 +63,8 @@ futures-lite = "2"
 async-attributes = "1"
 env_logger = "^0.11"
 pretty_assertions = "1"
-rand = "^0.9"
-testcontainers = { version = "0.26", features = ["blocking"] }
+rand = "0.10"
+testcontainers = { version = "0.27", features = ["blocking"] }
 webpki-roots = "1"
 
 [features]

--- a/crates/suppaftp/Cargo.toml
+++ b/crates/suppaftp/Cargo.toml
@@ -31,7 +31,7 @@ lazy-regex = "3"
 log = "0.4"
 thiserror = "2"
 # async
-async-native-tls-crate = { package = "async-native-tls", version = "0.5", default-features = false, optional = true }
+async-native-tls-crate = { package = "async-native-tls", version = "0.6", default-features = false, optional = true }
 async-std = { version = "1", optional = true }
 async-trait = { version = "0.1", optional = true }
 futures-rustls = { version = "0.26", optional = true, default-features = false, features = [
@@ -99,7 +99,7 @@ async-std-rustls-ring = [
 async-std-async-native-tls = [
   "async-std",
   "dep:async-native-tls-crate",
-  "async-native-tls-crate/runtime-async-std",
+  "async-native-tls-crate/runtime-smol",
   "async-native-tls-crate/futures-util",
   "async-secure",
 ]

--- a/crates/suppaftp/src/async_ftp/async_std_ftp/mod.rs
+++ b/crates/suppaftp/src/async_ftp/async_std_ftp/mod.rs
@@ -462,10 +462,11 @@ where
         file_name: S,
     ) -> FtpResult<DataStream<T>> {
         debug!("Retrieving '{}'", file_name.as_ref());
-        let data_stream = self
-            .data_command(Command::Retr(file_name.as_ref().to_string()))
-            .await?;
-        self.read_response_in(&[Status::AboutToSend, Status::AlreadyOpen])
+        let (_, data_stream) = self
+            .data_command_with_response(
+                Command::Retr(file_name.as_ref().to_string()),
+                &[Status::AboutToSend, Status::AlreadyOpen],
+            )
             .await?;
         Ok(data_stream)
     }
@@ -528,10 +529,11 @@ where
         filename: S,
     ) -> FtpResult<DataStream<T>> {
         debug!("Put file {}", filename.as_ref());
-        let stream = self
-            .data_command(Command::Store(filename.as_ref().to_string()))
-            .await?;
-        self.read_response_in(&[Status::AlreadyOpen, Status::AboutToSend])
+        let (_, stream) = self
+            .data_command_with_response(
+                Command::Store(filename.as_ref().to_string()),
+                &[Status::AlreadyOpen, Status::AboutToSend],
+            )
             .await?;
         Ok(stream)
     }
@@ -559,10 +561,11 @@ where
         filename: S,
     ) -> FtpResult<DataStream<T>> {
         debug!("Appending to file {}", filename.as_ref());
-        let stream = self
-            .data_command(Command::Appe(filename.as_ref().to_string()))
-            .await?;
-        self.read_response_in(&[Status::AlreadyOpen, Status::AboutToSend])
+        let (_, stream) = self
+            .data_command_with_response(
+                Command::Appe(filename.as_ref().to_string()),
+                &[Status::AlreadyOpen, Status::AboutToSend],
+            )
             .await?;
         Ok(stream)
     }
@@ -812,8 +815,9 @@ where
     ) -> FtpResult<(Response, DataStream<T>)> {
         let command = command.to_string();
         debug!("Sending custom data command: {}", command);
-        let data_stream = self.data_command(Command::Custom(command)).await?;
-        let response = self.read_response_in(expected_code).await?;
+        let (response, data_stream) = self
+            .data_command_with_response(Command::Custom(command), expected_code)
+            .await?;
         Ok((response, data_stream))
     }
 
@@ -926,6 +930,29 @@ where
             self.data_connection_open = true;
         }
         result
+    }
+
+    /// Open a data connection for `cmd` and read the preliminary response confirming the transfer.
+    ///
+    /// If the server rejects the command (the response is not one of `expected_code`), the data
+    /// connection is dropped and `data_connection_open` is reset to `false`. This guarantees that a
+    /// failed command never leaves the client believing a data connection is still open, which would
+    /// otherwise make every subsequent data command fail with [`FtpError::DataConnectionAlreadyOpen`].
+    async fn data_command_with_response(
+        &mut self,
+        cmd: Command,
+        expected_code: &[Status],
+    ) -> FtpResult<(Response, DataStream<T>)> {
+        let data_stream = self.data_command(cmd).await?;
+        match self.read_response_in(expected_code).await {
+            Ok(response) => Ok((response, data_stream)),
+            Err(err) => {
+                // server rejected the command: drop the data stream and reset the open flag
+                drop(data_stream);
+                self.data_connection_open = false;
+                Err(err)
+            }
+        }
     }
 
     /// Runs the EPSV to enter Extended passive mode.
@@ -1100,9 +1127,10 @@ where
 
     /// Execute a command which returns list of strings in a separate stream
     async fn stream_lines(&mut self, cmd: Command, open_code: Status) -> FtpResult<Vec<String>> {
-        let mut data_stream = BufReader::new(self.data_command(cmd).await?);
-        self.read_response_in(&[open_code, Status::AlreadyOpen])
+        let (_, stream) = self
+            .data_command_with_response(cmd, &[open_code, Status::AlreadyOpen])
             .await?;
+        let mut data_stream = BufReader::new(stream);
         let lines = Self::get_lines_from_stream(&mut data_stream).await;
         self.finalize_retr_stream(data_stream).await?;
         lines
@@ -1489,6 +1517,39 @@ mod test {
             .expect("Failed to get lines from stream");
         // finalize
         assert!(stream.close_data_connection(reader).await.is_ok());
+    }
+
+    #[async_attributes::test]
+    async fn should_reset_data_connection_after_failed_data_command() {
+        use async_std::io::Cursor;
+
+        let (mut stream, _container) = setup_stream().await;
+        assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+
+        // A failed data command must leave the data connection free, otherwise the next data
+        // command would wrongly fail with `DataConnectionAlreadyOpen` instead of the real error.
+        for _ in 0..3 {
+            assert!(stream.retr_as_stream("non-existing.txt").await.is_err());
+            assert!(
+                stream
+                    .custom_data_command("RETR non-existing.txt", &[Status::AboutToSend])
+                    .await
+                    .is_err()
+            );
+        }
+
+        // After the failures every kind of data command must still be usable.
+        let mut reader = Cursor::new("test data\n".as_bytes());
+        assert!(stream.put_file("test.txt", &mut reader).await.is_ok());
+        let mut reader = Cursor::new("test data\n".as_bytes());
+        assert!(stream.append_file("test.txt", &mut reader).await.is_ok());
+        let data_stream = stream.retr_as_stream("test.txt").await.unwrap();
+        assert!(stream.finalize_retr_stream(data_stream).await.is_ok());
+        assert!(stream.list(None).await.is_ok());
+        assert!(stream.nlst(None).await.is_ok());
+
+        assert!(stream.rm("test.txt").await.is_ok());
+        finalize_stream(stream).await;
     }
 
     #[async_attributes::test]

--- a/crates/suppaftp/src/async_ftp/async_std_ftp/mod.rs
+++ b/crates/suppaftp/src/async_ftp/async_std_ftp/mod.rs
@@ -1168,7 +1168,7 @@ mod test {
     #[cfg(feature = "async-secure")]
     use pretty_assertions::assert_eq;
     use rand::distr::Alphanumeric;
-    use rand::{Rng, rng};
+    use rand::{RngExt, rng};
 
     use super::super::async_std::AsyncFtpStream;
     use super::*;

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/mod.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/mod.rs
@@ -1164,7 +1164,7 @@ mod test {
 
     use pretty_assertions::assert_eq;
     use rand::distr::Alphanumeric;
-    use rand::{Rng, rng};
+    use rand::{RngExt, rng};
     use tokio::io::AsyncReadExt;
 
     use super::super::tokio::AsyncFtpStream;

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/mod.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/mod.rs
@@ -456,10 +456,11 @@ where
         file_name: S,
     ) -> FtpResult<DataStream<T>> {
         debug!("Retrieving '{}'", file_name.as_ref());
-        let data_stream = self
-            .data_command(Command::Retr(file_name.as_ref().to_string()))
-            .await?;
-        self.read_response_in(&[Status::AboutToSend, Status::AlreadyOpen])
+        let (_, data_stream) = self
+            .data_command_with_response(
+                Command::Retr(file_name.as_ref().to_string()),
+                &[Status::AboutToSend, Status::AlreadyOpen],
+            )
             .await?;
         Ok(data_stream)
     }
@@ -522,10 +523,11 @@ where
         filename: S,
     ) -> FtpResult<DataStream<T>> {
         debug!("Put file {}", filename.as_ref());
-        let stream = self
-            .data_command(Command::Store(filename.as_ref().to_string()))
-            .await?;
-        self.read_response_in(&[Status::AlreadyOpen, Status::AboutToSend])
+        let (_, stream) = self
+            .data_command_with_response(
+                Command::Store(filename.as_ref().to_string()),
+                &[Status::AlreadyOpen, Status::AboutToSend],
+            )
             .await?;
         Ok(stream)
     }
@@ -556,10 +558,11 @@ where
         filename: S,
     ) -> FtpResult<DataStream<T>> {
         debug!("Appending to file {}", filename.as_ref());
-        let stream = self
-            .data_command(Command::Appe(filename.as_ref().to_string()))
-            .await?;
-        self.read_response_in(&[Status::AlreadyOpen, Status::AboutToSend])
+        let (_, stream) = self
+            .data_command_with_response(
+                Command::Appe(filename.as_ref().to_string()),
+                &[Status::AlreadyOpen, Status::AboutToSend],
+            )
             .await?;
         Ok(stream)
     }
@@ -809,8 +812,9 @@ where
     ) -> FtpResult<(Response, DataStream<T>)> {
         let command = command.to_string();
         debug!("Sending custom data command: {}", command);
-        let data_stream = self.data_command(Command::Custom(command)).await?;
-        let response = self.read_response_in(expected_code).await?;
+        let (response, data_stream) = self
+            .data_command_with_response(Command::Custom(command), expected_code)
+            .await?;
         Ok((response, data_stream))
     }
 
@@ -923,6 +927,29 @@ where
             self.data_connection_open = true;
         }
         result
+    }
+
+    /// Open a data connection for `cmd` and read the preliminary response confirming the transfer.
+    ///
+    /// If the server rejects the command (the response is not one of `expected_code`), the data
+    /// connection is dropped and `data_connection_open` is reset to `false`. This guarantees that a
+    /// failed command never leaves the client believing a data connection is still open, which would
+    /// otherwise make every subsequent data command fail with [`FtpError::DataConnectionAlreadyOpen`].
+    async fn data_command_with_response(
+        &mut self,
+        cmd: Command,
+        expected_code: &[Status],
+    ) -> FtpResult<(Response, DataStream<T>)> {
+        let data_stream = self.data_command(cmd).await?;
+        match self.read_response_in(expected_code).await {
+            Ok(response) => Ok((response, data_stream)),
+            Err(err) => {
+                // server rejected the command: drop the data stream and reset the open flag
+                drop(data_stream);
+                self.data_connection_open = false;
+                Err(err)
+            }
+        }
     }
 
     /// Runs the EPSV to enter Extended passive mode.
@@ -1097,9 +1124,10 @@ where
 
     /// Execute a command which returns list of strings in a separate stream
     async fn stream_lines(&mut self, cmd: Command, open_code: Status) -> FtpResult<Vec<String>> {
-        let mut data_stream = BufReader::new(self.data_command(cmd).await?);
-        self.read_response_in(&[open_code, Status::AlreadyOpen])
+        let (_, stream) = self
+            .data_command_with_response(cmd, &[open_code, Status::AlreadyOpen])
             .await?;
+        let mut data_stream = BufReader::new(stream);
         let lines = Self::get_lines_from_stream(&mut data_stream).await;
         self.finalize_retr_stream(data_stream).await?;
         lines
@@ -1467,6 +1495,37 @@ mod test {
 
         finalize_stream(stream).await;
         drop(container);
+    }
+
+    #[tokio::test]
+    async fn should_reset_data_connection_after_failed_data_command() {
+        let (mut stream, _container) = setup_stream().await;
+        assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+
+        // A failed data command must leave the data connection free, otherwise the next data
+        // command would wrongly fail with `DataConnectionAlreadyOpen` instead of the real error.
+        for _ in 0..3 {
+            assert!(stream.retr_as_stream("non-existing.txt").await.is_err());
+            assert!(
+                stream
+                    .custom_data_command("RETR non-existing.txt", &[Status::AboutToSend])
+                    .await
+                    .is_err()
+            );
+        }
+
+        // After the failures every kind of data command must still be usable.
+        let mut reader = Cursor::new("test data\n".as_bytes());
+        assert!(stream.put_file("test.txt", &mut reader).await.is_ok());
+        let mut reader = Cursor::new("test data\n".as_bytes());
+        assert!(stream.append_file("test.txt", &mut reader).await.is_ok());
+        let data_stream = stream.retr_as_stream("test.txt").await.unwrap();
+        assert!(stream.finalize_retr_stream(data_stream).await.is_ok());
+        assert!(stream.list(None).await.is_ok());
+        assert!(stream.nlst(None).await.is_ok());
+
+        assert!(stream.rm("test.txt").await.is_ok());
+        finalize_stream(stream).await;
     }
 
     #[tokio::test]

--- a/crates/suppaftp/src/list.rs
+++ b/crates/suppaftp/src/list.rs
@@ -36,7 +36,7 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use chrono::prelude::Utc;
-use chrono::{Datelike, NaiveDate, NaiveDateTime};
+use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime};
 use lazy_regex::{Lazy, Regex};
 use thiserror::Error;
 
@@ -374,6 +374,17 @@ impl ListParser {
     /// 1. if year is current: %b %d %H:%M (e.g. Nov 5 13:46)
     /// 2. else: %b %d %Y (e.g. Nov 5 2019)
     fn parse_lstime(tm: &str, fmt_year: &str, fmt_hours: &str) -> Result<SystemTime, ParseError> {
+        Self::parse_lstime_with_now(tm, fmt_year, fmt_hours, Utc::now())
+    }
+
+    /// Same as [`Self::parse_lstime`], but with an injectable reference time so the
+    /// year-adjustment logic can be tested deterministically.
+    fn parse_lstime_with_now(
+        tm: &str,
+        fmt_year: &str,
+        fmt_hours: &str,
+        now: DateTime<Utc>,
+    ) -> Result<SystemTime, ParseError> {
         let datetime: NaiveDateTime = match NaiveDate::parse_from_str(tm, fmt_year) {
             Ok(date) => {
                 // Case 2.
@@ -383,7 +394,6 @@ impl ListParser {
             Err(_) => {
                 // Might be case 1.
                 // We need to add Current Year at the end of the string
-                let now = Utc::now();
                 let this_year: i32 = now.year();
                 let date_time_str: String = format!("{tm} {this_year}");
                 // Now parse
@@ -426,8 +436,6 @@ impl ListParser {
 
 #[cfg(test)]
 mod tests {
-    use chrono::DateTime;
-
     use super::*;
 
     #[test]
@@ -763,85 +771,69 @@ mod tests {
 
     #[test]
     fn parse_lstime_should_adjust_year_for_future_dates() {
-        use chrono::Months;
+        use chrono::TimeZone;
 
-        let now = Utc::now();
-        let this_year = now.year();
+        // Reference time fixed so the test is deterministic regardless of when it runs.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap();
 
-        // Pick a date 8 months in the future — more than the 6-month threshold
-        let future_date = now.naive_utc().date() + Months::new(8);
-        let month_abbr = future_date.format("%b").to_string();
-        let time_str = format!("{month_abbr} 15 12:00");
-
-        let result = ListParser::parse_lstime(&time_str, "%b %d %Y", "%b %d %H:%M").unwrap();
+        // "Dec 15" stamped with the current year (2024) lands >6 months in the future,
+        // so it must be re-assigned to the previous year.
+        let result =
+            ListParser::parse_lstime_with_now("Dec 15 12:00", "%b %d %Y", "%b %d %H:%M", now)
+                .unwrap();
         let result_dt: DateTime<Utc> = result.into();
 
-        // Should be assigned the previous year since it would be >6 months in the future
-        pretty_assertions::assert_eq!(result_dt.year(), this_year - 1);
-        pretty_assertions::assert_eq!(result_dt.month(), future_date.month());
+        pretty_assertions::assert_eq!(result_dt.year(), 2023);
+        pretty_assertions::assert_eq!(result_dt.month(), 12);
         pretty_assertions::assert_eq!(result_dt.day(), 15);
     }
 
     #[test]
     fn parse_lstime_should_not_adjust_year_for_near_future_dates() {
-        use chrono::Months;
+        use chrono::TimeZone;
 
-        let now = Utc::now();
-        let this_year = now.year();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap();
 
-        // Pick a date 2 months in the future — within the 6-month threshold
-        let near_date = now.naive_utc().date() + Months::new(2);
-        let month_abbr = near_date.format("%b").to_string();
-        let time_str = format!("{month_abbr} 15 12:00");
-
-        let result = ListParser::parse_lstime(&time_str, "%b %d %Y", "%b %d %H:%M").unwrap();
+        // "Aug 15" is ~2 months ahead — within the 6-month threshold, keep current year.
+        let result =
+            ListParser::parse_lstime_with_now("Aug 15 12:00", "%b %d %Y", "%b %d %H:%M", now)
+                .unwrap();
         let result_dt: DateTime<Utc> = result.into();
 
-        // Should keep the current year since it's within 6 months
-        pretty_assertions::assert_eq!(result_dt.year(), this_year);
-        pretty_assertions::assert_eq!(result_dt.month(), near_date.month());
+        pretty_assertions::assert_eq!(result_dt.year(), 2024);
+        pretty_assertions::assert_eq!(result_dt.month(), 8);
         pretty_assertions::assert_eq!(result_dt.day(), 15);
     }
 
     #[test]
     fn parse_lstime_should_not_adjust_year_for_recent_past_dates() {
-        use chrono::Months;
+        use chrono::TimeZone;
 
-        let now = Utc::now();
-        let this_year = now.year();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap();
 
-        // Pick a date 1 month in the past — recent past should keep the current year
-        let past_date = now.naive_utc().date() - Months::new(1);
-        let month_abbr = past_date.format("%b").to_string();
-        let time_str = format!("{month_abbr} 15 12:00");
-
-        let result = ListParser::parse_lstime(&time_str, "%b %d %Y", "%b %d %H:%M").unwrap();
+        // "May 15" is 1 month in the past — keep the current year.
+        let result =
+            ListParser::parse_lstime_with_now("May 15 12:00", "%b %d %Y", "%b %d %H:%M", now)
+                .unwrap();
         let result_dt: DateTime<Utc> = result.into();
 
-        pretty_assertions::assert_eq!(result_dt.year(), this_year);
-        pretty_assertions::assert_eq!(result_dt.month(), past_date.month());
+        pretty_assertions::assert_eq!(result_dt.year(), 2024);
+        pretty_assertions::assert_eq!(result_dt.month(), 5);
     }
 
     #[test]
-    fn parse_posix_line_should_adjust_year_for_future_dates() {
-        use chrono::Months;
+    fn parse_posix_line_should_route_date_through_lstime() {
+        // parse_posix has to thread the timeless date through parse_lstime, so its result
+        // must match parse_lstime for the same input. Both use the real `Utc::now()` here,
+        // which keeps the test correct regardless of the current date.
+        let line = "-rw-r--r-- 1 user group 1234 Dec 15 10:30 example.txt";
 
-        let now = Utc::now();
-        let this_year = now.year();
-
-        // Construct a POSIX line with a date 8 months in the future (time format, no year)
-        let future_date = now.naive_utc().date() + Months::new(8);
-        let month_abbr = future_date.format("%b").to_string();
-        let line = format!("-rw-r--r-- 1 user group 1234 {month_abbr} 15 10:30 example.txt");
-
-        let file = ListParser::parse_posix(&line).unwrap();
+        let file = ListParser::parse_posix(line).unwrap();
         pretty_assertions::assert_eq!(file.name(), "example.txt");
         pretty_assertions::assert_eq!(file.size, 1234);
 
-        let result_dt: DateTime<Utc> = file.modified.into();
-        // Should be assigned the previous year
-        pretty_assertions::assert_eq!(result_dt.year(), this_year - 1);
-        pretty_assertions::assert_eq!(result_dt.month(), future_date.month());
+        let expected = ListParser::parse_lstime("Dec 15 10:30", "%b %d %Y", "%b %d %H:%M").unwrap();
+        pretty_assertions::assert_eq!(file.modified, expected);
     }
 
     #[test]

--- a/crates/suppaftp/src/sync_ftp/mod.rs
+++ b/crates/suppaftp/src/sync_ftp/mod.rs
@@ -470,8 +470,10 @@ where
     /// Once file has been read, call [`ImplFtpStream::finalize_retr_stream`]
     pub fn retr_as_stream<S: AsRef<str>>(&mut self, file_name: S) -> FtpResult<DataStream<T>> {
         debug!("Retrieving '{}'", file_name.as_ref());
-        let data_stream = self.data_command(Command::Retr(file_name.as_ref().to_string()))?;
-        self.read_response_in(&[Status::AboutToSend, Status::AlreadyOpen])?;
+        let (_, data_stream) = self.data_command_with_response(
+            Command::Retr(file_name.as_ref().to_string()),
+            &[Status::AboutToSend, Status::AlreadyOpen],
+        )?;
         Ok(data_stream)
     }
 
@@ -521,8 +523,10 @@ where
     /// Once you've finished the write, YOU MUST CALL THIS METHOD: [`ImplFtpStream::finalize_put_stream`]
     pub fn put_with_stream<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<DataStream<T>> {
         debug!("Put file {}", filename.as_ref());
-        let stream = self.data_command(Command::Store(filename.as_ref().to_string()))?;
-        self.read_response_in(&[Status::AlreadyOpen, Status::AboutToSend])?;
+        let (_, stream) = self.data_command_with_response(
+            Command::Store(filename.as_ref().to_string()),
+            &[Status::AlreadyOpen, Status::AboutToSend],
+        )?;
         Ok(stream)
     }
 
@@ -545,8 +549,10 @@ where
     /// Once you've finished the write, YOU MUST CALL THIS METHOD: [`ImplFtpStream::finalize_put_stream`]
     pub fn append_with_stream<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<DataStream<T>> {
         debug!("Appending to file {}", filename.as_ref());
-        let stream = self.data_command(Command::Appe(filename.as_ref().to_string()))?;
-        self.read_response_in(&[Status::AlreadyOpen, Status::AboutToSend])?;
+        let (_, stream) = self.data_command_with_response(
+            Command::Appe(filename.as_ref().to_string()),
+            &[Status::AlreadyOpen, Status::AboutToSend],
+        )?;
         Ok(stream)
     }
 
@@ -791,8 +797,8 @@ where
     ) -> FtpResult<(Response, DataStream<T>)> {
         let command = command.to_string();
         debug!("Sending custom data command: {}", command);
-        let data_stream = self.data_command(Command::Custom(command))?;
-        let response = self.read_response_in(expected_code)?;
+        let (response, data_stream) =
+            self.data_command_with_response(Command::Custom(command), expected_code)?;
         Ok((response, data_stream))
     }
 
@@ -988,6 +994,29 @@ where
         result
     }
 
+    /// Open a data connection for `cmd` and read the preliminary response confirming the transfer.
+    ///
+    /// If the server rejects the command (the response is not one of `expected_code`), the data
+    /// connection is dropped and `data_connection_open` is reset to `false`. This guarantees that a
+    /// failed command never leaves the client believing a data connection is still open, which would
+    /// otherwise make every subsequent data command fail with [`FtpError::DataConnectionAlreadyOpen`].
+    fn data_command_with_response(
+        &mut self,
+        cmd: Command,
+        expected_code: &[Status],
+    ) -> FtpResult<(Response, DataStream<T>)> {
+        let data_stream = self.data_command(cmd)?;
+        match self.read_response_in(expected_code) {
+            Ok(response) => Ok((response, data_stream)),
+            Err(err) => {
+                // server rejected the command: drop the data stream and reset the open flag
+                drop(data_stream);
+                self.data_connection_open = false;
+                Err(err)
+            }
+        }
+    }
+
     /// Create a new tcp listener and send a PORT command for it
     fn active(&mut self) -> FtpResult<TcpListener> {
         debug!("Starting local tcp listener...");
@@ -1100,8 +1129,9 @@ where
 
     /// Execute a command which returns list of strings in a separate stream
     fn stream_lines(&mut self, cmd: Command, open_code: Status) -> FtpResult<Vec<String>> {
-        let mut data_stream = BufReader::new(self.data_command(cmd)?);
-        self.read_response_in(&[open_code, Status::AlreadyOpen])?;
+        let (_, stream) =
+            self.data_command_with_response(cmd, &[open_code, Status::AlreadyOpen])?;
+        let mut data_stream = BufReader::new(stream);
         let lines = Self::get_lines_from_stream(&mut data_stream);
         self.finalize_retr_stream(data_stream)?;
         lines
@@ -1368,6 +1398,46 @@ mod test {
             assert!(stream.rm("toast.txt").is_ok());
             // List directory again
             assert_eq!(stream.list(None).unwrap().len(), 0);
+        })
+    }
+
+    #[test]
+    fn should_make_subsequent_retr_call_to_non_existing_files() {
+        with_test_ftp_stream(|stream| {
+            // First call to non-existing file should return error
+            let e = stream.retr_as_stream("non-existing.txt").unwrap_err();
+            let e2 = stream.retr_as_stream("non-existing.txt").unwrap_err();
+            // Both errors should be the same and not be affected by each other
+            assert_eq!(e.to_string(), e2.to_string());
+        })
+    }
+
+    #[test]
+    fn should_reset_data_connection_after_failed_data_command() {
+        with_test_ftp_stream(|stream| {
+            assert!(stream.transfer_type(FileType::Binary).is_ok());
+
+            // A failed data command must leave the data connection free, otherwise the next data
+            // command would wrongly fail with `DataConnectionAlreadyOpen` instead of the real error.
+            for _ in 0..3 {
+                assert!(stream.retr_as_stream("non-existing.txt").is_err());
+                assert!(
+                    stream
+                        .custom_data_command("RETR non-existing.txt", &[Status::AboutToSend])
+                        .is_err()
+                );
+            }
+
+            // After the failures every kind of data command must still be usable.
+            let mut reader = Cursor::new("test data\n".as_bytes());
+            assert!(stream.put_file("test.txt", &mut reader).is_ok());
+            let mut reader = Cursor::new("test data\n".as_bytes());
+            assert!(stream.append_file("test.txt", &mut reader).is_ok());
+            assert!(stream.retr_as_buffer("test.txt").is_ok());
+            assert!(stream.list(None).is_ok());
+            assert!(stream.nlst(None).is_ok());
+
+            assert!(stream.rm("test.txt").is_ok());
         })
     }
 

--- a/crates/suppaftp/src/sync_ftp/mod.rs
+++ b/crates/suppaftp/src/sync_ftp/mod.rs
@@ -1165,7 +1165,7 @@ mod test {
     #[cfg(feature = "secure")]
     use pretty_assertions::assert_eq;
     use rand::distr::Alphanumeric;
-    use rand::{Rng, rng};
+    use rand::{RngExt, rng};
 
     use super::*;
     use crate::FtpStream;


### PR DESCRIPTION
## Problem

Closes #155.

Data commands set `data_connection_open = true` as soon as the data stream is opened, but the follow-up `read_response_in` could still fail — e.g. the server returns `550` when `RETR` targets a missing file. On that error the `?` propagated while the flag stayed `true`, so every subsequent data command wrongly failed with `DataConnectionAlreadyOpen` instead of the real server error.

## Fix

Add a private `data_command_with_response(cmd, expected_code)` wrapper that runs the data command and reads its preliminary response, dropping the stream and resetting `data_connection_open` to `false` on error. This centralizes the reset so no caller can leak the flag.

Routed every data-command caller through it, in the sync, tokio and async-std implementations:

- `retr_as_stream`
- `put_with_stream`
- `append_with_stream`
- `custom_data_command`
- `stream_lines` (powers `list` / `nlst`)

## Tests

Added `should_reset_data_connection_after_failed_data_command` in all three implementations: it fires repeated failing `retr` / `custom_data_command` calls, then asserts every kind of data command (`put`, `append`, `retr`, `list`, `nlst`) still works.

## Checklist

- [x] Rustdoc on the new wrapper
- [x] Tests for all data-command callers (sync, tokio, async-std)
- [x] `cargo clippy` passes (`native-tls`, `tokio`, `async-std`, `-Dwarnings`)
- [x] `cargo +nightly fmt --check` clean
- [x] CHANGELOG updated (`8.0.4`)
- [x] Version bumped `8.0.3` → `8.0.4`