### PR TITLE
ci: build all feature sets on windows and macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,10 +176,11 @@ jobs:
 
   build:
     needs: toolchain
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         features:
           [
             native-tls,
@@ -212,6 +213,7 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
       - name: Build
+        shell: bash
         env:
           FEATURES: ${{ matrix.features }}
         run: just build "$FEATURES"


### PR DESCRIPTION
# Description

The library is built in CI on Linux only. That means a build that works on Linux but breaks on Windows or macOS can slip through unnoticed, as happened with the Tokio plus native-tls code that did not compile on Windows.

This change builds every supported feature combination on Linux, Windows and macOS, so a platform specific build failure is caught before merge. The test suite and coverage stay on Linux only because they need Docker, which is not available on the Windows and macOS runners.

## Checklist

- [x] I have read the [AI Policy](https://github.com/veeso/suppaftp/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/veeso/suppaftp/blob/main/CONTRIBUTING.md).
- [ ] I have added rustdoc documentation for any new public API.
- [ ] I have added tests covering my changes.
- [x] `just check_code` passes locally.
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org) format (the `CHANGELOG.md` is generated from them at release time).

## AI Disclosure

I used Claude Code to add the operating system matrix to the build job and to validate the workflow with zizmor. I reviewed the change myself.
