### PR TITLE
fix: `tcp_stream()` Windows compatibility with tokio + native-tls

### DIFF
--- a/crates/suppaftp/src/async_ftp/tokio_ftp/tls/native_tls.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/tls/native_tls.rs
@@ -97,14 +97,14 @@ impl TokioTlsStream for AsyncNativeTlsStream {
     }
 
     fn tcp_stream(self) -> TcpStream {
-        use std::os::fd::AsFd;
-        let owned_fd = self
-            .stream
-            .get_ref()
-            .as_fd()
-            .try_clone_to_owned()
-            .expect("failed to clone tcp stream fd");
-        let std_stream = std::net::TcpStream::from(owned_fd);
+        let inner = self.stream.get_ref();
+        // OwnedFd / OwnedSocket differ per platform but both convert into TcpStream.
+        #[cfg(not(windows))]
+        let owned = std::os::fd::AsFd::as_fd(inner).try_clone_to_owned();
+        #[cfg(windows)]
+        let owned = std::os::windows::io::AsSocket::as_socket(inner).try_clone_to_owned();
+        let std_stream =
+            std::net::TcpStream::from(owned.expect("failed to clone tcp stream handle"));
         std_stream
             .set_nonblocking(true)
             .expect("set_nonblocking failed");


### PR DESCRIPTION
# Description

suppaftp's `tcp_stream()` implementation for Tokio runtime + native-tls TLS is not compatible with Windows as `std::os::fd` is not available there. Instead, obtain the native socket through `std::os::windows::io::AsSocket::as_socket` and clone that.

There are no API changes so no rustdoc additions. As there is no Windows CI, I did not add any tests.

## Checklist

- [x] I have read the [AI Policy](https://github.com/veeso/suppaftp/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/veeso/suppaftp/blob/main/CONTRIBUTING.md).
- [ ] I have added rustdoc documentation for any new public API.
- [ ] I have added tests covering my changes.
- [x] `just check_code` passes locally.
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org) format (the `CHANGELOG.md` is generated from them at release time).

## AI Disclosure

I've use claude code to analyze the problem, come up with a solution, simplify that solution after I deemed it too complex and then check the rest of the codebase if there are other spots that have the same issue.

I verified the soundness of the changes myself. Commit message and PR description were written by hand.
