### PR TITLE
fix(parser): tolerate non-RFC multiline replies (mismatched terminal code)

### DIFF
--- a/crates/suppaftp/src/async_ftp/smol_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp.rs
@@ -1090,20 +1090,30 @@ where
         }
 
         let code_word: u32 = self.code_from_buffer(&line, 3)?;
-        let code = Status::from(code_word);
+        let mut code = Status::from(code_word);
 
         trace!("Code parsed from response: {} ({})", code, code_word);
 
-        // multiple line reply
-        // loop while the line does not begin with the code and a space (or dash)
-        let expected = [line[0], line[1], line[2], 0x20];
-        let alt_expected = if expected_code.contains(&Status::System) {
-            [line[0], line[1], line[2], b'-']
-        } else {
-            expected
+        // Multi-line reply handling. RFC 959 opens a multi-line reply with
+        // "DDD-" and terminates it with the SAME "DDD <text>". Some non-RFC
+        // servers (notably glftpd) instead prefix the operative reply with
+        // informational lines under a DIFFERENT code, e.g.
+        //   553-
+        //   553- Directory excluded (precheck).
+        //   150 Opening BINARY mode data connection ...
+        // Waiting for the opener's code to reappear would hang forever, so
+        // terminate on ANY line that is three ASCII digits followed by a space,
+        // and adopt THAT line's code as the operative reply (matching how
+        // FlashFXP / lftp read the same servers). A single-line reply is already
+        // in terminal form, so the loop is skipped.
+        let is_terminal = |l: &[u8]| {
+            l.len() >= 4
+                && l[3] == b' '
+                && l[0].is_ascii_digit()
+                && l[1].is_ascii_digit()
+                && l[2].is_ascii_digit()
         };
-        trace!("CC IN: {:?}", line);
-        while line.len() < 5 || (line[0..4] != expected && line[0..4] != alt_expected) {
+        while !is_terminal(&line) {
             line.clear();
             let bytes_read = self.read_line(&mut line).await?;
             if bytes_read == 0 {
@@ -1115,6 +1125,10 @@ where
             body.extend(line.iter());
             trace!("CC IN: {:?}", line);
         }
+
+        // Adopt the terminal line's code — on a non-RFC server it can differ from
+        // the multiline opener (e.g. `553-` info lines, then a `150 ` terminal).
+        code = Status::from(self.code_from_buffer(&line, 3)?);
 
         let response: Response = Response::new(code, body);
         // Return Ok or error with response

--- a/crates/suppaftp/src/async_ftp/tokio_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp.rs
@@ -1075,20 +1075,30 @@ where
         }
 
         let code_word: u32 = self.code_from_buffer(&line, 3)?;
-        let code = Status::from(code_word);
+        let mut code = Status::from(code_word);
 
         trace!("Code parsed from response: {} ({})", code, code_word);
 
-        // multiple line reply
-        // loop while the line does not begin with the code and a space (or dash)
-        let expected = [line[0], line[1], line[2], 0x20];
-        let alt_expected = if expected_code.contains(&Status::System) {
-            [line[0], line[1], line[2], b'-']
-        } else {
-            expected
+        // Multi-line reply handling. RFC 959 opens a multi-line reply with
+        // "DDD-" and terminates it with the SAME "DDD <text>". Some non-RFC
+        // servers (notably glftpd) instead prefix the operative reply with
+        // informational lines under a DIFFERENT code, e.g.
+        //   553-
+        //   553- Directory excluded (precheck).
+        //   150 Opening BINARY mode data connection ...
+        // Waiting for the opener's code to reappear would hang forever, so
+        // terminate on ANY line that is three ASCII digits followed by a space,
+        // and adopt THAT line's code as the operative reply (matching how
+        // FlashFXP / lftp read the same servers). A single-line reply is already
+        // in terminal form, so the loop is skipped.
+        let is_terminal = |l: &[u8]| {
+            l.len() >= 4
+                && l[3] == b' '
+                && l[0].is_ascii_digit()
+                && l[1].is_ascii_digit()
+                && l[2].is_ascii_digit()
         };
-        trace!("CC IN: {:?}", line);
-        while line.len() < 5 || (line[0..4] != expected && line[0..4] != alt_expected) {
+        while !is_terminal(&line) {
             line.clear();
             let bytes_read = self.read_line(&mut line).await?;
             if bytes_read == 0 {
@@ -1100,6 +1110,10 @@ where
             body.extend(line.iter());
             trace!("CC IN: {:?}", line);
         }
+
+        // Adopt the terminal line's code — on a non-RFC server it can differ from
+        // the multiline opener (e.g. `553-` info lines, then a `150 ` terminal).
+        code = Status::from(self.code_from_buffer(&line, 3)?);
 
         let response: Response = Response::new(code, body);
         // Return Ok or error with response

--- a/crates/suppaftp/src/sync_ftp.rs
+++ b/crates/suppaftp/src/sync_ftp.rs
@@ -881,20 +881,30 @@ where
         }
 
         let code_word: u32 = self.code_from_buffer(&line, 3)?;
-        let code = Status::from(code_word);
+        let mut code = Status::from(code_word);
 
         trace!("Code parsed from response: {} ({})", code, code_word);
 
-        // multiple line reply
-        // loop while the line does not begin with the code and a space (or dash)
-        let expected = [line[0], line[1], line[2], 0x20];
-        let alt_expected = if expected_code.contains(&Status::System) {
-            [line[0], line[1], line[2], b'-']
-        } else {
-            expected
+        // Multi-line reply handling. RFC 959 opens a multi-line reply with
+        // "DDD-" and terminates it with the SAME "DDD <text>". Some non-RFC
+        // servers (notably glftpd) instead prefix the operative reply with
+        // informational lines under a DIFFERENT code, e.g.
+        //   553-
+        //   553- Directory excluded (precheck).
+        //   150 Opening BINARY mode data connection ...
+        // Waiting for the opener's code to reappear would hang forever, so
+        // terminate on ANY line that is three ASCII digits followed by a space,
+        // and adopt THAT line's code as the operative reply (matching how
+        // FlashFXP / lftp read the same servers). A single-line reply is already
+        // in terminal form, so the loop is skipped.
+        let is_terminal = |l: &[u8]| {
+            l.len() >= 4
+                && l[3] == b' '
+                && l[0].is_ascii_digit()
+                && l[1].is_ascii_digit()
+                && l[2].is_ascii_digit()
         };
-        trace!("CC IN: {:?}", line);
-        while line.len() < 5 || (line[0..4] != expected && line[0..4] != alt_expected) {
+        while !is_terminal(&line) {
             line.clear();
             let bytes_read = self.read_line(&mut line)?;
             if bytes_read == 0 {
@@ -906,6 +916,10 @@ where
             body.extend(line.iter());
             trace!("CC IN: {:?}", line);
         }
+
+        // Adopt the terminal line's code — on a non-RFC server it can differ from
+        // the multiline opener (e.g. `553-` info lines, then a `150 ` terminal).
+        code = Status::from(self.code_from_buffer(&line, 3)?);
 
         let response: Response = Response::new(code, body);
         // Return Ok or error with response


### PR DESCRIPTION
## Problem
`read_response_in` treats a multiline reply as finished only when it sees a line beginning with **the opener's code** + space (`DDD `). Some real-world servers — notably **glftpd** — send a multiline whose terminal line uses a **different** code, e.g. a `STOR` reply:

```
553-
553- Directory excluded (precheck).
150 Opening BINARY mode data connection for x using SSL/TLS.
```

The current loop waits for `553 ` forever, so the call blocks on the next control read and the transfer hangs (the caller eventually times out). FlashFXP, lftp, and other mainstream clients read these fine.

## Fix
Terminate a multiline reply on **any** line that is three ASCII digits followed by a space, and adopt **that** line's code as the operative reply (a single-line reply is already terminal, so the loop is skipped). Applied consistently to the `tokio`, `smol`, and `sync` backends.

- Single-line replies: unchanged (loop skipped).
- RFC multiline (matching terminal code): unchanged.
- FEAT-style indented continuations: unaffected (they don't match `DDD `).
- glftpd-style mismatched terminal: now parsed instead of hanging.

Happy to add a unit test in your preferred style if you'd like — pointers welcome.