### PR TITLE
refactor!: replace panics with errors across library and CLI

### DIFF
--- a/crates/suppaftp-cli/src/actions.rs
+++ b/crates/suppaftp-cli/src/actions.rs
@@ -59,8 +59,9 @@ pub fn connect(remote: &str, secure: bool) -> Option<FtpStream> {
                 return None;
             }
         };
-        // Get address without port
-        let address: &str = remote.split(':').next().unwrap();
+        // Get address without port; `split` always yields at least one element, so the whole
+        // remote is used as a fallback.
+        let address: &str = remote.split(':').next().unwrap_or(remote);
         stream = match stream.into_secure(NativeTlsConnector::from(ctx), address) {
             Ok(s) => s,
             Err(err) => {

--- a/crates/suppaftp-cli/src/main.rs
+++ b/crates/suppaftp-cli/src/main.rs
@@ -61,9 +61,10 @@ fn input() -> Command {
         print!(">> ");
         let _ = io::stdout().flush();
         let mut input: String = String::new();
-        io::stdin()
-            .read_line(&mut input)
-            .expect("Failed to read stdin");
+        if let Err(err) = io::stdin().read_line(&mut input) {
+            eprintln!("Failed to read stdin: {err}");
+            return Command::Quit;
+        }
         // Try to create command
         if let Ok(cmd) = Command::from_str(input.as_str()) {
             return cmd;
@@ -158,7 +159,8 @@ fn perform_connected(ftp: &mut FtpStream, command: Command) {
         Command::Rmdir(file) => rmdir(ftp, file.as_str()),
         Command::Size(file) => size(ftp, file.as_str()),
         Command::Help | Command::Quit => {
-            panic!("Something unexpected happened")
+            // `Help` and `Quit` are already handled by the main loop before reaching this point.
+            eprintln!("Unexpected command in connected state");
         }
     }
 }

--- a/crates/suppaftp/src/async_ftp/smol_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp.rs
@@ -162,7 +162,7 @@ where
         let stream = tls_connector
             .connect(
                 domain,
-                self.reader.into_inner().into_tcp_stream().to_owned(),
+                self.reader.into_inner().into_tcp_stream()?.to_owned(),
             )
             .await
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
@@ -236,7 +236,7 @@ where
         debug!("Established connection with server");
         debug!("TLS OK; initializing ssl stream");
         let stream = tls_connector
-            .connect(domain, stream.reader.into_inner().into_tcp_stream())
+            .connect(domain, stream.reader.into_inner().into_tcp_stream()?)
             .await
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
@@ -336,7 +336,7 @@ where
         self.perform(Command::ClearCommandChannel).await?;
         self.read_response(Status::CommandOk).await?;
         trace!("CCC OK");
-        self.reader = BufReader::new(DataStream::Tcp(self.reader.into_inner().into_tcp_stream()));
+        self.reader = BufReader::new(DataStream::Tcp(self.reader.into_inner().into_tcp_stream()?));
         Ok(self)
     }
 
@@ -935,13 +935,17 @@ where
         let result = Ok(DataStream::Tcp(stream));
 
         #[cfg(feature = "async-secure")]
-        let result = match self.tls_ctx {
-            Some(ref tls_ctx) => tls_ctx
-                .connect(self.domain.as_ref().unwrap(), stream)
+        let result = match (self.tls_ctx.as_ref(), self.domain.as_ref()) {
+            (Some(tls_ctx), Some(domain)) => tls_ctx
+                .connect(domain, stream)
                 .await
                 .map(|x| DataStream::Ssl(Box::new(x)))
                 .map_err(|e| FtpError::SecureError(format!("{e}"))),
-            None => Ok(DataStream::Tcp(stream)),
+            (Some(_), None) => Err(FtpError::SecureError(
+                "TLS context is set but no domain is available for the secure connection"
+                    .to_string(),
+            )),
+            (None, _) => Ok(DataStream::Tcp(stream)),
         };
 
         if result.is_ok() {

--- a/crates/suppaftp/src/async_ftp/smol_ftp/data_stream.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp/data_stream.rs
@@ -29,10 +29,12 @@ where
     T: SmolTlsStream + Send,
 {
     /// Unwrap the stream into TcpStream. This method is only used in secure connection.
-    pub fn into_tcp_stream(self) -> TcpStream {
+    ///
+    /// Returns an error if the underlying secure stream cannot be turned into a [`TcpStream`].
+    pub fn into_tcp_stream(self) -> crate::FtpResult<TcpStream> {
         match self {
-            DataStream::Tcp(stream) => stream,
-            DataStream::Ssl(stream) => stream.get_ref().clone(),
+            DataStream::Tcp(stream) => Ok(stream),
+            DataStream::Ssl(stream) => stream.tcp_stream(),
         }
     }
 }

--- a/crates/suppaftp/src/async_ftp/smol_ftp/tls.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp/tls.rs
@@ -31,8 +31,10 @@ pub trait AsyncTlsConnector: Debug {
 pub trait SmolTlsStream: Debug + Read + Write + Unpin {
     type InnerStream: Read + Write;
 
-    /// Get underlying tcp stream
-    fn tcp_stream(self) -> TcpStream;
+    /// Get underlying tcp stream.
+    ///
+    /// Returns an error if the underlying socket cannot be turned into an owned [`TcpStream`].
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream>;
 
     /// Get ref to underlying tcp stream
     fn get_ref(&self) -> &TcpStream;
@@ -41,8 +43,22 @@ pub trait SmolTlsStream: Debug + Read + Write + Unpin {
     fn mut_ref(&mut self) -> &mut Self::InnerStream;
 }
 
+/// A placeholder TLS stream used for plain (non-secure) async FTP connections.
+///
+/// It is only ever used as the `T` type parameter of a plain async FTP stream; a plain FTP data
+/// connection is always a TCP stream, so the I/O and accessor methods below are never reached. The
+/// I/O methods return an [`std::io::ErrorKind::Unsupported`] error instead of panicking, while the
+/// infallible accessors panic, as reaching them indicates a logic error in the library.
 #[derive(Debug)]
 pub struct AsyncNoTlsStream;
+
+/// Error returned by the I/O methods of [`AsyncNoTlsStream`].
+fn no_tls_stream_error() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "AsyncNoTlsStream is a placeholder for plain FTP and cannot perform TLS I/O",
+    )
+}
 
 impl Read for AsyncNoTlsStream {
     fn poll_read(
@@ -50,7 +66,7 @@ impl Read for AsyncNoTlsStream {
         _cx: &mut std::task::Context<'_>,
         _buf: &mut [u8],
     ) -> std::task::Poll<std::io::Result<usize>> {
-        panic!()
+        std::task::Poll::Ready(Err(no_tls_stream_error()))
     }
 }
 
@@ -60,36 +76,42 @@ impl Write for AsyncNoTlsStream {
         _cx: &mut std::task::Context<'_>,
         _buf: &[u8],
     ) -> std::task::Poll<std::io::Result<usize>> {
-        panic!()
+        std::task::Poll::Ready(Err(no_tls_stream_error()))
     }
 
     fn poll_flush(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        panic!()
+        std::task::Poll::Ready(Err(no_tls_stream_error()))
     }
 
     fn poll_close(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        panic!()
+        std::task::Poll::Ready(Err(no_tls_stream_error()))
     }
 }
 
 impl SmolTlsStream for AsyncNoTlsStream {
     type InnerStream = TcpStream;
 
-    fn tcp_stream(self) -> TcpStream {
-        panic!()
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream> {
+        unreachable!(
+            "AsyncNoTlsStream is a placeholder for plain FTP and has no underlying TcpStream"
+        )
     }
 
     fn get_ref(&self) -> &TcpStream {
-        panic!()
+        unreachable!(
+            "AsyncNoTlsStream is a placeholder for plain FTP and has no underlying TcpStream"
+        )
     }
 
     fn mut_ref(&mut self) -> &mut Self::InnerStream {
-        panic!()
+        unreachable!(
+            "AsyncNoTlsStream is a placeholder for plain FTP and has no underlying TcpStream"
+        )
     }
 }

--- a/crates/suppaftp/src/async_ftp/smol_ftp/tls/native_tls.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp/tls/native_tls.rs
@@ -96,7 +96,7 @@ impl SmolTlsStream for AsyncNativeTlsStream {
         &mut self.stream
     }
 
-    fn tcp_stream(self) -> TcpStream {
-        self.stream.get_ref().clone()
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream> {
+        Ok(self.stream.get_ref().clone())
     }
 }

--- a/crates/suppaftp/src/async_ftp/smol_ftp/tls/rustls.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp/tls/rustls.rs
@@ -108,7 +108,7 @@ impl SmolTlsStream for AsyncRustlsStream {
         &mut self.stream
     }
 
-    fn tcp_stream(self) -> TcpStream {
-        self.stream.get_ref().0.clone()
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream> {
+        Ok(self.stream.get_ref().0.clone())
     }
 }

--- a/crates/suppaftp/src/async_ftp/tokio_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp.rs
@@ -150,7 +150,7 @@ where
         self.read_response(Status::AuthOk).await?;
         debug!("TLS OK; initializing ssl stream");
         let stream = tls_connector
-            .connect(domain, self.reader.into_inner().into_tcp_stream())
+            .connect(domain, self.reader.into_inner().into_tcp_stream()?)
             .await
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         let mut secured_ftp_tream = ImplAsyncFtpStream {
@@ -223,7 +223,7 @@ where
         debug!("Established connection with server");
         debug!("TLS OK; initializing ssl stream");
         let stream = tls_connector
-            .connect(domain, stream.reader.into_inner().into_tcp_stream())
+            .connect(domain, stream.reader.into_inner().into_tcp_stream()?)
             .await
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
@@ -323,7 +323,7 @@ where
         self.perform(Command::ClearCommandChannel).await?;
         self.read_response(Status::CommandOk).await?;
         trace!("CCC OK");
-        self.reader = BufReader::new(DataStream::Tcp(self.reader.into_inner().into_tcp_stream()));
+        self.reader = BufReader::new(DataStream::Tcp(self.reader.into_inner().into_tcp_stream()?));
         Ok(self)
     }
 
@@ -920,13 +920,17 @@ where
         let result = Ok(DataStream::Tcp(stream));
 
         #[cfg(feature = "async-secure")]
-        let result = match self.tls_ctx {
-            Some(ref tls_ctx) => tls_ctx
-                .connect(self.domain.as_ref().unwrap(), stream)
+        let result = match (self.tls_ctx.as_ref(), self.domain.as_ref()) {
+            (Some(tls_ctx), Some(domain)) => tls_ctx
+                .connect(domain, stream)
                 .await
                 .map(|x| DataStream::Ssl(Box::new(x)))
                 .map_err(|e| FtpError::SecureError(format!("{e}"))),
-            None => Ok(DataStream::Tcp(stream)),
+            (Some(_), None) => Err(FtpError::SecureError(
+                "TLS context is set but no domain is available for the secure connection"
+                    .to_string(),
+            )),
+            (None, _) => Ok(DataStream::Tcp(stream)),
         };
 
         if result.is_ok() {

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/data_stream.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/data_stream.rs
@@ -29,9 +29,11 @@ where
     T: TokioTlsStream + Send,
 {
     /// Unwrap the stream into TcpStream. This method is only used in secure connection.
-    pub fn into_tcp_stream(self) -> TcpStream {
+    ///
+    /// Returns an error if the underlying secure stream cannot be turned into a [`TcpStream`].
+    pub fn into_tcp_stream(self) -> crate::FtpResult<TcpStream> {
         match self {
-            DataStream::Tcp(stream) => stream,
+            DataStream::Tcp(stream) => Ok(stream),
             DataStream::Ssl(stream) => stream.tcp_stream(),
         }
     }

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/tls.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/tls.rs
@@ -31,8 +31,10 @@ pub trait AsyncTlsConnector: Debug {
 pub trait TokioTlsStream: Debug + AsyncRead + AsyncWrite + Unpin {
     type InnerStream: AsyncRead + AsyncWrite;
 
-    /// Get underlying tcp stream
-    fn tcp_stream(self) -> TcpStream;
+    /// Get underlying tcp stream.
+    ///
+    /// Returns an error if the underlying socket cannot be turned into an owned [`TcpStream`].
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream>;
 
     /// Get ref to underlying tcp stream
     fn get_ref(&self) -> &TcpStream;
@@ -41,8 +43,22 @@ pub trait TokioTlsStream: Debug + AsyncRead + AsyncWrite + Unpin {
     fn mut_ref(&mut self) -> &mut Self::InnerStream;
 }
 
+/// A placeholder TLS stream used for plain (non-secure) async FTP connections.
+///
+/// It is only ever used as the `T` type parameter of a plain async FTP stream; a plain FTP data
+/// connection is always a TCP stream, so the I/O and accessor methods below are never reached. The
+/// I/O methods return an [`std::io::ErrorKind::Unsupported`] error instead of panicking, while the
+/// infallible accessors panic, as reaching them indicates a logic error in the library.
 #[derive(Debug)]
 pub struct AsyncNoTlsStream;
+
+/// Error returned by the I/O methods of [`AsyncNoTlsStream`].
+fn no_tls_stream_error() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "AsyncNoTlsStream is a placeholder for plain FTP and cannot perform TLS I/O",
+    )
+}
 
 impl AsyncRead for AsyncNoTlsStream {
     fn poll_read(
@@ -50,7 +66,7 @@ impl AsyncRead for AsyncNoTlsStream {
         _cx: &mut std::task::Context<'_>,
         _buf: &mut ReadBuf<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        panic!()
+        std::task::Poll::Ready(Err(no_tls_stream_error()))
     }
 }
 
@@ -60,36 +76,42 @@ impl AsyncWrite for AsyncNoTlsStream {
         _cx: &mut std::task::Context<'_>,
         _buf: &[u8],
     ) -> std::task::Poll<std::io::Result<usize>> {
-        panic!()
+        std::task::Poll::Ready(Err(no_tls_stream_error()))
     }
 
     fn poll_flush(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        panic!()
+        std::task::Poll::Ready(Err(no_tls_stream_error()))
     }
 
     fn poll_shutdown(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        panic!()
+        std::task::Poll::Ready(Err(no_tls_stream_error()))
     }
 }
 
 impl TokioTlsStream for AsyncNoTlsStream {
     type InnerStream = TcpStream;
 
-    fn tcp_stream(self) -> TcpStream {
-        panic!()
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream> {
+        unreachable!(
+            "AsyncNoTlsStream is a placeholder for plain FTP and has no underlying TcpStream"
+        )
     }
 
     fn get_ref(&self) -> &TcpStream {
-        panic!()
+        unreachable!(
+            "AsyncNoTlsStream is a placeholder for plain FTP and has no underlying TcpStream"
+        )
     }
 
     fn mut_ref(&mut self) -> &mut Self::InnerStream {
-        panic!()
+        unreachable!(
+            "AsyncNoTlsStream is a placeholder for plain FTP and has no underlying TcpStream"
+        )
     }
 }

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/tls/native_tls.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/tls/native_tls.rs
@@ -96,7 +96,11 @@ impl TokioTlsStream for AsyncNativeTlsStream {
         &mut self.stream
     }
 
-    fn tcp_stream(self) -> TcpStream {
+    /// Get underlying tcp stream.
+    ///
+    /// Returns a [`crate::FtpError::ConnectionError`] if the underlying socket handle cannot be
+    /// cloned or converted into a tokio [`TcpStream`] (e.g. on OS resource exhaustion).
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream> {
         let inner = self.stream.get_ref();
         // OwnedFd / OwnedSocket differ per platform but both convert into TcpStream.
         #[cfg(not(windows))]
@@ -104,10 +108,10 @@ impl TokioTlsStream for AsyncNativeTlsStream {
         #[cfg(windows)]
         let owned = std::os::windows::io::AsSocket::as_socket(inner).try_clone_to_owned();
         let std_stream =
-            std::net::TcpStream::from(owned.expect("failed to clone tcp stream handle"));
+            std::net::TcpStream::from(owned.map_err(crate::FtpError::ConnectionError)?);
         std_stream
             .set_nonblocking(true)
-            .expect("set_nonblocking failed");
-        TcpStream::from_std(std_stream).expect("failed to convert to tokio TcpStream")
+            .map_err(crate::FtpError::ConnectionError)?;
+        TcpStream::from_std(std_stream).map_err(crate::FtpError::ConnectionError)
     }
 }

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/tls/rustls.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/tls/rustls.rs
@@ -107,7 +107,7 @@ impl TokioTlsStream for AsyncRustlsStream {
         &mut self.stream
     }
 
-    fn tcp_stream(self) -> TcpStream {
-        self.stream.into_inner().0
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream> {
+        Ok(self.stream.into_inner().0)
     }
 }

--- a/crates/suppaftp/src/list.rs
+++ b/crates/suppaftp/src/list.rs
@@ -181,7 +181,11 @@ impl ListParser {
         }
 
         // get name
-        f.name = tokens.last().unwrap().trim_start().to_string();
+        f.name = tokens
+            .last()
+            .ok_or(ParseError::SyntaxError)?
+            .trim_start()
+            .to_string();
 
         Ok(f)
     }
@@ -208,16 +212,18 @@ impl ListParser {
                 }
                 // Collect metadata
                 // Get if is directory and if is symlink
-                let file_type: FileType = match metadata.get(1).unwrap().as_str() {
-                    "-" => FileType::File,
-                    "d" => FileType::Directory,
-                    "l" => FileType::Symlink(PathBuf::default()),
-                    _ => return Err(ParseError::SyntaxError), // This case is actually already covered by the regex
-                };
+                let file_type: FileType =
+                    match metadata.get(1).ok_or(ParseError::SyntaxError)?.as_str() {
+                        "-" => FileType::File,
+                        "d" => FileType::Directory,
+                        "l" => FileType::Symlink(PathBuf::default()),
+                        _ => return Err(ParseError::SyntaxError), // This case is actually already covered by the regex
+                    };
 
+                let permissions = metadata.get(2).ok_or(ParseError::SyntaxError)?.as_str();
                 let pex = |range: Range<usize>| {
                     let mut count: u8 = 0;
-                    for (i, c) in metadata.get(2).unwrap().as_str()[range].chars().enumerate() {
+                    for (i, c) in permissions[range].chars().enumerate() {
                         match c {
                             '-' | 'S' | 'T' => {}
                             _ => {
@@ -242,25 +248,42 @@ impl ListParser {
 
                 // Parse mtime and convert to SystemTime
                 let modified: SystemTime = Self::parse_lstime(
-                    metadata.get(7).unwrap().as_str().trim(),
+                    metadata
+                        .get(7)
+                        .ok_or(ParseError::SyntaxError)?
+                        .as_str()
+                        .trim(),
                     "%b %d %Y",
                     "%b %d %H:%M",
                 )?;
                 // Get gid
-                let gid: Option<u32> = metadata.get(5).unwrap().as_str().trim().parse::<u32>().ok();
+                let gid: Option<u32> = metadata
+                    .get(5)
+                    .ok_or(ParseError::SyntaxError)?
+                    .as_str()
+                    .trim()
+                    .parse::<u32>()
+                    .ok();
                 // Get uid
-                let uid: Option<u32> = metadata.get(4).unwrap().as_str().trim().parse::<u32>().ok();
+                let uid: Option<u32> = metadata
+                    .get(4)
+                    .ok_or(ParseError::SyntaxError)?
+                    .as_str()
+                    .trim()
+                    .parse::<u32>()
+                    .ok();
                 // Get filesize
                 let size: usize = metadata
                     .get(6)
-                    .unwrap()
+                    .ok_or(ParseError::SyntaxError)?
                     .as_str()
                     .parse::<usize>()
                     .map_err(|_| ParseError::BadSize)?;
                 // Split filename if required
+                let filename = metadata.get(8).ok_or(ParseError::SyntaxError)?.as_str();
                 let (name, symlink_path): (String, Option<PathBuf>) = match file_type.is_symlink() {
-                    true => Self::get_name_and_link(metadata.get(8).unwrap().as_str()),
-                    false => (String::from(metadata.get(8).unwrap().as_str()), None),
+                    true => Self::get_name_and_link(filename),
+                    false => (String::from(filename), None),
                 };
                 // If symlink path is Some, assign symlink path to file_type
                 let file_type: FileType = match symlink_path {
@@ -306,7 +329,8 @@ impl ListParser {
                     return Err(ParseError::SyntaxError);
                 }
                 // Parse date time
-                let modified: SystemTime = Self::parse_dostime(metadata.get(1).unwrap().as_str())?;
+                let modified: SystemTime =
+                    Self::parse_dostime(metadata.get(1).ok_or(ParseError::SyntaxError)?.as_str())?;
                 // Get if is a directory
                 let file_type: FileType = match metadata.get(2).is_some() {
                     true => FileType::Directory,
@@ -326,7 +350,8 @@ impl ListParser {
                     },
                 };
                 // Get file name
-                let name: String = String::from(metadata.get(4).unwrap().as_str());
+                let name: String =
+                    String::from(metadata.get(4).ok_or(ParseError::SyntaxError)?.as_str());
                 trace!(
                     "Found file with name {}, type: {:?}, size: {}",
                     name, file_type, size,
@@ -353,7 +378,9 @@ impl ListParser {
     /// Returns from a `ls -l` command output file name token, the name of the file and the symbolic link (if there is any)
     fn get_name_and_link(token: &str) -> (String, Option<PathBuf>) {
         let tokens: Vec<&str> = token.split(" -> ").collect();
-        let filename: String = String::from(*tokens.first().unwrap());
+        // `split` always yields at least one element, so the filename defaults to the
+        // whole token when no link separator is present.
+        let filename: String = tokens.first().copied().unwrap_or_default().to_string();
         let symlink: Option<PathBuf> = tokens.get(1).map(PathBuf::from);
         (filename, symlink)
     }
@@ -389,7 +416,7 @@ impl ListParser {
             Ok(date) => {
                 // Case 2.
                 // Return NaiveDateTime from NaiveDate with time 00:00:00
-                date.and_hms_opt(0, 0, 0).unwrap()
+                date.and_hms_opt(0, 0, 0).ok_or(ParseError::InvalidDate)?
             }
             Err(_) => {
                 // Might be case 1.

--- a/crates/suppaftp/src/sync_ftp.rs
+++ b/crates/suppaftp/src/sync_ftp.rs
@@ -168,7 +168,7 @@ where
         self.read_response(Status::AuthOk)?;
         debug!("TLS OK; initializing ssl stream");
         let stream = tls_connector
-            .connect(domain, self.reader.into_inner().into_tcp_stream())
+            .connect(domain, self.reader.into_inner().into_tcp_stream()?)
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
         let mut secured_ftp_tream = Self {
@@ -235,7 +235,7 @@ where
         debug!("Established connection with server");
         debug!("TLS OK; initializing ssl stream");
         let stream = tls_connector
-            .connect(domain, stream.reader.into_inner().into_tcp_stream())
+            .connect(domain, stream.reader.into_inner().into_tcp_stream()?)
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
         let mut stream = Self {
@@ -311,7 +311,7 @@ where
         self.perform(Command::ClearCommandChannel)?;
         self.read_response(Status::CommandOk)?;
         trace!("CCC OK");
-        self.reader = BufReader::new(DataStream::Tcp(self.reader.into_inner().into_tcp_stream()));
+        self.reader = BufReader::new(DataStream::Tcp(self.reader.into_inner().into_tcp_stream()?));
         Ok(self)
     }
 
@@ -985,12 +985,16 @@ where
         let result = Ok(DataStream::Tcp(stream));
 
         #[cfg(feature = "secure")]
-        let result = match self.tls_ctx {
-            Some(ref tls_ctx) => tls_ctx
-                .connect(self.domain.as_ref().unwrap(), stream)
+        let result = match (self.tls_ctx.as_ref(), self.domain.as_ref()) {
+            (Some(tls_ctx), Some(domain)) => tls_ctx
+                .connect(domain, stream)
                 .map(|x| DataStream::Ssl(Box::new(x)))
                 .map_err(|e| FtpError::SecureError(format!("{e}"))),
-            None => Ok(DataStream::Tcp(stream)),
+            (Some(_), None) => Err(FtpError::SecureError(
+                "TLS context is set but no domain is available for the secure connection"
+                    .to_string(),
+            )),
+            (None, _) => Ok(DataStream::Tcp(stream)),
         };
 
         if result.is_ok() {
@@ -1114,17 +1118,20 @@ where
         let caps = PASV_PORT_RE
             .captures(&response_str)
             .ok_or_else(|| FtpError::UnexpectedResponse(response.clone()))?;
-        // If the regex matches we can be sure groups contains numbers
+        // The regex only guarantees the groups are digits; a malicious or buggy
+        // server may still send an octet that overflows a `u8`, so parsing is fallible.
+        let parse_octet = |index: usize| -> FtpResult<u8> {
+            caps[index]
+                .parse::<u8>()
+                .map_err(|_| FtpError::UnexpectedResponse(response.clone()))
+        };
         let (oct1, oct2, oct3, oct4) = (
-            caps[1].parse::<u8>().unwrap(),
-            caps[2].parse::<u8>().unwrap(),
-            caps[3].parse::<u8>().unwrap(),
-            caps[4].parse::<u8>().unwrap(),
+            parse_octet(1)?,
+            parse_octet(2)?,
+            parse_octet(3)?,
+            parse_octet(4)?,
         );
-        let (msb, lsb) = (
-            caps[5].parse::<u8>().unwrap(),
-            caps[6].parse::<u8>().unwrap(),
-        );
+        let (msb, lsb) = (parse_octet(5)?, parse_octet(6)?);
         let ip = Ipv4Addr::new(oct1, oct2, oct3, oct4);
         let port = (u16::from(msb) << 8) | u16::from(lsb);
         let addr = SocketAddr::new(ip.into(), port);
@@ -1646,6 +1653,15 @@ mod test {
         let response = Response::new(
             Status::PassiveMode,
             "227 No passive mode info here".as_bytes().to_vec(),
+        );
+        assert!(FtpStream::parse_passive_address_from_response(response).is_err());
+
+        // Octet out of range for a u8 must error instead of panicking
+        let response = Response::new(
+            Status::PassiveMode,
+            "227 Entering Passive Mode (213,229,112,999,216,4)"
+                .as_bytes()
+                .to_vec(),
         );
         assert!(FtpStream::parse_passive_address_from_response(response).is_err());
     }

--- a/crates/suppaftp/src/sync_ftp/data_stream.rs
+++ b/crates/suppaftp/src/sync_ftp/data_stream.rs
@@ -24,9 +24,11 @@ where
     T: TlsStream,
 {
     /// Unwrap the stream into TcpStream. This method is only used in secure connection.
-    pub fn into_tcp_stream(self) -> TcpStream {
+    ///
+    /// Returns an error if the underlying secure stream cannot be turned into a [`TcpStream`].
+    pub fn into_tcp_stream(self) -> crate::FtpResult<TcpStream> {
         match self {
-            DataStream::Tcp(stream) => stream,
+            DataStream::Tcp(stream) => Ok(stream),
             DataStream::Ssl(stream) => stream.tcp_stream(),
         }
     }

--- a/crates/suppaftp/src/sync_ftp/tls.rs
+++ b/crates/suppaftp/src/sync_ftp/tls.rs
@@ -29,8 +29,10 @@ pub trait TlsConnector: Debug {
 pub trait TlsStream: Debug {
     type InnerStream: Read + Write;
 
-    /// Get underlying tcp stream
-    fn tcp_stream(self) -> TcpStream;
+    /// Get underlying tcp stream.
+    ///
+    /// Returns an error if the underlying socket cannot be turned into an owned [`TcpStream`].
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream>;
 
     /// Get ref to underlying tcp stream
     fn get_ref(&self) -> &TcpStream;
@@ -39,21 +41,26 @@ pub trait TlsStream: Debug {
     fn mut_ref(&mut self) -> &mut Self::InnerStream;
 }
 
+/// A placeholder TLS stream used for plain (non-secure) FTP connections.
+///
+/// It is only ever used as the `T` type parameter of a plain [`crate::FtpStream`]; the data
+/// connection of a plain FTP session is always a TCP stream, so the TLS methods below are never
+/// reached. Calling any of them indicates a logic error in the library and therefore panics.
 #[derive(Debug)]
 pub struct NoTlsStream;
 
 impl TlsStream for NoTlsStream {
     type InnerStream = TcpStream;
 
-    fn tcp_stream(self) -> TcpStream {
-        unimplemented!("NoTlsStream has no underlying TcpStream")
+    fn tcp_stream(self) -> crate::FtpResult<TcpStream> {
+        unreachable!("NoTlsStream is a placeholder for plain FTP and has no underlying TcpStream")
     }
 
     fn get_ref(&self) -> &TcpStream {
-        unimplemented!("NoTlsStream has no underlying TcpStream")
+        unreachable!("NoTlsStream is a placeholder for plain FTP and has no underlying TcpStream")
     }
 
     fn mut_ref(&mut self) -> &mut Self::InnerStream {
-        unimplemented!("NoTlsStream has no underlying TcpStream")
+        unreachable!("NoTlsStream is a placeholder for plain FTP and has no underlying TcpStream")
     }
 }

--- a/crates/suppaftp/src/sync_ftp/tls/native_tls.rs
+++ b/crates/suppaftp/src/sync_ftp/tls/native_tls.rs
@@ -46,9 +46,16 @@ pub struct NativeTlsStream {
 impl TlsStreamTrait for NativeTlsStream {
     type InnerStream = TlsStream<TcpStream>;
 
-    /// Get underlying tcp stream
-    fn tcp_stream(mut self) -> TcpStream {
-        let mut stream = self.stream.get_ref().try_clone().unwrap();
+    /// Get underlying tcp stream.
+    ///
+    /// Returns a [`crate::FtpError::ConnectionError`] if the underlying socket handle cannot be
+    /// cloned (e.g. on OS resource exhaustion).
+    fn tcp_stream(mut self) -> crate::FtpResult<TcpStream> {
+        let mut stream = self
+            .stream
+            .get_ref()
+            .try_clone()
+            .map_err(crate::FtpError::ConnectionError)?;
         // Don't perform shutdown later
         self.ssl_shutdown = false;
         // flush stream (otherwise can cause bad chars on channel)
@@ -56,7 +63,7 @@ impl TlsStreamTrait for NativeTlsStream {
             error!("Error in flushing tcp stream: {}", err);
         }
         trace!("TLS stream terminated");
-        stream
+        Ok(stream)
     }
 
     /// Get ref to underlying tcp stream

--- a/crates/suppaftp/src/sync_ftp/tls/rustls.rs
+++ b/crates/suppaftp/src/sync_ftp/tls/rustls.rs
@@ -58,9 +58,15 @@ pub struct RustlsStream {
 impl TlsStream for RustlsStream {
     type InnerStream = StreamOwned<ClientConnection, TcpStream>;
 
-    /// Get underlying tcp stream
-    fn tcp_stream(mut self) -> TcpStream {
-        let mut stream = self.get_ref().try_clone().unwrap();
+    /// Get underlying tcp stream.
+    ///
+    /// Returns a [`crate::FtpError::ConnectionError`] if the underlying socket handle cannot be
+    /// cloned (e.g. on OS resource exhaustion).
+    fn tcp_stream(mut self) -> crate::FtpResult<TcpStream> {
+        let mut stream = self
+            .get_ref()
+            .try_clone()
+            .map_err(crate::FtpError::ConnectionError)?;
         // Don't perform shutdown later
         self.ssl_shutdown = false;
         // flush stream (otherwise can cause bad chars on channel)
@@ -68,7 +74,7 @@ impl TlsStream for RustlsStream {
             error!("Error in flushing tcp stream: {}", err);
         }
         trace!("TLS stream terminated");
-        stream
+        Ok(stream)
     }
 
     /// Get ref to underlying tcp stream


### PR DESCRIPTION
# Description

The library used to crash in several places when something went wrong, using patterns that stop the whole program instead of reporting a recoverable error. This was unsafe for a library, because a single bad reply from a server or a failed socket operation could take down the application using it.

This change replaces those crash points with normal error results. The affected cases include parsing a passive mode reply with an out of range value, parsing malformed directory listing lines, recovering the plain connection from a secure one, and reading user input in the command line tool. In all of these the code now returns an error that the caller can handle, instead of aborting.

A few internal placeholder streams (used only for plain, non secure connections) keep a guard that signals a programming mistake if they are ever reached, since by design they never are.

Fixes #

## Checklist

- [ ] I have read the [AI Policy](https://github.com/veeso/suppaftp/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/veeso/suppaftp/blob/main/CONTRIBUTING.md).
- [x] I have added rustdoc documentation for any new public API.
- [ ] I have added tests covering my changes.
- [x] `just check_code` passes locally.
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org) format (the `CHANGELOG.md` is generated from them at release time).

## AI Disclosure

This change was prepared with Claude Code. It located the crash points, applied the conversions to error results, and ran the build, lints, and tests. All changes were reviewed by the author.

## Notes

This is a breaking change. The method that returns the underlying TCP connection now returns a result that can fail, both on the trait that abstracts TLS streams and on the public data stream type. Code that called these and expected a plain value will need to handle the error case. The version bump is intentionally left out and will be done at release time.