### PR TITLE
fix(tokio): send close_notify on finalize_retr_stream to fix TLS 1.3 data-channel 426

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,23 @@
 # Changelog
 
 - [Changelog](#changelog)
-  - [10.0.2](#1002)
-    - [Fixed](#fixed)
-  - [10.0.1](#1001)
-    - [Fixed](#fixed-1)
-  - [10.0.0](#1000)
+  - [11.0.0](#1100)
     - [⚠ Breaking Changes](#-breaking-changes)
+    - [Fixed](#fixed)
+  - [10.0.2](#1002)
+    - [Fixed](#fixed-1)
+  - [10.0.1](#1001)
+    - [Fixed](#fixed-2)
+  - [10.0.0](#1000)
+    - [⚠ Breaking Changes](#-breaking-changes-1)
     - [CI](#ci)
     - [Changed](#changed)
-    - [Fixed](#fixed-2)
+    - [Fixed](#fixed-3)
   - [9.0.0](#900)
-    - [⚠ Breaking Changes](#-breaking-changes-1)
+    - [⚠ Breaking Changes](#-breaking-changes-2)
     - [Added](#added)
   - [8.0.5](#805)
-    - [Fixed](#fixed-3)
+    - [Fixed](#fixed-4)
   - [8.0.4](#804)
   - [8.0.3](#803)
   - [8.0.2](#802)
@@ -71,6 +74,49 @@
   - [4.0.0](#400)
 
 ---
+
+## 11.0.0
+
+Released on 2026-08-31
+
+### ⚠ Breaking Changes
+
+- **tokio:** send close_notify on finalize_retr_stream
+  > tokio finalize_retr_stream now requires streams to implement AsyncWrite and Unpin.
+- **smol:** close retrieval streams gracefully
+  > smol finalize_retr_stream now requires streams to implement AsyncWrite and Unpin.
+
+### Fixed
+
+- 💥 **tokio:** send close_notify on finalize_retr_stream
+  > finalize_retr_stream() (used by retr()/list()/nlst()/mlsd() on the tokio
+  > backend) dropped the data-connection stream without a graceful shutdown,
+  > unlike finalize_put_stream() which already calls stream.shutdown().
+  > 
+  > For a plain TCP data stream this is harmless, but for a TLS-secured FTPS
+  > data channel it means no close_notify is sent. TLS 1.2 servers tolerate
+  > the abrupt close (session-ID based resumption apparently masks it), but
+  > TLS-1.3-strict servers reply "426 Transfer failed (unable to close data
+  > connection gracefully)" even though the transfer already completed —
+  > reproduced live against test.rebex.net (public FTPS server, TLS 1.3) with
+  > RUST_LOG=trace: rustls confirms `Resuming using PSK` and the full LIST
+  > payload is read before the 426 appears, ruling out a session-resumption
+  > mismatch. The 426 only goes away when the data stream shuts down cleanly.
+  > 
+  > This widens finalize_retr_stream()'s bound from `impl AsyncRead` to
+  > `impl AsyncRead + AsyncWriteExt + Unpin` (matching finalize_put_stream's
+  > existing bound) and sends the close_notify before dropping. Shutdown
+  > errors are ignored, mirroring the fact that the data has already been
+  > fully read by this point — a failed shutdown must not fail an
+  > otherwise-successful transfer (finalize_put_stream is stricter here since
+  > for uploads the write isn't confirmed complete until shutdown succeeds).
+  > 
+  > Verified with a small standalone client exercising both an unrestricted
+  > rustls config (negotiates TLS 1.3) and one capped at TLS 1.2 against
+  > test.rebex.net: before this fix, only the TLS-1.2-capped path completed
+  > LIST; after, both do.
+- 💥 **smol:** close retrieval streams gracefully
+  > Mirror Tokio retrieval finalization by closing smol data streams before reading the final control response. Add deterministic coverage for both runtimes and document the response-authority policy.
 
 ## 10.0.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/suppaftp", "crates/suppaftp-cli"]
 resolver = "3"
 
 [workspace.package]
-version = "10.0.2"
+version = "11.0.0"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]
 categories = ["asynchronous", "network-programming"]
 edition = "2024"
@@ -29,8 +29,8 @@ rpassword = "7.2"
 rustls-crate = { package = "rustls", version = "0.23", default-features = false }
 rustls-pki-types = "1"
 smol = "2"
-suppaftp = { path = "crates/suppaftp", version = "10" }
-testcontainers = "0.27"
+suppaftp = { path = "crates/suppaftp", version = "11" }
+testcontainers = "0.28"
 thiserror = "2"
 tokio = "1"
 tokio-rustls-crate = { package = "tokio-rustls", version = "0.26", default-features = false }

--- a/crates/suppaftp/src/async_ftp/smol_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp.rs
@@ -482,9 +482,18 @@ where
         Ok(data_stream)
     }
 
-    /// Finalize retr stream; must be called once the requested file, got previously with `retr_as_stream()` has been read
-    pub async fn finalize_retr_stream(&mut self, stream: impl Read) -> FtpResult<()> {
+    /// Finalize retr stream; must be called once the requested file, got previously with `retr_as_stream()` has been read.
+    ///
+    /// Write-side close errors are ignored after the payload has been read. The final FTP control
+    /// response determines whether the transfer succeeded.
+    pub async fn finalize_retr_stream(
+        &mut self,
+        mut stream: impl Read + Write + Unpin,
+    ) -> FtpResult<()> {
         debug!("Finalizing retr stream");
+        // Close the write side so TLS streams send close_notify before being dropped. The server's
+        // completion response remains authoritative if closing an already-read stream fails.
+        let _ = stream.close().await;
         // Drop stream NOTE: must be done first, otherwise server won't return any response
         drop(stream);
         self.data_connection_open = false;
@@ -1209,8 +1218,11 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::pin::Pin;
     use std::str::FromStr as _;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::{Context, Poll};
 
     #[cfg(feature = "async-secure")]
     use pretty_assertions::assert_eq;
@@ -1224,12 +1236,104 @@ mod test {
     use crate::types::FormatControl;
     use crate::{FtpError, Status};
 
+    #[derive(Debug)]
+    struct CloseTrackingStream {
+        close_attempted: Arc<AtomicBool>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl smol::io::AsyncRead for CloseTrackingStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut [u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(0))
+        }
+    }
+
+    impl smol::io::AsyncWrite for CloseTrackingStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            self.close_attempted.store(true, Ordering::SeqCst);
+            Poll::Ready(Err(std::io::Error::other("close failed")))
+        }
+    }
+
+    impl Drop for CloseTrackingStream {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
     #[test]
     fn connect() {
         smol::block_on(async {
             crate::log_init();
             let (stream, _container) = setup_stream().await;
             finalize_stream(stream).await;
+        })
+    }
+
+    #[test]
+    fn finalize_retr_stream_attempts_close_before_reading_response() {
+        smol::block_on(async {
+            use smol::io::AsyncWriteExt as _;
+
+            let close_attempted = Arc::new(AtomicBool::new(false));
+            let dropped = Arc::new(AtomicBool::new(false));
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind");
+            let port = listener.local_addr().expect("missing local address").port();
+            let server_close_attempted = Arc::clone(&close_attempted);
+            let server_dropped = Arc::clone(&dropped);
+            let server = smol::spawn(async move {
+                let (mut control, _) = listener.accept().await.expect("no incoming connection");
+                control.write_all(b"220 Welcome\r\n").await.unwrap();
+
+                let deadline = std::time::Instant::now() + Duration::from_secs(1);
+                while !server_dropped.load(Ordering::SeqCst) && std::time::Instant::now() < deadline
+                {
+                    smol::Timer::after(Duration::from_millis(1)).await;
+                }
+
+                let response: &[u8] = if server_close_attempted.load(Ordering::SeqCst)
+                    && server_dropped.load(Ordering::SeqCst)
+                {
+                    b"226 Transfer complete\r\n"
+                } else {
+                    b"426 Data connection was not closed gracefully\r\n"
+                };
+                control.write_all(response).await.unwrap();
+            });
+
+            let control = TcpStream::connect(("127.0.0.1", port))
+                .await
+                .expect("failed to connect");
+            let mut ftp = AsyncFtpStream::connect_with_stream(control)
+                .await
+                .expect("failed handshake");
+            let data = CloseTrackingStream {
+                close_attempted: Arc::clone(&close_attempted),
+                dropped: Arc::clone(&dropped),
+            };
+
+            ftp.finalize_retr_stream(data)
+                .await
+                .expect("FTP completion should override the local close error");
+            server.await;
         })
     }
 

--- a/crates/suppaftp/src/async_ftp/tokio_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp.rs
@@ -470,8 +470,19 @@ where
     }
 
     /// Finalize retr stream; must be called once the requested file, got previously with `retr_as_stream()` has been read
-    pub async fn finalize_retr_stream(&mut self, stream: impl AsyncRead) -> FtpResult<()> {
+    pub async fn finalize_retr_stream(
+        &mut self,
+        mut stream: impl AsyncRead + AsyncWriteExt + Unpin,
+    ) -> FtpResult<()> {
         debug!("Finalizing retr stream");
+        // Send a graceful TLS close_notify before dropping the stream, mirroring
+        // finalize_put_stream() below. Without it, TLS 1.3 servers that enforce a
+        // clean data-channel shutdown (e.g. test.rebex.net) reply 426 "unable to
+        // close data connection gracefully" even though the transfer already
+        // completed — TLS 1.2's session resumption tolerated the abrupt close, but
+        // 1.3 does not. Errors here are ignored: the data has already been fully
+        // read, so a failed shutdown must not fail an otherwise-successful transfer.
+        let _ = stream.shutdown().await;
         // Drop stream NOTE: must be done first, otherwise server won't return any response
         drop(stream);
         self.data_connection_open = false;

--- a/crates/suppaftp/src/async_ftp/tokio_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp.rs
@@ -23,7 +23,7 @@ pub use tls::{AsyncNativeTlsConnector, AsyncNativeTlsStream};
 pub use tls::{AsyncNoTlsStream, TokioTlsStream};
 #[cfg(any(feature = "tokio-rustls-aws-lc-rs", feature = "tokio-rustls-ring"))]
 pub use tls::{AsyncRustlsConnector, AsyncRustlsStream};
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader, copy};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, copy};
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
 
 use super::super::Status;
@@ -469,19 +469,17 @@ where
         Ok(data_stream)
     }
 
-    /// Finalize retr stream; must be called once the requested file, got previously with `retr_as_stream()` has been read
+    /// Finalize retr stream; must be called once the requested file, got previously with `retr_as_stream()` has been read.
+    ///
+    /// Write-side shutdown errors are ignored after the payload has been read. The final FTP
+    /// control response determines whether the transfer succeeded.
     pub async fn finalize_retr_stream(
         &mut self,
-        mut stream: impl AsyncRead + AsyncWriteExt + Unpin,
+        mut stream: impl AsyncRead + AsyncWrite + Unpin,
     ) -> FtpResult<()> {
         debug!("Finalizing retr stream");
-        // Send a graceful TLS close_notify before dropping the stream, mirroring
-        // finalize_put_stream() below. Without it, TLS 1.3 servers that enforce a
-        // clean data-channel shutdown (e.g. test.rebex.net) reply 426 "unable to
-        // close data connection gracefully" even though the transfer already
-        // completed — TLS 1.2's session resumption tolerated the abrupt close, but
-        // 1.3 does not. Errors here are ignored: the data has already been fully
-        // read, so a failed shutdown must not fail an otherwise-successful transfer.
+        // Close the write side so TLS streams send close_notify before being dropped. The server's
+        // completion response remains authoritative if closing an already-read stream fails.
         let _ = stream.shutdown().await;
         // Drop stream NOTE: must be done first, otherwise server won't return any response
         drop(stream);
@@ -1201,8 +1199,11 @@ where
 #[cfg(test)]
 mod test {
     use std::io::Cursor;
+    use std::pin::Pin;
     use std::str::FromStr as _;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::{Context, Poll};
 
     use pretty_assertions::assert_eq;
     use rand::distr::Alphanumeric;
@@ -1214,11 +1215,100 @@ mod test {
     use crate::test_container::AsyncPureFtpRunner;
     use crate::types::FormatControl;
 
+    #[derive(Debug)]
+    struct ShutdownTrackingStream {
+        shutdown_attempted: Arc<AtomicBool>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl tokio::io::AsyncRead for ShutdownTrackingStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl tokio::io::AsyncWrite for ShutdownTrackingStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            self.shutdown_attempted.store(true, Ordering::SeqCst);
+            Poll::Ready(Err(std::io::Error::other("shutdown failed")))
+        }
+    }
+
+    impl Drop for ShutdownTrackingStream {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
     #[tokio::test]
     async fn connect() {
         crate::log_init();
         let (stream, _container) = setup_stream().await;
         finalize_stream(stream).await;
+    }
+
+    #[tokio::test]
+    async fn finalize_retr_stream_attempts_shutdown_before_reading_response() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let shutdown_attempted = Arc::new(AtomicBool::new(false));
+        let dropped = Arc::new(AtomicBool::new(false));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind");
+        let port = listener.local_addr().expect("missing local address").port();
+        let server_shutdown_attempted = Arc::clone(&shutdown_attempted);
+        let server_dropped = Arc::clone(&dropped);
+        let server = tokio::spawn(async move {
+            let (mut control, _) = listener.accept().await.expect("no incoming connection");
+            control.write_all(b"220 Welcome\r\n").await.unwrap();
+
+            let deadline = std::time::Instant::now() + Duration::from_secs(1);
+            while !server_dropped.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
+                tokio::task::yield_now().await;
+            }
+
+            let response: &[u8] = if server_shutdown_attempted.load(Ordering::SeqCst)
+                && server_dropped.load(Ordering::SeqCst)
+            {
+                b"226 Transfer complete\r\n"
+            } else {
+                b"426 Data connection was not closed gracefully\r\n"
+            };
+            control.write_all(response).await.unwrap();
+        });
+
+        let control = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("failed to connect");
+        let mut ftp = AsyncFtpStream::connect_with_stream(control)
+            .await
+            .expect("failed handshake");
+        let data = ShutdownTrackingStream {
+            shutdown_attempted: Arc::clone(&shutdown_attempted),
+            dropped: Arc::clone(&dropped),
+        };
+
+        ftp.finalize_retr_stream(data)
+            .await
+            .expect("FTP completion should override the local shutdown error");
+        server.await.expect("server task panicked");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`finalize_retr_stream()` on the tokio backend (`crates/suppaftp/src/async_ftp/tokio_ftp.rs`) drops the data-connection stream without a graceful shutdown, unlike `finalize_put_stream()`, which already calls `stream.shutdown().await`. For a plain TCP data stream this is harmless, but for a TLS-secured FTPS data channel it means no `close_notify` is ever sent.

TLS 1.2 servers tolerate the abrupt close. TLS-1.3-strict servers reply `426 Transfer failed (unable to close data connection gracefully)` even though the transfer already completed — this is what forces downstream consumers of this crate to cap their `rustls::ClientConfig` at TLS 1.2 for FTPS to work at all.

## Root cause / how I verified it

Reproduced live against `test.rebex.net` (public FTPS server, TLS 1.3) with `RUST_LOG=trace`. My first hypothesis was a TLS-session-resumption mismatch between the control and data channel (session-ID vs. session-ticket schemes), but the trace ruled that out: rustls logs `Resuming using PSK`, and the full `LIST` payload is read from the data stream *before* the 426 shows up. The 426 only disappears once the data stream is shut down cleanly before being dropped — i.e. it's purely about the missing `close_notify`, not resumption.

I exercised this with a small standalone client running two scenarios against `test.rebex.net`: an unrestricted `rustls::ClientConfig` (negotiates TLS 1.3) and one capped at TLS 1.2. Before this fix, only the TLS-1.2-capped path completed `LIST`; after this fix, both do.

## Change

Widens `finalize_retr_stream()`'s bound from `impl AsyncRead` to `impl AsyncRead + AsyncWriteExt + Unpin` (matching `finalize_put_stream`'s existing bound) and sends `close_notify` before dropping. All existing callers (`retr()`, `list()`/`nlst()`/`mlsd()` via `stream_lines()`, and the test suite) already pass a `DataStream<T>` or a `BufReader` wrapping one, both of which implement `AsyncWrite`, so no call sites needed to change.

Shutdown errors are ignored deliberately: the data has already been fully read by the time `finalize_retr_stream` runs, so a failed shutdown must not fail an otherwise-successful transfer. This is intentionally looser than `finalize_put_stream`, which still propagates the shutdown error (for uploads, the write isn't confirmed complete until shutdown succeeds).

## Not included

`sync_ftp.rs` and the async-std `smol_ftp.rs` backend have the same drop-without-shutdown pattern in their `finalize_retr_stream`. I only patched and verified the tokio backend (the one exercised above) — the other two likely need the equivalent fix but I haven't tested them, so I left them out of this PR rather than guess.

## Testing

- `cargo build -p suppaftp --no-default-features --features tokio-rustls-ring` — compiles clean.
- Live reproduction via a standalone client against `test.rebex.net` (both TLS 1.2-capped and unrestricted/TLS 1.3 configs) — both complete `LIST` after this fix; only the capped one did before.