### PR TITLE
accept 200 as a valid response for file operations

### DIFF
--- a/crates/suppaftp/src/async_ftp/async_std_ftp/mod.rs
+++ b/crates/suppaftp/src/async_ftp/async_std_ftp/mod.rs
@@ -389,7 +389,10 @@ where
         debug!("Creating directory at {}", pathname.as_ref());
         self.perform(Command::Mkd(pathname.as_ref().to_string()))
             .await?;
-        self.read_response(Status::PathCreated).await.map(|_| ())
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 257.
+        self.read_response_in(&[Status::PathCreated, Status::CommandOk])
+            .await
+            .map(|_| ())
     }
 
     /// Sets the type of file to be transferred. That is the implementation
@@ -419,7 +422,8 @@ where
         self.read_response(Status::RequestFilePending).await?;
         self.perform(Command::RenameTo(to_name.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestedFileActionOk)
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -489,7 +493,8 @@ where
         debug!("Removing directory {}", pathname.as_ref());
         self.perform(Command::Rmd(pathname.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestedFileActionOk)
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -499,7 +504,8 @@ where
         debug!("Removing file {}", filename.as_ref());
         self.perform(Command::Dele(filename.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestedFileActionOk)
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -1903,5 +1909,62 @@ mod test {
             .take(5)
             .collect();
         format!("temp_{}", name)
+    }
+
+    #[async_attributes::test]
+    async fn should_accept_200_for_file_operations() {
+        use async_std::io::BufReader as AsyncBufReader;
+        // Use UFCS below to disambiguate from the in-scope `futures_lite` extension traits.
+        use async_std::io::prelude::{BufReadExt, WriteExt};
+
+        crate::log_init();
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind");
+        let port = listener.local_addr().unwrap().port();
+
+        // Fake FTP server that replies with 200 instead of the spec-mandated
+        // 250/257 to file operations, mimicking non-compliant servers such as bftpd.
+        let handle = async_std::task::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("no incoming connection");
+            let mut writer = stream.clone();
+            let mut reader = AsyncBufReader::new(stream);
+
+            WriteExt::write_all(&mut writer, b"220 Welcome\r\n")
+                .await
+                .unwrap();
+
+            let mut line = String::new();
+            while BufReadExt::read_line(&mut reader, &mut line).await.unwrap() > 0 {
+                let reply: &[u8] = match line.split_whitespace().next() {
+                    // RNFR must be acknowledged with 350 before RNTO is sent.
+                    Some("RNFR") => b"350 ready for destination name\r\n",
+                    Some("QUIT") => b"221 goodbye\r\n",
+                    // Everything else is answered with the non-compliant 200.
+                    _ => b"200 ok\r\n",
+                };
+                WriteExt::write_all(&mut writer, reply).await.unwrap();
+                if line.starts_with("QUIT") {
+                    break;
+                }
+                line.clear();
+            }
+        });
+
+        let tcp = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("failed to connect");
+        let mut stream = AsyncFtpStream::connect_with_stream(tcp)
+            .await
+            .expect("failed handshake");
+
+        assert!(stream.mkdir("dir").await.is_ok());
+        assert!(stream.rename("a", "b").await.is_ok());
+        assert!(stream.rmdir("dir").await.is_ok());
+        assert!(stream.rm("file").await.is_ok());
+
+        assert!(stream.quit().await.is_ok());
+        handle.await;
     }
 }

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/mod.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/mod.rs
@@ -383,7 +383,10 @@ where
         debug!("Creating directory at {}", pathname.as_ref());
         self.perform(Command::Mkd(pathname.as_ref().to_string()))
             .await?;
-        self.read_response(Status::PathCreated).await.map(|_| ())
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 257.
+        self.read_response_in(&[Status::PathCreated, Status::CommandOk])
+            .await
+            .map(|_| ())
     }
 
     /// Sets the type of file to be transferred. That is the implementation
@@ -413,7 +416,8 @@ where
         self.read_response(Status::RequestFilePending).await?;
         self.perform(Command::RenameTo(to_name.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestedFileActionOk)
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -483,7 +487,8 @@ where
         debug!("Removing directory {}", pathname.as_ref());
         self.perform(Command::Rmd(pathname.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestedFileActionOk)
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -493,7 +498,8 @@ where
         debug!("Removing file {}", filename.as_ref());
         self.perform(Command::Dele(filename.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestedFileActionOk)
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -1919,5 +1925,58 @@ mod test {
             .take(5)
             .collect();
         format!("temp_{}", name)
+    }
+
+    #[tokio::test]
+    async fn should_accept_200_for_file_operations() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as TokioBufReader};
+
+        crate::log_init();
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind");
+        let port = listener.local_addr().unwrap().port();
+
+        // Fake FTP server that replies with 200 instead of the spec-mandated
+        // 250/257 to file operations, mimicking non-compliant servers such as bftpd.
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("no incoming connection");
+            let (read_half, mut writer) = stream.into_split();
+            let mut reader = TokioBufReader::new(read_half);
+
+            writer.write_all(b"220 Welcome\r\n").await.unwrap();
+
+            let mut line = String::new();
+            while reader.read_line(&mut line).await.unwrap() > 0 {
+                let reply: &[u8] = match line.split_whitespace().next() {
+                    // RNFR must be acknowledged with 350 before RNTO is sent.
+                    Some("RNFR") => b"350 ready for destination name\r\n",
+                    Some("QUIT") => b"221 goodbye\r\n",
+                    // Everything else is answered with the non-compliant 200.
+                    _ => b"200 ok\r\n",
+                };
+                writer.write_all(reply).await.unwrap();
+                if line.starts_with("QUIT") {
+                    break;
+                }
+                line.clear();
+            }
+        });
+
+        let tcp = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("failed to connect");
+        let mut stream = AsyncFtpStream::connect_with_stream(tcp)
+            .await
+            .expect("failed handshake");
+
+        assert!(stream.mkdir("dir").await.is_ok());
+        assert!(stream.rename("a", "b").await.is_ok());
+        assert!(stream.rmdir("dir").await.is_ok());
+        assert!(stream.rm("file").await.is_ok());
+
+        assert!(stream.quit().await.is_ok());
+        handle.await.expect("server task panicked");
     }
 }

--- a/crates/suppaftp/src/sync_ftp/mod.rs
+++ b/crates/suppaftp/src/sync_ftp/mod.rs
@@ -369,7 +369,9 @@ where
     pub fn mkdir<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<()> {
         debug!("Creating directory at {}", pathname.as_ref());
         self.perform(Command::Mkd(pathname.as_ref().to_string()))?;
-        self.read_response(Status::PathCreated).map(|_| ())
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 257.
+        self.read_response_in(&[Status::PathCreated, Status::CommandOk])
+            .map(|_| ())
     }
 
     /// Sets the type of file to be transferred. That is the implementation
@@ -398,7 +400,8 @@ where
         self.read_response(Status::RequestFilePending)
             .and_then(|_| {
                 self.perform(Command::RenameTo(to_name.as_ref().to_string()))?;
-                self.read_response(Status::RequestedFileActionOk)
+                // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+                self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
                     .map(|_| ())
             })
     }
@@ -494,7 +497,8 @@ where
     pub fn rmdir<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<()> {
         debug!("Removing directory {}", pathname.as_ref());
         self.perform(Command::Rmd(pathname.as_ref().to_string()))?;
-        self.read_response(Status::RequestedFileActionOk)
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .map(|_| ())
     }
 
@@ -502,7 +506,8 @@ where
     pub fn rm<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<()> {
         debug!("Removing file {}", filename.as_ref());
         self.perform(Command::Dele(filename.as_ref().to_string()))?;
-        self.read_response(Status::RequestedFileActionOk)
+        // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .map(|_| ())
     }
 
@@ -1919,5 +1924,54 @@ mod test {
             });
 
         is_sync::<FtpStream>(ftp_stream);
+    }
+
+    #[test]
+    fn should_accept_200_for_file_operations() {
+        use std::io::{BufRead, BufReader as IoBufReader, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        crate::log_init();
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind");
+        let port = listener.local_addr().unwrap().port();
+
+        // Fake FTP server that replies with 200 instead of the spec-mandated
+        // 250/257 to file operations, mimicking non-compliant servers such as bftpd.
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("no incoming connection");
+            let mut writer = stream.try_clone().expect("failed to clone stream");
+            let mut reader = IoBufReader::new(stream);
+
+            writer.write_all(b"220 Welcome\r\n").unwrap();
+
+            let mut line = String::new();
+            while reader.read_line(&mut line).unwrap() > 0 {
+                let reply: &[u8] = match line.split_whitespace().next() {
+                    // RNFR must be acknowledged with 350 before RNTO is sent.
+                    Some("RNFR") => b"350 ready for destination name\r\n",
+                    Some("QUIT") => b"221 goodbye\r\n",
+                    // Everything else is answered with the non-compliant 200.
+                    _ => b"200 ok\r\n",
+                };
+                writer.write_all(reply).unwrap();
+                if line.starts_with("QUIT") {
+                    break;
+                }
+                line.clear();
+            }
+        });
+
+        let tcp = TcpStream::connect(("127.0.0.1", port)).expect("failed to connect");
+        let mut stream = FtpStream::connect_with_stream(tcp).expect("failed handshake");
+
+        assert!(stream.mkdir("dir").is_ok());
+        assert!(stream.rename("a", "b").is_ok());
+        assert!(stream.rmdir("dir").is_ok());
+        assert!(stream.rm("file").is_ok());
+
+        assert!(stream.quit().is_ok());
+        handle.join().expect("server thread panicked");
     }
 }


### PR DESCRIPTION
# accept 200 as a valid response for file operations

Fixes #157

## Description

Some FTP servers, such as bftpd, answer file operations with the code 200 instead of the codes the standard asks for (250 or 257), even though the operation succeeded. Until now SuppaFTP rejected those replies and reported an error.

This change makes the client tolerant: delete file, remove directory, rename, and create directory now accept 200 in addition to the standard codes. The fix is applied across all three implementations (the blocking one and both async runtimes), so the behaviour is consistent no matter how the library is used.

A test was added for each implementation. It runs a small fake server that always answers with 200, and confirms the four operations now succeed.
