### PR TITLE
fix(parser): accept mismatched terminal codes

### DIFF
--- a/crates/suppaftp/src/async_ftp/smol_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp.rs
@@ -1094,20 +1094,26 @@ where
         }
 
         let code_word: u32 = self.code_from_buffer(&line, 3)?;
-        let code = Status::from(code_word);
+        let mut code = Status::from(code_word);
 
         trace!("Code parsed from response: {} ({})", code, code_word);
 
-        // multiple line reply
-        // loop while the line does not begin with the code and a space (or dash)
+        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
+        // including glFTPd, use a different operative code. FEAT remains special because
+        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
+        // M-DOCUMENTED-MAGIC: FTP replies start with a three-digit code and one separator.
         let expected = [line[0], line[1], line[2], 0x20];
-        let alt_expected = if expected_code.contains(&Status::System) {
-            [line[0], line[1], line[2], b'-']
-        } else {
-            expected
+        let feat_opener = [line[0], line[1], line[2], b'-'];
+        let is_terminal = |reply: &[u8]| {
+            reply.len() >= 4
+                && reply[0].is_ascii_digit()
+                && reply[1].is_ascii_digit()
+                && reply[2].is_ascii_digit()
+                && (reply[3] == b' '
+                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
         };
         trace!("CC IN: {:?}", line);
-        while line.len() < 5 || (line[0..4] != expected && line[0..4] != alt_expected) {
+        while !is_terminal(&line) {
             line.clear();
             let bytes_read = self.read_line(&mut line).await?;
             if bytes_read == 0 {
@@ -1118,6 +1124,11 @@ where
             }
             body.extend(line.iter());
             trace!("CC IN: {:?}", line);
+        }
+
+        if line[0..4] != expected {
+            code = Status::from(self.code_from_buffer(&line, 3)?);
+            trace!("Code updated from terminal response: {}", code);
         }
 
         let response: Response = Response::new(code, body);
@@ -2013,6 +2024,77 @@ mod test {
             .take(5)
             .collect();
         format!("temp_{}", name)
+    }
+
+    // M-MOCKABLE-SYSCALLS: use a local server for deterministic control-response tests.
+    async fn connect_with_control_response(
+        expected_command: &'static str,
+        response: &'static [u8],
+    ) -> (AsyncFtpStream, smol::Task<()>) {
+        use smol::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as AsyncBufReader};
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind");
+        let port = listener.local_addr().expect("missing local address").port();
+        let handle = smol::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("no incoming connection");
+            let mut writer = stream.clone();
+            let mut reader = AsyncBufReader::new(stream);
+
+            AsyncWriteExt::write_all(&mut writer, b"220 Welcome\r\n")
+                .await
+                .unwrap();
+
+            let mut line = String::new();
+            AsyncBufReadExt::read_line(&mut reader, &mut line)
+                .await
+                .unwrap();
+            assert_eq!(line, format!("{expected_command}\r\n"));
+            AsyncWriteExt::write_all(&mut writer, response)
+                .await
+                .unwrap();
+        });
+
+        let tcp = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("failed to connect");
+        let stream = AsyncFtpStream::connect_with_stream(tcp)
+            .await
+            .expect("failed handshake");
+        (stream, handle)
+    }
+
+    #[test]
+    fn should_accept_mismatched_multiline_terminal_code() {
+        smol::block_on(async {
+            let response = b"553-\r\n\
+553- Directory excluded (precheck).\r\n\
+150 Opening BINARY mode data connection.\r\n";
+            let (mut stream, handle) =
+                connect_with_control_response("STOR upload.bin", response).await;
+
+            let response = stream
+                .custom_command("STOR upload.bin", &[Status::AboutToSend])
+                .await
+                .expect("mismatched terminal code should be accepted");
+
+            assert_eq!(response.status, Status::AboutToSend);
+            handle.await;
+        })
+    }
+
+    #[test]
+    fn should_preserve_feat_multiline_handling() {
+        smol::block_on(async {
+            let response = b"211-Features:\r\n UTF8\r\n211 END\r\n";
+            let (mut stream, handle) = connect_with_control_response("FEAT", response).await;
+
+            let features = stream.feat().await.expect("FEAT response should be parsed");
+
+            assert!(features.contains_key("UTF8"));
+            handle.await;
+        })
     }
 
     #[test]

--- a/crates/suppaftp/src/async_ftp/tokio_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp.rs
@@ -1079,20 +1079,26 @@ where
         }
 
         let code_word: u32 = self.code_from_buffer(&line, 3)?;
-        let code = Status::from(code_word);
+        let mut code = Status::from(code_word);
 
         trace!("Code parsed from response: {} ({})", code, code_word);
 
-        // multiple line reply
-        // loop while the line does not begin with the code and a space (or dash)
+        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
+        // including glFTPd, use a different operative code. FEAT remains special because
+        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
+        // M-DOCUMENTED-MAGIC: FTP replies start with a three-digit code and one separator.
         let expected = [line[0], line[1], line[2], 0x20];
-        let alt_expected = if expected_code.contains(&Status::System) {
-            [line[0], line[1], line[2], b'-']
-        } else {
-            expected
+        let feat_opener = [line[0], line[1], line[2], b'-'];
+        let is_terminal = |reply: &[u8]| {
+            reply.len() >= 4
+                && reply[0].is_ascii_digit()
+                && reply[1].is_ascii_digit()
+                && reply[2].is_ascii_digit()
+                && (reply[3] == b' '
+                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
         };
         trace!("CC IN: {:?}", line);
-        while line.len() < 5 || (line[0..4] != expected && line[0..4] != alt_expected) {
+        while !is_terminal(&line) {
             line.clear();
             let bytes_read = self.read_line(&mut line).await?;
             if bytes_read == 0 {
@@ -1103,6 +1109,11 @@ where
             }
             body.extend(line.iter());
             trace!("CC IN: {:?}", line);
+        }
+
+        if line[0..4] != expected {
+            code = Status::from(self.code_from_buffer(&line, 3)?);
+            trace!("Code updated from terminal response: {}", code);
         }
 
         let response: Response = Response::new(code, body);
@@ -1929,6 +1940,66 @@ mod test {
             .take(5)
             .collect();
         format!("temp_{}", name)
+    }
+
+    // M-MOCKABLE-SYSCALLS: use a local server for deterministic control-response tests.
+    async fn connect_with_control_response(
+        expected_command: &'static str,
+        response: &'static [u8],
+    ) -> (AsyncFtpStream, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as TokioBufReader};
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind");
+        let port = listener.local_addr().expect("missing local address").port();
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("no incoming connection");
+            let (read_half, mut writer) = stream.into_split();
+            let mut reader = TokioBufReader::new(read_half);
+
+            writer.write_all(b"220 Welcome\r\n").await.unwrap();
+
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            assert_eq!(line, format!("{expected_command}\r\n"));
+            writer.write_all(response).await.unwrap();
+        });
+
+        let tcp = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("failed to connect");
+        let stream = AsyncFtpStream::connect_with_stream(tcp)
+            .await
+            .expect("failed handshake");
+        (stream, handle)
+    }
+
+    #[tokio::test]
+    async fn should_accept_mismatched_multiline_terminal_code() {
+        let response = b"553-\r\n\
+553- Directory excluded (precheck).\r\n\
+150 Opening BINARY mode data connection.\r\n";
+        let (mut stream, handle) = connect_with_control_response("STOR upload.bin", response).await;
+
+        let response = stream
+            .custom_command("STOR upload.bin", &[Status::AboutToSend])
+            .await
+            .expect("mismatched terminal code should be accepted");
+
+        assert_eq!(response.status, Status::AboutToSend);
+        handle.await.expect("server task panicked");
+    }
+
+    #[tokio::test]
+    async fn should_preserve_feat_multiline_handling() {
+        let response = b"211-Features:\r\n UTF8\r\n211 END\r\n";
+        let (mut stream, handle) = connect_with_control_response("FEAT", response).await;
+
+        let features = stream.feat().await.expect("FEAT response should be parsed");
+
+        assert!(features.contains_key("UTF8"));
+        handle.await.expect("server task panicked");
     }
 
     #[tokio::test]

--- a/crates/suppaftp/src/sync_ftp.rs
+++ b/crates/suppaftp/src/sync_ftp.rs
@@ -881,20 +881,26 @@ where
         }
 
         let code_word: u32 = self.code_from_buffer(&line, 3)?;
-        let code = Status::from(code_word);
+        let mut code = Status::from(code_word);
 
         trace!("Code parsed from response: {} ({})", code, code_word);
 
-        // multiple line reply
-        // loop while the line does not begin with the code and a space (or dash)
+        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
+        // including glFTPd, use a different operative code. FEAT remains special because
+        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
+        // M-DOCUMENTED-MAGIC: FTP replies start with a three-digit code and one separator.
         let expected = [line[0], line[1], line[2], 0x20];
-        let alt_expected = if expected_code.contains(&Status::System) {
-            [line[0], line[1], line[2], b'-']
-        } else {
-            expected
+        let feat_opener = [line[0], line[1], line[2], b'-'];
+        let is_terminal = |reply: &[u8]| {
+            reply.len() >= 4
+                && reply[0].is_ascii_digit()
+                && reply[1].is_ascii_digit()
+                && reply[2].is_ascii_digit()
+                && (reply[3] == b' '
+                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
         };
         trace!("CC IN: {:?}", line);
-        while line.len() < 5 || (line[0..4] != expected && line[0..4] != alt_expected) {
+        while !is_terminal(&line) {
             line.clear();
             let bytes_read = self.read_line(&mut line)?;
             if bytes_read == 0 {
@@ -905,6 +911,11 @@ where
             }
             body.extend(line.iter());
             trace!("CC IN: {:?}", line);
+        }
+
+        if line[0..4] != expected {
+            code = Status::from(self.code_from_buffer(&line, 3)?);
+            trace!("Code updated from terminal response: {}", code);
         }
 
         let response: Response = Response::new(code, body);
@@ -1908,6 +1919,33 @@ mod test {
         format!("temp_{}", name)
     }
 
+    // M-MOCKABLE-SYSCALLS: use a local server for deterministic control-response tests.
+    fn connect_with_control_response(
+        expected_command: &'static str,
+        response: &'static [u8],
+    ) -> (FtpStream, std::thread::JoinHandle<()>) {
+        use std::io::{BufRead as _, BufReader as IoBufReader, Write as _};
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind");
+        let port = listener.local_addr().expect("missing local address").port();
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("no incoming connection");
+            let mut writer = stream.try_clone().expect("failed to clone stream");
+            let mut reader = IoBufReader::new(stream);
+
+            writer.write_all(b"220 Welcome\r\n").unwrap();
+
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            assert_eq!(line, format!("{expected_command}\r\n"));
+            writer.write_all(response).unwrap();
+        });
+
+        let tcp = TcpStream::connect(("127.0.0.1", port)).expect("failed to connect");
+        let stream = FtpStream::connect_with_stream(tcp).expect("failed handshake");
+        (stream, handle)
+    }
+
     /// Test if the stream is Send
     fn is_send<T: Send>(_send: T) {}
 
@@ -1940,6 +1978,32 @@ mod test {
             });
 
         is_sync::<FtpStream>(ftp_stream);
+    }
+
+    #[test]
+    fn should_accept_mismatched_multiline_terminal_code() {
+        let response = b"553-\r\n\
+553- Directory excluded (precheck).\r\n\
+150 Opening BINARY mode data connection.\r\n";
+        let (mut stream, handle) = connect_with_control_response("STOR upload.bin", response);
+
+        let response = stream
+            .custom_command("STOR upload.bin", &[Status::AboutToSend])
+            .expect("mismatched terminal code should be accepted");
+
+        assert_eq!(response.status, Status::AboutToSend);
+        handle.join().expect("server thread panicked");
+    }
+
+    #[test]
+    fn should_preserve_feat_multiline_handling() {
+        let response = b"211-Features:\r\n UTF8\r\n211 END\r\n";
+        let (mut stream, handle) = connect_with_control_response("FEAT", response);
+
+        let features = stream.feat().expect("FEAT response should be parsed");
+
+        assert!(features.contains_key("UTF8"));
+        handle.join().expect("server thread panicked");
     }
 
     #[test]


### PR DESCRIPTION
# Description

Restores the intent of #168 by accepting non-standard multiline FTP replies whose terminal line uses a different three-digit status code. The parser now returns that terminal status in the sync, Tokio, and smol backends while preserving the existing FEAT flow, where the `211-` opener must be returned before feature lines are read. This supports servers such as glFTPd without regressing FEAT parsing.

Adds deterministic regression tests for mismatched terminal codes and FEAT parsing across all three backends.

Related to #168.

## Checklist

- [x] I have read the [AI Policy](https://github.com/veeso/suppaftp/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/veeso/suppaftp/blob/main/CONTRIBUTING.md).
- [x] I have added rustdoc documentation for any new public API.
- [x] I have added tests covering my changes.
- [x] `just check_code` passes locally.
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org) format (the `CHANGELOG.md` is generated from them at release time).

## AI Disclosure

OpenAI Codex was used to inspect PR #168, reason about the FEAT regression, implement and test the fix, and prepare this commit and PR. I reviewed the diff and test results and take responsibility for the contribution.