### PR TITLE
feat!: make data streams finalize themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,122 +1,92 @@
 # Changelog
 
-- [Changelog](#changelog)
-  - [11.0.0](#1100)
-    - [⚠ Breaking Changes](#-breaking-changes)
-    - [Fixed](#fixed)
-  - [10.0.2](#1002)
-    - [Fixed](#fixed-1)
-  - [10.0.1](#1001)
-    - [Fixed](#fixed-2)
-  - [10.0.0](#1000)
-    - [⚠ Breaking Changes](#-breaking-changes-1)
-    - [CI](#ci)
-    - [Changed](#changed)
-    - [Fixed](#fixed-3)
-  - [9.0.0](#900)
-    - [⚠ Breaking Changes](#-breaking-changes-2)
-    - [Added](#added)
-  - [8.0.5](#805)
-    - [Fixed](#fixed-4)
-  - [8.0.4](#804)
-  - [8.0.3](#803)
-  - [8.0.2](#802)
-  - [8.0.1](#801)
-  - [8.0.0](#800)
-  - [7.1.0](#710)
-  - [7.0.7](#707)
-  - [7.0.6](#706)
-  - [7.0.5](#705)
-  - [7.0.4](#704)
-  - [7.0.3](#703)
-  - [7.0.1](#701)
-  - [7.0.0](#700)
-  - [6.3.0](#630)
-  - [6.2.1](#621)
-  - [6.2.0](#620)
-  - [6.1.1](#611)
-  - [6.1.0](#610)
-  - [6.0.7](#607)
-  - [6.0.6](#606)
-  - [6.0.5](#605)
-  - [6.0.4](#604)
-  - [6.0.3](#603)
-  - [6.0.2](#602)
-  - [6.0.1](#601)
-  - [6.0.0](#600)
-  - [5.4.0](#540)
-  - [5.3.1](#531)
-  - [5.3.0](#530)
-  - [5.2.2](#522)
-  - [5.2.1](#521)
-  - [5.2.0](#520)
-  - [5.1.2](#512)
-  - [5.1.1](#511)
-  - [5.1.0](#510)
-  - [5.0.1](#501)
-  - [5.0.0](#500)
-  - [4.7.0](#470)
-  - [4.6.1](#461)
-  - [4.6.0](#460)
-  - [4.5.3](#453)
-  - [4.5.2](#452)
-  - [4.5.1](#451)
-  - [4.5.0](#450)
-  - [4.4.0](#440)
-  - [4.3.0](#430)
-  - [4.2.0](#420)
-  - [4.1.3](#413)
-  - [4.1.2](#412)
-  - [4.1.1](#411)
-  - [4.1.0](#410)
-  - [4.0.2](#402)
-  - [4.0.1](#401)
-  - [4.0.0](#400)
+All notable changes to this project are documented in this file.
 
----
+## 12.0.0
+
+Released on 2026-09-08
+
+### Breaking changes
+
+- make data streams finalize themselves
+
+> finalize_put_stream, finalize_retr_stream and
+> close_data_connection are removed; put_with_stream, append_with_stream,
+> retr_as_stream and custom_data_command return TransferStream, whose
+> finish() replaces them; abort takes a TransferStream; the async retr
+> callbacks receive and return a TransferStream; get_ref returns a locked
+> ControlSocket (async: through an async fn); get_lines_from_stream is
+> generic over BufRead readers.
+
+### Added
+
+- Breaking: make data streams finalize themselves
+
+> Move the control connection (reply reader and data-connection flag) of
+> every client behind an Arc<Mutex<..>> shared with a new TransferStream
+> returned by put_with_stream, append_with_stream, retr_as_stream and
+> custom_data_command. The stream closes its data socket and reads the
+> 226/250 reply itself through finish(); a dropped stream does the same
+> (sync) or defers the reply to the next command (tokio, smol), so the
+> control connection can no longer desynchronize because a caller forgot
+> to finalize.
+
+### Fixed
+
+- preserve transfer cleanup across cancellation and locking
+
+> Retain pending replies and partial response buffers when async finalization is cancelled. Record dropped transfers without locking the control channel and reject TLS mode changes before sending commands while a transfer is alive.
+>
+> Add regression coverage for cancellation, control socket contention, and TLS transitions. Document the breaking stream API migration and cleanup limitations, and resolve test helper lint warnings.
 
 ## 11.0.0
 
 Released on 2026-08-31
 
-### ⚠ Breaking Changes
+### Breaking changes
 
 - **tokio:** send close_notify on finalize_retr_stream
-  > tokio finalize_retr_stream now requires streams to implement AsyncWrite and Unpin.
+
+> tokio finalize_retr_stream now requires streams to implement AsyncWrite and Unpin.
+
 - **smol:** close retrieval streams gracefully
-  > smol finalize_retr_stream now requires streams to implement AsyncWrite and Unpin.
+
+> smol finalize_retr_stream now requires streams to implement AsyncWrite and Unpin.
 
 ### Fixed
 
-- 💥 **tokio:** send close_notify on finalize_retr_stream
-  > finalize_retr_stream() (used by retr()/list()/nlst()/mlsd() on the tokio
-  > backend) dropped the data-connection stream without a graceful shutdown,
-  > unlike finalize_put_stream() which already calls stream.shutdown().
-  > 
-  > For a plain TCP data stream this is harmless, but for a TLS-secured FTPS
-  > data channel it means no close_notify is sent. TLS 1.2 servers tolerate
-  > the abrupt close (session-ID based resumption apparently masks it), but
-  > TLS-1.3-strict servers reply "426 Transfer failed (unable to close data
-  > connection gracefully)" even though the transfer already completed —
-  > reproduced live against test.rebex.net (public FTPS server, TLS 1.3) with
-  > RUST_LOG=trace: rustls confirms `Resuming using PSK` and the full LIST
-  > payload is read before the 426 appears, ruling out a session-resumption
-  > mismatch. The 426 only goes away when the data stream shuts down cleanly.
-  > 
-  > This widens finalize_retr_stream()'s bound from `impl AsyncRead` to
-  > `impl AsyncRead + AsyncWriteExt + Unpin` (matching finalize_put_stream's
-  > existing bound) and sends the close_notify before dropping. Shutdown
-  > errors are ignored, mirroring the fact that the data has already been
-  > fully read by this point — a failed shutdown must not fail an
-  > otherwise-successful transfer (finalize_put_stream is stricter here since
-  > for uploads the write isn't confirmed complete until shutdown succeeds).
-  > 
-  > Verified with a small standalone client exercising both an unrestricted
-  > rustls config (negotiates TLS 1.3) and one capped at TLS 1.2 against
-  > test.rebex.net: before this fix, only the TLS-1.2-capped path completed
-  > LIST; after, both do.
-- 💥 **smol:** close retrieval streams gracefully
-  > Mirror Tokio retrieval finalization by closing smol data streams before reading the final control response. Add deterministic coverage for both runtimes and document the response-authority policy.
+- Breaking: **tokio:** send close_notify on finalize_retr_stream
+
+> finalize_retr_stream() (used by retr()/list()/nlst()/mlsd() on the tokio
+> backend) dropped the data-connection stream without a graceful shutdown,
+> unlike finalize_put_stream() which already calls stream.shutdown().
+>
+> For a plain TCP data stream this is harmless, but for a TLS-secured FTPS
+> data channel it means no close_notify is sent. TLS 1.2 servers tolerate
+> the abrupt close (session-ID based resumption apparently masks it), but
+> TLS-1.3-strict servers reply "426 Transfer failed (unable to close data
+> connection gracefully)" even though the transfer already completed —
+> reproduced live against test.rebex.net (public FTPS server, TLS 1.3) with
+> RUST_LOG=trace: rustls confirms `Resuming using PSK` and the full LIST
+> payload is read before the 426 appears, ruling out a session-resumption
+> mismatch. The 426 only goes away when the data stream shuts down cleanly.
+>
+> This widens finalize_retr_stream()'s bound from `impl AsyncRead` to
+> `impl AsyncRead + AsyncWriteExt + Unpin` (matching finalize_put_stream's
+> existing bound) and sends the close_notify before dropping. Shutdown
+> errors are ignored, mirroring the fact that the data has already been
+> fully read by this point — a failed shutdown must not fail an
+> otherwise-successful transfer (finalize_put_stream is stricter here since
+> for uploads the write isn't confirmed complete until shutdown succeeds).
+>
+> Verified with a small standalone client exercising both an unrestricted
+> rustls config (negotiates TLS 1.3) and one capped at TLS 1.2 against
+> test.rebex.net: before this fix, only the TLS-1.2-capped path completed
+> LIST; after, both do.
+
+- Breaking: **smol:** close retrieval streams gracefully
+
+> Mirror Tokio retrieval finalization by closing smol data streams before reading the final control response. Add deterministic coverage for both runtimes and document the response-authority policy.
 
 ## 10.0.2
 
@@ -124,15 +94,18 @@ Released on 2026-08-18
 
 ### Fixed
 
-- reject FTP commands carrying CR or LF to prevent command injection
-  > An argument containing CR or LF ended the intended command line and let a
-  > second command be smuggled onto the control channel. Every rendered command
-  > is now validated before it is written to the wire, in the sync, tokio and
-  > smol implementations alike, and rejected with an InvalidInput connection
-  > error.
-  > 
-  > As a consequence custom_command no longer accepts several commands joined by
-  > CRLF in a single call.
+- reject FTP commands carrying CR or LF to prevent command injection (#172)
+
+> - fix: reject FTP commands carrying CR or LF to prevent command injection
+>
+> An argument containing CR or LF ended the intended command line and let a
+> second command be smuggled onto the control channel. Every rendered command
+> is now validated before it is written to the wire, in the sync, tokio and
+> smol implementations alike, and rejected with an InvalidInput connection
+> error.
+>
+> As a consequence custom_command no longer accepts several commands joined by
+> CRLF in a single call.
 
 ## 10.0.1
 
@@ -141,85 +114,82 @@ Released on 2026-07-13
 ### Fixed
 
 - **parser:** accept mismatched terminal codes (#169)
-  > Accept non-standard multiline replies that finish with a different status code while preserving FEAT continuation handling.
+
+> Accept non-standard multiline replies that finish with a different status code while preserving FEAT continuation handling.
 
 ## 10.0.0
 
 Released on 2026-06-29
 
-### ⚠ Breaking Changes
+### Breaking changes
+
 - replace panics with errors across library and CLI (#166)
-  > the `tcp_stream` method of the `TlsStream`, `TokioTlsStream` and
-`SmolTlsStream` traits now returns `FtpResult<TcpStream>` instead of `TcpStream`,
-and `DataStream::into_tcp_stream` now returns `FtpResult<TcpStream>`.
 
-### CI
-
-- build all feature sets on windows and macos (#165)
-  > Extend the build job with an os matrix (ubuntu, windows, macos) so every feature combination is compiled on all three platforms, catching platform-specific build breaks. Coverage/tests stay linux-only as they require Docker.
+> the `tcp_stream` method of the `TlsStream`, `TokioTlsStream` and
+> `SmolTlsStream` traits now returns `FtpResult<TcpStream>` instead of `TcpStream`,
+> and `DataStream::into_tcp_stream` now returns `FtpResult<TcpStream>`.
 
 ### Changed
 
-- 💥 replace panics with errors across library and CLI (#166)
-  > Convert unwrap/expect/panic patterns in production code paths to proper
-  > FtpError/ParseError results, so malformed server responses (e.g. an out-of-range
-  > PASV octet or unparsable LIST/MLSx line) and socket-clone failures no longer abort
-  > the program. Placeholder no-TLS streams now return io errors or unreachable! for
-  > truly unreachable accessors.
+- Breaking: replace panics with errors across library and CLI (#166)
+
+> Convert unwrap/expect/panic patterns in production code paths to proper
+> FtpError/ParseError results, so malformed server responses (e.g. an out-of-range
+> PASV octet or unparsable LIST/MLSx line) and socket-clone failures no longer abort
+> the program. Placeholder no-TLS streams now return io errors or unreachable! for
+> truly unreachable accessors.
 
 ### Fixed
 
-- bump `time` to 0.3.47 to fix RUSTSEC-2026-0009 (#167)
-  > `time` 0.3.45 (a dev-only dependency via testcontainers) is affected by a
-  > denial-of-service via stack exhaustion when parsing RFC 2822 input. Bumping to
-  > 0.3.47 raises the workspace MSRV to 1.88.0.
 - `tcp_stream()` Windows compatibility with tokio + native-tls (#164)
-  > Add a branch on windows that uses `as_socket` instead of `as_fd` to get
-  > a reference to the underlying system socket before cloning.
+
+> Add a branch on windows that uses `as_socket` instead of `as_fd` to get
+> a reference to the underlying system socket before cloning.
 
 ## 9.0.0
 
 Released on 2026-06-20
 
-### ⚠ Breaking Changes
+### Breaking changes
 
 - replace async-std runtime with smol (#162)
 
+> the async-std runtime and all async-std* cargo features are
+> removed; use the smol runtime and the equivalent smol* features instead. The
+
 ### Added
 
-- 💥 replace async-std runtime with smol (#162)
-  > async-std is unmaintained upstream (RUSTSEC-2025-0052). Drop it as an async
-  > backend and replace it with smol, an equivalent lightweight runtime.
-  >
-  > The TLS backends are unchanged: futures-rustls and async-native-tls are
-  > runtime-agnostic, so only the runtime glue (TcpStream/TcpListener, timers,
-  > spawn, task) moved from async-std to smol. async-native-tls already ran on its
-  > runtime-smol backend. The direct futures-lite dependency is gone too: smol
-  > re-exports it and nothing else used it, so it is no longer compiled for
-  > sync/tokio builds.
-  >
-  > This commit also centralizes dependencies into [workspace.dependencies], applies
-  > Cargo.toml conventions across all manifests, and renames mod.rs files to the
-  > module_name.rs style.
-  >
-  > Migrating from async-std:
-  >
-  > - Cargo features: rename every async-std feature to its smol counterpart.
-  >   - async-std                            -> smol
-  >   - async-std-async-native-tls           -> smol-async-native-tls
-  >   - async-std-async-native-tls-vendored  -> smol-async-native-tls-vendored
-  >   - async-std-rustls-aws-lc-rs           -> smol-rustls-aws-lc-rs
-  >   - async-std-rustls-ring                -> smol-rustls-ring
-  >
-  > - Module path: the async module is now suppaftp::smol instead of
-  >   suppaftp::async_std. The stream type aliases are unchanged: AsyncFtpStream,
-  >   AsyncNativeTlsFtpStream, AsyncRustlsFtpStream.
-  >
-  > - Helper types: AsyncStdTlsStream is now SmolTlsStream, and
-  >   AsyncStdPassiveStreamBuilder is now SmolPassiveStreamBuilder.
-  >
-  > - Runtime: drive the client on a smol executor (e.g. smol::block_on) instead of
-  >   async_std::task::block_on or #[async_std::main].
+- Breaking: replace async-std runtime with smol (#162)
+
+> async-std is unmaintained upstream (RUSTSEC-2025-0052). Drop it as an async
+> backend and replace it with smol, an equivalent lightweight runtime.
+>
+> The TLS backends are unchanged: futures-rustls and async-native-tls are
+> runtime-agnostic, so only the runtime glue (TcpStream/TcpListener, timers,
+> spawn, task) moved from async-std to smol. async-native-tls already ran on its
+> runtime-smol backend. The direct futures-lite dependency is gone too: smol
+> re-exports it and nothing else used it, so it is no longer compiled for
+> sync/tokio builds.
+>
+> This commit also centralizes dependencies into [workspace.dependencies], applies
+> Cargo.toml conventions across all manifests, and renames mod.rs files to the
+> module_name.rs style.
+>
+> Migrating from async-std:
+>
+> - Cargo features: rename every async-std* feature to its smol* counterpart.
+>   - async-std -> smol
+>   - async-std-async-native-tls -> smol-async-native-tls
+>   - async-std-async-native-tls-vendored -> smol-async-native-tls-vendored
+>   - async-std-rustls-aws-lc-rs -> smol-rustls-aws-lc-rs
+>   - async-std-rustls-ring -> smol-rustls-ring
+> - Module path: the async module is now suppaftp::smol instead of
+>   suppaftp::async_std. The stream type aliases are unchanged: AsyncFtpStream,
+>   AsyncNativeTlsFtpStream, AsyncRustlsFtpStream.
+> - Helper types: AsyncStdTlsStream is now SmolTlsStream, and
+>   AsyncStdPassiveStreamBuilder is now SmolPassiveStreamBuilder.
+> - Runtime: drive the client on a smol executor (e.g. smol::block_on) instead of
+>   async_std::task::block_on or #[async_std::main].
 
 ## 8.0.5
 
@@ -228,481 +198,581 @@ Released on 2026-06-20
 ### Fixed
 
 - accept 200 as a valid response for file operations (#158)
-  > Some non-compliant FTP servers (e.g. bftpd) reply with 200 instead of
-  > the spec-mandated 250/257 to file operations such as DELE, RMD, RNTO and
-  > MKD. Tolerate 200 alongside the expected code in rm, rmdir, rename and
-  > mkdir, across the sync, tokio and async-std implementations.
+
+> Some non-compliant FTP servers (e.g. bftpd) reply with 200 instead of
+> the spec-mandated 250/257 to file operations such as DELE, RMD, RNTO and
+> MKD. Tolerate 200 alongside the expected code in rm, rmdir, rename and
+> mkdir, across the sync, tokio and async-std implementations.
 
 ## 8.0.4
 
-- [Issue 155](https://github.com/veeso/suppaftp/issues/155): Fixed data commands (`retr_as_stream`, `retr_as_buffer`, `put_with_stream`, `append_with_stream`, `custom_data_command`, `list`, `nlst`) leaving the `data_connection_open` flag set when the server rejected the command, which made every subsequent data command wrongly fail with `DataConnectionAlreadyOpen`.
-- Upgraded `async-native-tls` to 0.6. The async-std FTPS backend now uses the `runtime-smol` feature of `async-native-tls` (the crate dropped its `runtime-async-std` feature in 0.6).
+Released on 2026-06-08
+
+### Fixed
+
+- reset data_connection_open flag when a data command fails
+
+> Data commands set `data_connection_open = true` once the data stream is
+> opened, but the follow-up `read_response_in` could still fail (e.g. the
+> server returns 550 for a missing file). On that error the flag stayed
+> true, so every subsequent data command wrongly failed with
+> `DataConnectionAlreadyOpen`.
+>
+> Introduce a `data_command_with_response` wrapper that runs the data
+> command and reads its preliminary response, dropping the stream and
+> resetting the flag on error. Route every data-command caller
+> (`retr_as_stream`, `put_with_stream`, `append_with_stream`,
+> `custom_data_command`, `stream_lines`) through it, in the sync, tokio
+> and async-std implementations.
+>
+> Add tests in all three implementations verifying that every kind of
+> data command remains usable after a failed one.
+
+### Build
+
+- bump rand 0.10
+- upgrade async-native-tls to 0.6
+
+> The crate dropped its runtime-async-std feature in 0.6, so the
+> async-std FTPS backend now enables runtime-smol instead, which uses
+> the futures-util IO traits compatible with async-std's TcpStream.
 
 ## 8.0.3
 
-Released on 23/04/2026
+Released on 2026-04-23
 
-- [PR 153](https://github.com/veeso/suppaftp/pull/153): Fixed `cwd()` to accept `200 Command OK` in addition to `250` as success, for compatibility with servers that deviate from RFC 959.
+### Fixed
+
+- handle 200 (command OK) as success in cwd()
+
+> RFC 959 specifies 250 as the standard response code when changing
+> the working directory successfully, but some FTP servers return
+> 200 instead.
 
 ## 8.0.2
 
-Released on 12/02/2026
+Released on 2026-02-12
 
-- [PR 135](https://github.com/veeso/suppaftp/pull/135): Fixed unsafe undefined behavior in tokio `AsyncNativeTlsStream::tcp_stream()` which could cause use-after-free / double-free.
-- [PR 136](https://github.com/veeso/suppaftp/pull/136): Fixed `data_connection_open` flag being set before the data stream was actually created, which could incorrectly report `DataConnectionAlreadyOpen` on failure.
-- [PR 137](https://github.com/veeso/suppaftp/pull/137): Fixed infinite loop in async `feat()` when the server disconnects mid-response.
-- [PR 138](https://github.com/veeso/suppaftp/pull/138): Fixed infinite loop in `read_response_in()` on multiline responses when the server disconnects.
-- [PR 139](https://github.com/veeso/suppaftp/pull/139): Fixed MLSX parser to accept `cdir` and `pdir` entry types as directories (per RFC 3659).
-- [PR 140](https://github.com/veeso/suppaftp/pull/140): Fixed MLSX `unix.mode` parser to accept 4-digit octal modes (e.g. `0755`).
-- [PR 141](https://github.com/veeso/suppaftp/pull/141): Fixed `abort()` hanging when server sends 226 directly instead of 426+226.
-- [PR 142](https://github.com/veeso/suppaftp/pull/142): Fixed DOS LIST parser to handle comma-separated file sizes (e.g. `1,234,567`).
-- [PR 143](https://github.com/veeso/suppaftp/pull/143): Fixed `parse_lstime` to adjust year for future dates (matches GNU ls behavior).
-- [PR 144](https://github.com/veeso/suppaftp/pull/144): Fixed DOS time parser to handle space before AM/PM (e.g. `01:30 PM`).
-- [PR 145](https://github.com/veeso/suppaftp/pull/145): Fixed active mode to use EPRT command for IPv6 connections.
-- [PR 146](https://github.com/veeso/suppaftp/pull/146): Replaced `unwrap()` panics on server-controlled data (EPSV, SIZE, MDTM) with proper error handling.
-- [PR 147](https://github.com/veeso/suppaftp/pull/147): Removed redundant `feature = "async-std"` in cfg gate.
-- [PR 148](https://github.com/veeso/suppaftp/pull/148): Fixed `doc(cfg)` attribute on `SecureError` variant to show both `secure` and `async-secure` features.
-- [PR 133](https://github.com/veeso/suppaftp/pull/133): Moved crates to `crates/` folder.
-- [PR 134](https://github.com/veeso/suppaftp/pull/134): Changed test container image to `delfer/alpine-ftp-server`.
+### Changed
+
+- Moved crates to crates/ folder (#133)
+
+### Fixed
+
+- reader does not need to be mutable
+- replace unsafe UB in tokio AsyncNativeTlsStream::tcp_stream() (#135)
+
+> The previous implementation used Box::from_raw on a pointer obtained from
+> get_ref(), which points into the interior of a TlsStream allocation, not
+> a Box allocation. This caused heap corruption / undefined behavior.
+>
+> Replace with safe fd cloning via BorrowedFd::try_clone_to_owned().
+
+- data_connection_open flag now only set on successful data_command (#136)
+
+> The data_connection_open flag was being set before the data stream was
+> actually created, causing it to remain true even when connection failed.
+
+- add EOF check to async feat() to prevent infinite loop (#137)
+
+> The async implementations of feat() were missing an EOF check in their
+> read loop, causing an infinite loop if the server disconnected mid-response.
+
+- add EOF check to read_response_in multiline loop (#138)
+
+> The multiline response reader could loop infinitely if the server
+> disconnected mid-response. Now returns ConnectionError on unexpected EOF.
+
+- MLSX parser now accepts cdir and pdir type values (#139)
+
+> RFC 3659 defines cdir (current directory) and pdir (parent directory)
+> as standard MLSX type values. Most FTP servers include these in MLSD
+> output for . and .. entries.
+
+- MLSX unix.mode accepts 4-digit octal modes (#140)
+
+> - fix: MLSX unix.mode now accepts 4-digit octal modes
+>
+> Some FTP servers return 4-digit octal modes (e.g. 0755) in MLSX responses.
+> The parser now accepts both 3 and 4 digit modes by taking the last 3 chars.
+
+- abort() only reads second response when server sends 426 (#141)
+
+> Previously abort() always tried to read two responses, which could hang
+> if the server only sends one response (226). Now conditionally reads the
+> second response only when the first is 426 (TransferAborted).
+
+- DOS LIST parser handles comma-separated file sizes (#142)
+
+> - fix: DOS LIST parser now handles comma-separated file sizes
+>
+> Some FTP servers return file sizes with comma separators (e.g. 1,234,567).
+> The parser now strips commas before parsing the size.
+
+- remove redundant feature = "async-std" in cfg gate (#147)
+- correct doc(cfg) attribute on SecureError (#148)
+- parse_lstime adjusts year for future dates (#143)
+
+> - fix: parse_lstime now adjusts year for future dates
+>
+> When a LIST response contains a date more than 6 months in the future
+> (no year specified), it almost certainly refers to the previous year.
+> The parser now adjusts accordingly, matching the behavior of GNU ls.
+
+- DOS time parser handles space before AM/PM (#144)
+
+> - fix: DOS time parser now handles space before AM/PM
+>
+> Some FTP servers format DOS timestamps with a space before AM/PM
+> (e.g. '01:30 PM' vs '01:30PM'). The parser now tries both formats.
+
+- replace unwrap() panics on server-controlled data (#146)
+
+> - fix: replace unwrap() with error handling on server-controlled data
+>
+> Server responses parsed via unwrap() (EPSV port, SIZE value, MDTM
+> timestamp) could panic on malformed data. Now returns FtpError::BadResponse.
+
+- active mode uses EPRT for IPv6 connections (#145)
+
+> - fix: active mode uses EPRT for IPv6, fix unwrap panics
+>
+> The PORT command only supports IPv4. When connected via IPv6, the client
+> now uses EPRT instead. Also replaces unwrap() on local_addr() with
+> proper error handling.
 
 ## 8.0.1
 
-Released on 18/01/2026
+Released on 2026-01-18
+
+### Fixed
 
 - Fixed docs.rs build
 
 ## 8.0.0
 
-Released on 18/01/2026
+Released on 2026-01-18
 
-- [Issue 131](https://github.com/veeso/suppaftp/issues/131): Added new features to choose the backend for `rustls`:
-    - `rustls-ring`: use `ring` as crypto backend (default)
-    - `rustls-aws-lc-rs`: use `aws-lc-rs` as crypto backend
-    - Removed `rustls` feature. Use either `rustls-ring` or `rustls-aws-lc-rs` instead.
-    - Removed `async-rustls` feature. Use either `async-std-rustls-ring` or `async-std-rustls-aws-lc-rs` instead.
-    - Removed `tokio-rustls` feature. Use either `tokio-rustls-ring` or `tokio-rustls-aws-lc-rs` instead.
+### Breaking changes
 
-> [!CAUTION]
-> In case you're using `rustls`, `tokio-rustls`, or `async-rustls` features, you need to update your `Cargo.toml`
-> accordingly.
+- **deps:** Added new features to choose the backend for `rustls` (#132)
+
+> Update your Cargo.toml if you're using `rustls` to explicitly set the Rustls backend to use
+
+### Build
+
+- Breaking: **deps:** Added new features to choose the backend for `rustls` (#132)
+
+> - build(deps)!: Added new features to choose the backend for `rustls`
+>
+> Added `-aws-lc-rs` and `-ring` to all `rustls` features to allow choosing the backend. Removed all the `async-std-rustls`, `rustls`, and `tokio-rustls` features to prevent ambiguity.
 
 ## 7.1.0
 
-Released on 07/01/2026
+Released on 2026-01-07
 
-- [Issue 128](https://github.com/veeso/suppaftp/issues/128)
-    - Made `FileType` enum public
-    - Added `File::file_type()` method to retrieve the file type
-    - Deprecated `File::from_dos_line`,  `File::from_mlsx_line`, and `File::from_posix_line` methods in favor of
-      `ListParser::parse_dos`, `ListParser::parse_mlst`, `ListParser::parse_mlsd`, and `ListParser::parse_posix`
-      respectively.
-- [Issue 127](https://github.com/veeso/suppaftp/issues/127): Prevent commands which require a data connection to be
-  executed if there is already a data connection open.
+### Added
+
+- **list:** FileType enum is now public; deprecated File::from...line in favour of `LineParser` (#129)
+
+> It is now possible to retrieve the `FileType` from a file using `File::file_type()`.
+>
+> [Issue 128](https://github.com/veeso/suppaftp/issues/128)
+>
+> - Made `FileType` enum public
+> - Added `File::file_type()` method to retrieve the file type
+> - Deprecated `File::from_dos_line`, `File::from_mlsx_line`, and `File::from_posix_line` methods in favor of `ListParser::parse_dos`, `ListParser::parse_mlst`, `ListParser::parse_mlsd`, and `ListParser::parse_posix` respectively.
+
+### Fixed
+
+- Prevent commands which require a data connection to be executed if there is already a data connection open (#130)
+
+> - fix: Prevent commands which require a data connection from being executed if there is already a data connection open
+>
+> ftp should never allow this. Indeed, it currently causes the code to hang
 
 ## 7.0.7
 
-Released on 05/11/2025
+Released on 2025-11-05
 
-- [Issue 126](https://github.com/veeso/suppaftp/pull/126): re-export tls streams when using tokio
+### Fix
+
+- re-export tls streams when using tokio (#126)
 
 ## 7.0.6
 
-Released on 07/10/2025
+Released on 2025-10-07
 
-- [Issue 125](https://github.com/veeso/suppaftp/pull/125): Allow to access async_native_tls when using tokio
+### Fixed
+
+- Allow to access async_native_tls when using tokio (#125)
+- 7.0.6
 
 ## 7.0.5
 
-Released on 03/10/2025
+Released on 2025-10-03
 
-- Update `chrono` version to `0.4.25` to guarantee compatibility with `and_utc` method.
+### Build
+
+- Update chrono version (#124)
+
+> - update chrono version
+> - docs: 7.0.5
+>
+> ---
 
 ## 7.0.4
 
-Released on 22/09/2025
+Released on 2025-09-22
 
-- Exported `TlsStream` types for implementing functions that use the retrieved stream.
-    - `TlsStream` for sync ftp.
-    - `AsyncStdTlsStream` for async-std ftp.
-    - `TokioTlsStream` for tokio ftp.
+### Fixed
 
-## 7.0.3
+- docs.rs build
+- Exported `TlsStream` types for implementing functions that use the retrieved stream. (#122)
 
-Released on 31/08/2025
-
-- Just docs.rs whining like a baby he can't fix a single missing comma.
-
-## 7.0.1
-
-Released on 31/08/2025
-
-- fixed docs.rs build
+> - fix: Exported `TlsStream` types for implementing functions that use the retrieved stream.
+>
+> `TlsStream` for sync ftp.
+> `AsyncStdTlsStream` for async-std ftp.
 
 ## 7.0.0
 
-Released on 31/08/2025
+Released on 2025-08-31
 
-- **Breaking changes**:
-    - Removed `async` feature; use either `async-std` or `tokio`.
-    - Removed `async-native-tls`; use either `async-std-async-native-tls` (for `async-std`) or
-      `tokio-async-native-tls` (for `tokio`) instead.
-    - Renamed `async-native-tls-vendored` to `async-std-async-native-tls-vendored`.
-    - Removed `async-default-tls`.
-    - Removed `default-tls`
-    - Renamed `async-rustls` to `async-std-rustls`.
-- **Higher MSRV requirements**
-    - Now requires Rust edition 2024 (before: 2021)
-    - Now requires Rust version 1.85.1 or later (before: 1.80.1)
-- **Tokio support**:
-    - Added tokio support along with async-std.
-    - Use `tokio` feature to use tokio
-    - Use `tokio-rustls` feature to use tokio with rustls
-    - Use `tokio-async-native-tls` feature to use async-native-tls with tokio
-- **Custom Data commands**:
-    - Added `custom_data_command` to perform the execution of custom data commands.
-    - Added `close_data_connection` to close the `DataStream` once consumed after executing custom data commands.
-    - Made `get_lines_from_stream` public to easily read String lines from the `DataStream`.
+### Breaking changes
+
+- Tokio for a new async backend of suppaftp (#116)
+
+> Tokio for a new async backend of suppaftp (#116)
+
+### Added
+
+- Breaking: Tokio for a new async backend of suppaftp (#116)
+
+> - feat: add tokio for a new backend of suppaftp
+> - feat: make async-std and tokio backend parallel existed.
+> - fix: conflicting with tokio async backend and test container environment.
+> - fix: mismatched feature gates of async-native-tls-std, async-std; fix wrong ref.
+> - fix: Exports for async and features
+> - fix: fail-fast
+> - ci: Workflow
+> - test: tests
+> - docs: Features docs
+> - ci: Merged coverage workflow into tests
+> - ci: coverage
+>
+> ---
+
+- Custom Data commands (#117)
+
+> Added `custom_data_command` to perform the execution of custom data commands.
+> Added `close_data_connection` to close the `DataStream` once consumed after executing custom data commands.
+> Made `get_lines_from_stream` public to easily read String lines from the `DataStream`.
 
 ## 6.3.0
 
-Released on 05/06/2025
+Released on 2025-06-05
 
-- [Issue 85](https://github.com/veeso/suppaftp/issues/85): Fixed `retr` method signature on the `AsyncFtpStream` to
-  allow passing a closure taking the stream reader.
+### Fixed
 
-    ```rust
-    stream
-      .retr("test.txt", |mut reader| {
-            Box::pin(async move {
-                let mut buf = Vec::new();
-                reader.read_to_end(&mut buf).await.expect("failed to read stream");
-                Ok((buf, reader))
-            })
-        })
-        .await
-    ```
+- FEAT command response parser (#109)
 
-- [Issue 108](https://github.com/veeso/suppaftp/issues/108): fixed FEAT command response parser
+> The parser didn't fully respect the RFC 2389
+
+- **async:** Fixed `retr` method signature on the `AsyncFtpStream` to allow passing a closure taking the stream reader. (#110)
+
+> The signature of the `retr` method was not allowing any argument, because the dyn Read needs to be Unpin, but it's a mutable reference at the same time and this with Async causes several issues. The mutable reference is required by the finalize_retr_stream which is called immediately after calling the closure. Because of this, the signature has been changed to return both the result and the stream back to be able to finalize it.
+
+- 6.3.0
 
 ## 6.2.1
 
-Released on 13/05/2025
+Released on 2025-05-13
 
-- [Issue 106](https://github.com/veeso/suppaftp/issues/106): Fixed `list` related commands which failed if the file name
-  contained non UTF-8 characters.
-- MSRV updated to 1.80.1
+### Fixed
+
+- **chore:** Update/fix rustls example in readme (#104)
+- Fixed `list` related commands which failed if the file name contained non UTF8 characters (#107)
+
+> Changed the logic of get stream lines: use read_until and then convert to UTF8 lossy
+
+### Build
+
+- Updated dev-dependencies
 
 ## 6.2.0
 
-Released on 14/04/2025
+Released on 2025-04-14
 
-- [feat (BREAKING): `get_ref` for async tls stream was unnecessarily async](https://github.com/veeso/suppaftp/pull/103)
+### Breaking changes
+
+- `get_ref` for async tls stream was unnecessarily async
+
+> get_ref calls must remove await
+
+### Added
+
+- Breaking: `get_ref` for async tls stream was unnecessarily async
+
+> it was an async function, but it didn't make sense to be async and created issues when dealing with pooling
+
+### Fixed
+
+- set `get_ref` to sync, to acquire reference to internal tls stream. (#103)
+- unnecessary to_string
+- lint
 
 ## 6.1.1
 
-Released on 17/03/2025
+Released on 2025-03-17
 
-- added a couple of logs to debug streams.
+### Changed
+
+- **log:** added better logs for tracing streams
+
+### Fixed
+
+- **chore:** readme styles
 
 ## 6.1.0
 
-Released on 10/03/2025
+Released on 2025-03-10
 
-- [Issue 100](https://github.com/veeso/suppaftp/issues/100): Migrated away from unmaintained `async-tls` to
-  `futures-rustls`
-- [Issue 98](https://github.com/veeso/suppaftp/issues/98): doc: fixed minor typos that referenced `termscp`
+### Added
+
+- **deps:** migrated from async-tls to futures-rustls (#101)
+
+> async-tls is unmaintained and rustls has actually released an official version for async tls, so we should use that instead
+
+### Fixed
+
+- **ci:** coverage
+- doc: fix minor typos referencing 'termscp' in CONTRIBUTING.md (#98) (#99)
 
 ## 6.0.7
 
-- [Issue 88](https://github.com/veeso/suppaftp/issues/88): Removed `ip.is_private()` check on NAT workaround, which
-  prevented public IPs to be used for Natting.
+Released on 2025-01-18
+
+### Fixed
+
+- remove is_private check for nat workaround (#97)
+- 6.0.7
 
 ## 6.0.6
 
-Released on 17/01/2025
+Released on 2025-01-17
 
-- [Issue 95](https://github.com/veeso/suppaftp/issues/95): Fixed TLS Stream not properly closed when using rustls.
+### Fixed
+
+- msrv
+- close rustls stream on drop (#96)
+- suppaftp 6.0.6
 
 ## 6.0.5
 
-Released on 27/11/2024
+Released on 2024-11-27
 
-- [Force rustls to use ring](https://github.com/veeso/suppaftp/issues/94)
+### Fixed
+
+- **deps:** force rustls to use ring
+- ci
+- testcontainers for tests
 
 ## 6.0.4
 
-Released on 26/10/2024
+Released on 2024-10-26
 
-- Added `Sync` to client.
-- Added unit test to guarantee that sync FtpStream stays `Sync`
+### Fixed
+
+- FtpStream should be Sync
 
 ## 6.0.3
 
-Released on 15/10/2024
+Released on 2024-10-15
 
-- Added `Send` marker to the Closure:
-  `dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Output = FtpResult<TcpStream>> + Send>> + Send;`
-- Added unit test to guarantee that FtpStream stays `Send`
+### Fixed
+
+- Added `Send` marker to the Closure: `dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Output = FtpResult<TcpStream>> + Send>> + Send;`
 
 ## 6.0.2
 
-Released on 14/10/2024
+Released on 2024-10-14
 
-- [Issue 89](https://github.com/veeso/suppaftp/issues/89): added new `FtpStream::passive_stream_builder` to provide a
-  function to build the Passive mode `TcpStream` with a custom builder. This is useful if you need to use some proxy.
+### Fixed
+
+- Passive mode with custom provided TcpStream (#91)
+
+> - fix: Passive mode with custom provided TcpStream
+> - fix: ci
+> - fix: ci
 
 ## 6.0.1
 
-Released on 24/05/2024
+Released on 2024-05-24
 
-- [PR 84](https://github.com/veeso/suppaftp/pull/84): LIST with DOS lines parsed `%d-%m` but the correct syntax is
-  `%m-%d`
+### Fixed
+
+- docs
+- docs
+- ms-dos date format (#84)
+
+> - fix:ms-dos date format
+> - fix:ms-dos date format
+>
+> ---
 
 ## 6.0.0
 
-Released on 20/05/2024
+Released on 2024-05-20
 
-- feat!: `Response.body` now contains the entire response
-- feat!: `site()` and `custom_command` now return `FtpResult<Response>`
+### Breaking changes
+
+- `Response.body` now contains the entire response
+
+> `Response.body` now contains the entire response
+
+- `site()` and `custom_command` now return `FtpResult<Response>`
+
+> `site()` and `custom_command` now return `FtpResult<Response>`
+
+- 6.0.0
+
+> 6.0.0
+
+### Added
+
+- Breaking: `Response.body` now contains the entire response
+- Breaking: `site()` and `custom_command` now return `FtpResult<Response>`
+- Breaking: 6.0.0
+
+### Fixed
+
+- style flat stars badge
+- unique manifest
+- deps
+- lint
+- test
+- test
 
 ## 5.4.0
 
-Released on 18/05/2024
+Released on 2024-05-18
 
-- [Issue 70](https://github.com/veeso/suppaftp/issues/70): **SITE** Command
-- [Issue 75](https://github.com/veeso/suppaftp/issues/75): Public access to `connect_with_stream`
-- [Issue 76](https://github.com/veeso/suppaftp/issues/76): Support for **MLST** and **MLSD**
-- [PR 78](https://github.com/veeso/suppaftp/pull/78): Async SSL file uploads not properly closing
-- `custom_command`: added `custom_command` function to perform custom commands
+### Added
+
+- custom_command
+- SITE command
+- Support MLST and MLSD
+
+### Fixed
+
+- #75 Make function connect_with_stream public
+- lint
+- async
+- async
+- lint
 
 ## 5.3.1
 
-Released on 28/01/2024
+Released on 2024-01-28
 
-- Fixed [issue #69](https://github.com/veeso/suppaftp/issues/69): SyntaxError on name that starts with 2 numbers
+### Added
+
+- suppaftp 5.3.1
+
+### Fixed
+
+- issue #69 Syntax error on name that staqrts with 2 number
 
 ## 5.3.0
 
-Released on 06/01/2024
+Released on 2024-01-06
 
-- Fix [issue #64](https://github.com/veeso/suppaftp/issues/64): added active mode listener timeout
-- Fix [issue #66](https://github.com/veeso/suppaftp/issues/66): abort can be called without passing ownership to
-  data_stream
+### Added
+
+- active mode socket timeout (#68)
+
+> - feat: active mode socket timeout
+> - fix: build
+
+- release
 
 ## 5.2.2
 
-Released on 14/11/2023
+Released on 2023-11-14
 
-- Fix issue #61: Send + Sync trait to AsyncFtpStream/FtpStream
-- Fix issue #63: FEAT function hangs on async
+### Added
+
+- Send + Sync trait to AsyncFtpStream/FtpStream (#61)
+
+> - feat: Send trait to AsyncFtpStream/FtpStream
+> - fix: ci failing
+
+### Fixed
+
+- async feat function hang (#63)
+- format
 
 ## 5.2.1
 
-Released on 16/10/2023
+Released on 2023-10-16
 
-- Add POSIX setgid/setuid/sticky bit support: [PR59](https://github.com/veeso/suppaftp/pull/59)
+### Added
 
-Thanks to [@rye](https://github.com/rye)
+- deps
+- changelog
+- removed broken tests
+
+### Fixed
+
+- removed test
 
 ## 5.2.0
 
-Released on 07/09/2023
+Released on 2023-09-07
 
-- Implemented [RFC 2389](https://www.rfc-editor.org/rfc/rfc2389)
-    - Added `FEAT` command
-    - Added `OPTS` command
+### Added
 
-## 5.1.2
-
-Released on 14/06/2023
-
-- Added `clock` feature to chrono to overcome security issue with `time` <https://github.com/veeso/suppaftp/issues/46>
+- FEAT and OPTS commands (#51)
 
 ## 5.1.1
 
-Released on 03/04/2023
+Released on 2023-04-03
+
+### Added
 
 - `ImplFtpStream` and `ImplAsyncFtpStream` are now public
 
-## 5.1.0
-
-Released on 02/03/2023
-
-- Implemented new connection method `connect_timeout` with the possibility to specify a timeout on connect
-
-## 5.0.1
-
-Released on 26/02/2023
-
-- Exposed publicly `DataStream` and `AsyncDataStream`
-
-## 5.0.0
-
-Released on 24/02/2023
-
-- [Issue 33](https://github.com/veeso/suppaftp/issues/33) **‼️ BREAKING CHANGES ‼️**
-    - Features are now additive. This means that you can successfully build suppaftp with all the features enabled at
-      the same time.
-    - Ftp stream has now been split into different types:
-        - `FtpStream`: sync no-tls stream
-        - `NativeTlsFtpStream`: ftp stream with TLS with native-tls
-        - `RustlsFtpStream`: ftp stream with TLS with rustls
-        - `AsyncFtpStream`: async no-tls stream
-        - `AsyncNativeTlsFtpStream`: async ftp stream with TLS with async-native-tls
-        - `AsyncRustlsFtpStream`: async ftp stream with TLS with async-rustls
-
-## 4.7.0
-
-Released on 01/02/2023
-
-- [RFC 2428](https://www.rfc-editor.org/rfc/rfc2428) implementation
-    - [Issue 28](https://github.com/veeso/suppaftp/issues/28): Implemented Extended Passive mode (**EPSV**)
-    - [Issue 30](https://github.com/veeso/suppaftp/issues/30): Implemented EPRT
-- Updated suppaftp-cli to suppaftp 4.7.0
-
-## 4.6.1
-
-Released on 26/01/2023
-
-- `suppaftp::list::File` now derives the `core::hash::Hash` trait
-
-## 4.6.0
-
-Released on 09/01/2023
-
-- `MDTM` now returns `NaiveDateTime` since the command won't provide timezone
-
-## 4.5.3
-
-Released on 27/12/2022
-
-- Don't use read to string from stream, but read line
-- Response body is now bytes
-- Fixed [issue 24](https://github.com/veeso/suppaftp/issues/24)
-
 ## 4.5.2
 
-Released on 10/10/2022
+Released on 2022-10-10
 
-- Fixed missing export of tls stream
+### Fixed
+
+- tls::TlsConnector should be pub use
 
 ## 4.5.1
 
-Released on 08/10/2022
+Released on 2022-10-08
 
-- Export `TlsStream` when async secure
+### Fixed
 
-## 4.5.0
-
-Released on 08/10/2022
-
-- Added `native-tls-vendored` and `async-native-tls-vendored` features to link OpenSSL statically
-- suppaftp-cli as a separate package.
-- Rustls support
-- **‼️ BREAKING CHANGE**: refactored secure features:
-    - **REMOVED** `secure`/`async-secure` feature
-    - Use `native-tls` to enable TLS support with native-tls crate
-    - Use `async-native-tls` to enable async TLS support with async-native-tls crate
-    - Use `rustls` to enable TLS support with rustls crate
-    - Use `async-rustls` to enable TLS support with async-tls crate
+- async TlsConnector not exported
 
 ## 4.4.0
 
-Released on 02/08/2022
+Released on 2022-08-02
 
-- Added `set_passive_nat_workaround()` method to allow PASV with server behind NAT/proxy
+### FtpStream
 
-## 4.3.0
-
-Released on 27/06/2022
-
-- Added implicit FTPS support
-    - Added `connect_secure_implicit()` method
-    - Added `deprecated` feature to enable deprecated methods (required for implicit FTPS)
-
-## 4.2.0
-
-Released on 07/12/2021
-
-- **Active mode**
-    - suppaftp now supports Active-mode (credit [@devbydav](https://github.com/devbydav))
-    - You can change mode with `set_mode(Mode::Passive) or set_mode(Mode::Active)` whenever you want
-- **New commands**
-    - **Abort command**: implemented the `ABOR` FTP command
-    - **Append command**: implemented the `APPE` FTP command
-    - **Resume transfer command**: implemented the `REST` FTP command
-- **Logging**: `log` crate has been implemented for debugging. You can disable logging with `no-log` feature
-- Security
-    - **TlsStream shutdown**: fixed [issue 5](https://github.com/veeso/suppaftp/issues/5) (
-      credit [@devbydav](https://github.com/devbydav))
-- ❗ Breaking changes:
-    - `Response.code` renamed to `status`.
-    - status is no more a `u32`: from now on it will be an enum named `Status`.
-        - The status enum implements the `code()` method which will return the `u32` representation
-        - The status enum can be displayed and converted to string: this will return the description of the error code
-    - Changed `into_insecure()` to `clear_command_channel()`: the implementation of into_insecure was wrong and
-      inconsistent. What it actually does is to make the server not to encrypt the communication on the command channel.
-    - Removed `File::from_line`; use `File::try_from()` or `File::from_str()`
-
-## 4.1.3
-
-Released on 01/12/2021
-
-- UNIX file parser:
-    - Fixed file parsing, which didn't allow any other characters than alphanumerics for groups, users and dates
-- `put_file()` will now return the amount of bytes written
-- Updated dependencies
-
-## 4.1.2
-
-Released on 23/08/2021
-
-- Renamed `InvalidResponse` to `UnexpectedResponse`, which makes more sense
-- Renamed `File::from_unix_line` to `File::from_posix_line`
-- Renamed `UnixPexQuery` to `PosixPexQuery`
-- Made `parse_dostime` private
+- :set_nat_workaround() instead of feature flag "nat".
 
 ## 4.1.1
 
-Released on 22/08/2021
+Released on 2021-08-22
 
-- Fixed missing `cli/` directory on Cargo registry.
+### README
 
-## 4.1.0
+- syntax highlighting fix
 
-Released on 22/08/2021
-
-- Added `Response` struct, which will be returned in case of `InvalidResponse` error.
-    - This adds the possibility to get the exact error code and the message
-- Added **async** support
-- **API** changes
-    - renamed `simple_retr` to `retr_as_buffer`
-    - renamed `get` to `retr_as_stream`
-    - renamed `finalize_get_stream` to `finalize_retr_stream`
-- **LIST** command output parser
-    - Read more on [docs.rs](https://docs.rs/suppaftp/4.1.0/suppaftp/list/index.html)
-- Optimized code to reuse stream functions as much as possible
-- `size()` and `mdtm()` methods will return an option no more.
-- Improved code with linter
-- Added CI tests
-
-## 4.0.2
-
-Released on 09/01/2020
-
-- Fixed `finalize_get` and `finalize_put_stream`. Stream must be dropped before waiting for response.
-
-## 4.0.1
-
-Released on 10/12/2020
-
-- Added `finalize_get` method to terminate reader and `RETR` command
-
-## 4.0.0
-
-Released on 06/12/2020
-
-- Removed deprecated statements
-- Replaced openssl with native-tls
-- Added `put_with_stream` method
-- Added `get_welcome_msg` method
+> This fixes the syntax highlighting for the Rust code by using the `rust` language for the fenced code block.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/suppaftp", "crates/suppaftp-cli"]
 resolver = "3"
 
 [workspace.package]
-version = "11.0.0"
+version = "12.0.0"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]
 categories = ["asynchronous", "network-programming"]
 edition = "2024"
@@ -29,7 +29,7 @@ rpassword = "7.2"
 rustls-crate = { package = "rustls", version = "0.23", default-features = false }
 rustls-pki-types = "1"
 smol = "2"
-suppaftp = { path = "crates/suppaftp", version = "11" }
+suppaftp = { path = "crates/suppaftp", version = "12" }
 testcontainers = "0.28"
 thiserror = "2"
 tokio = "1"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ programming. It aims to be a complete, reliable and well-tested implementation o
   [rustls](https://crates.io/crates/rustls)
 - 🕙 First-class **sync and async** APIs, with [tokio](https://crates.io/crates/tokio) and
   [smol](https://crates.io/crates/smol) as async backends
-- ⬇️ **Stream-based** transfers (e.g. `put_with_stream`, `retr`) for fine-grained control over data connections
+- ⬇️ **Stream-based** transfers (e.g. `put_with_stream`, `retr_as_stream`) returning a self-finalizing
+  `TransferStream`: call `finish()` to complete the transfer, or just drop it
 - ↔️ Both **passive and active** transfer modes
 - 🌟 Wide command coverage, including `ABOR`, `APPE`, `REST`, `EPSV` and `EPRT`
 - 📑 Built-in parser for the **LIST** command output (POSIX and DOS formats) into structured `File` objects

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@
   - [Introduction 👋](#introduction-)
     - [Features ✨](#features-)
   - [Get started 🏁](#get-started-)
-    - [Migrating to self-finalizing streams (unreleased)](#migrating-to-self-finalizing-streams-unreleased)
     - [Cargo features](#cargo-features)
       - [SSL/TLS Support](#ssltls-support)
       - [Async support](#async-support)
@@ -116,54 +115,6 @@ To get started, first add **suppaftp** to your dependencies:
 ```toml
 suppaftp = "^11"
 ```
-
-### Migrating to self-finalizing streams (unreleased)
-
-The next major release changes the streaming API from version 11. The changes below
-apply to this development branch and are not available in the published version 11.
-
-- `put_with_stream`, `append_with_stream`, `retr_as_stream`, and
-  `custom_data_command` return a `TransferStream` that owns transfer cleanup.
-- Replace `ftp.finalize_put_stream(stream)` and `ftp.finalize_retr_stream(stream)`
-  with `stream.finish()`. For Tokio and smol, use `stream.finish().await`.
-  `close_data_connection` is removed; finish or abort the transfer instead.
-- `abort` takes the `TransferStream` returned by that client.
-- Async `retr` callbacks receive a `TransferStream` and return it with the callback
-  result as `(value, stream)`. A callback that returns an error drops its stream,
-  leaving cleanup to the next command.
-- `ftp.get_ref()` returns a `ControlSocket` guard that dereferences to the TCP
-  socket. Async clients require `ftp.get_ref().await`. Keep the guard short-lived;
-  release it before calling another client method or finishing a transfer. In the
-  sync client, release it before dropping a transfer too, to avoid a deadlock.
-- To access the data connection, use `transfer.get_ref()` or `transfer.get_mut()`.
-  If you wrap a transfer in a buffered reader or writer, flush any buffered writes
-  and recover the transfer with `into_inner()` before calling `finish()`.
-
-```rust
-use std::io::Write;
-use suppaftp::FtpStream;
-
-let mut ftp = FtpStream::connect("127.0.0.1:21")?;
-ftp.login("test", "test")?;
-let mut upload = ftp.put_with_stream("hello.txt")?;
-upload.write_all(b"hello")?;
-upload.finish()?;
-ftp.noop()?;
-Ok::<(), Box<dyn std::error::Error>>(())
-```
-
-Always finish the transfer before issuing another command, including when the
-transfer runs in another thread or task. `finish()` closes the data connection and
-checks the server's completion reply. Dropping a transfer loses its result and does
-not guarantee that all data was transferred. Sync drop waits for the completion
-reply and can block; async drop defers reading that reply to the next command.
-Async drop also skips the TLS close notification, which strict FTPS servers may
-reject, so prefer `finish().await` for successful transfers.
-
-Cancelling async `finish()` leaves the completion reply for the next command.
-If that command is cancelled while draining the reply, a later command resumes
-reading it. This recovery does not extend to arbitrary commands or `abort()`;
-reconnect if their futures are cancelled after polling begins.
 
 ### Cargo features
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
   - [Introduction 👋](#introduction-)
     - [Features ✨](#features-)
   - [Get started 🏁](#get-started-)
+    - [Migrating to self-finalizing streams (unreleased)](#migrating-to-self-finalizing-streams-unreleased)
     - [Cargo features](#cargo-features)
       - [SSL/TLS Support](#ssltls-support)
       - [Async support](#async-support)
@@ -96,7 +97,7 @@ programming. It aims to be a complete, reliable and well-tested implementation o
 - 🕙 First-class **sync and async** APIs, with [tokio](https://crates.io/crates/tokio) and
   [smol](https://crates.io/crates/smol) as async backends
 - ⬇️ **Stream-based** transfers (e.g. `put_with_stream`, `retr_as_stream`) returning a self-finalizing
-  `TransferStream`: call `finish()` to complete the transfer, or just drop it
+  `TransferStream`: call `finish()` to check the transfer result; dropping it attempts cleanup
 - ↔️ Both **passive and active** transfer modes
 - 🌟 Wide command coverage, including `ABOR`, `APPE`, `REST`, `EPSV` and `EPRT`
 - 📑 Built-in parser for the **LIST** command output (POSIX and DOS formats) into structured `File` objects
@@ -113,8 +114,56 @@ programming. It aims to be a complete, reliable and well-tested implementation o
 To get started, first add **suppaftp** to your dependencies:
 
 ```toml
-suppaftp = "^8"
+suppaftp = "^11"
 ```
+
+### Migrating to self-finalizing streams (unreleased)
+
+The next major release changes the streaming API from version 11. The changes below
+apply to this development branch and are not available in the published version 11.
+
+- `put_with_stream`, `append_with_stream`, `retr_as_stream`, and
+  `custom_data_command` return a `TransferStream` that owns transfer cleanup.
+- Replace `ftp.finalize_put_stream(stream)` and `ftp.finalize_retr_stream(stream)`
+  with `stream.finish()`. For Tokio and smol, use `stream.finish().await`.
+  `close_data_connection` is removed; finish or abort the transfer instead.
+- `abort` takes the `TransferStream` returned by that client.
+- Async `retr` callbacks receive a `TransferStream` and return it with the callback
+  result as `(value, stream)`. A callback that returns an error drops its stream,
+  leaving cleanup to the next command.
+- `ftp.get_ref()` returns a `ControlSocket` guard that dereferences to the TCP
+  socket. Async clients require `ftp.get_ref().await`. Keep the guard short-lived;
+  release it before calling another client method or finishing a transfer. In the
+  sync client, release it before dropping a transfer too, to avoid a deadlock.
+- To access the data connection, use `transfer.get_ref()` or `transfer.get_mut()`.
+  If you wrap a transfer in a buffered reader or writer, flush any buffered writes
+  and recover the transfer with `into_inner()` before calling `finish()`.
+
+```rust
+use std::io::Write;
+use suppaftp::FtpStream;
+
+let mut ftp = FtpStream::connect("127.0.0.1:21")?;
+ftp.login("test", "test")?;
+let mut upload = ftp.put_with_stream("hello.txt")?;
+upload.write_all(b"hello")?;
+upload.finish()?;
+ftp.noop()?;
+Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Always finish the transfer before issuing another command, including when the
+transfer runs in another thread or task. `finish()` closes the data connection and
+checks the server's completion reply. Dropping a transfer loses its result and does
+not guarantee that all data was transferred. Sync drop waits for the completion
+reply and can block; async drop defers reading that reply to the next command.
+Async drop also skips the TLS close notification, which strict FTPS servers may
+reject, so prefer `finish().await` for successful transfers.
+
+Cancelling async `finish()` leaves the completion reply for the next command.
+If that command is cancelled while draining the reply, a later command resumes
+reading it. This recovery does not extend to arbitrary commands or `abort()`;
+reconnect if their futures are cancelled after polling begins.
 
 ### Cargo features
 
@@ -159,9 +208,9 @@ If you want to enable **support for FTPS**, you must enable the `native-tls` or 
 cargo dependencies, based on the TLS provider you prefer.
 
 ```toml
-suppaftp = { version = "^8", features = ["native-tls"] }
+suppaftp = { version = "^11", features = ["native-tls"] }
 # or
-suppaftp = { version = "^8", features = ["rustls-aws-lc-rs"] }
+suppaftp = { version = "^11", features = ["rustls-aws-lc-rs"] }
 ```
 
 > [!NOTE]
@@ -175,7 +224,7 @@ use [smol](https://crates.io/crates/smol) or `tokio` feature, to use [tokio](htt
 as backend, in your cargo dependencies.
 
 ```toml
-suppaftp = { version = "^8", features = ["tokio"] }
+suppaftp = { version = "^11", features = ["tokio"] }
 ```
 
 > [!CAUTION]

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,11 +1,17 @@
 [changelog]
+header = """
+# Changelog
+
+All notable changes to this project are documented in this file.
+"""
 body = """
+
 ## {{ version | trim_start_matches(pat="v") }}
 
 Released on {{ timestamp | date(format="%Y-%m-%d") }}
 {%- if commits | filter(attribute="breaking", value=true) | length > 0 %}
 
-### ⚠ Breaking Changes
+### Breaking changes
 
 {%- for commit in commits | filter(attribute="breaking", value=true) %}
 - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | trim }}
@@ -17,15 +23,16 @@ Released on {{ timestamp | date(format="%Y-%m-%d") }}
 {%- for group, commits in commits | group_by(attribute="group") %}
 
 ### {{ group | upper_first }}
+
 {% for commit in commits %}
-- {% if commit.breaking %}💥 {% endif %}{% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | trim }}
+- {% if commit.breaking %}Breaking: {% endif %}{% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | trim }}
   {%- if commit.body %}
   > {{ commit.body | split(pat="\n") | join(sep="\n  > ") }}
   {%- endif %}
 {%- endfor %}
 {%- endfor %}
 """
-trim = false
+trim = true
 
 [git]
 conventional_commits = true
@@ -36,8 +43,8 @@ commit_parsers = [
   { message = "^fix", group = "Fixed" },
   { message = "^refactor", group = "Changed" },
   { message = "^perf", group = "Performance" },
-  { message = "^doc", group = "Documentation" },
-  { message = "^test", group = "Testing" },
+  { message = "^docs", skip = true },
+  { message = "^test", skip = true },
   { message = "^ci", skip = true },
   { message = "^chore", skip = true },
 ]

--- a/crates/suppaftp/Cargo.toml
+++ b/crates/suppaftp/Cargo.toml
@@ -37,7 +37,7 @@ rustls-crate = { workspace = true, features = ["logging", "std", "tls12"], optio
 rustls-pki-types = { workspace = true, features = ["alloc"], optional = true }
 smol = { workspace = true, optional = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "net", "rt", "time"], optional = true }
+tokio = { workspace = true, features = ["io-util", "net", "rt", "sync", "time"], optional = true }
 tokio-rustls-crate = { workspace = true, features = ["logging", "tls12"], optional = true }
 
 [dev-dependencies]

--- a/crates/suppaftp/src/async_ftp.rs
+++ b/crates/suppaftp/src/async_ftp.rs
@@ -36,7 +36,9 @@ pub mod smol {
     use crate::async_ftp::smol_ftp::AsyncNativeTlsStream;
     #[cfg(feature = "smol")]
     #[cfg_attr(docsrs, doc(cfg(feature = "smol")))]
-    pub use crate::async_ftp::smol_ftp::DataStream as AsyncDataStream;
+    pub use crate::async_ftp::smol_ftp::{
+        ControlSocket, DataStream as AsyncDataStream, TransferStream,
+    };
 
     #[cfg(feature = "smol-async-native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "smol-async-native-tls")))]
@@ -100,7 +102,8 @@ pub mod tokio {
     )]
     pub use super::tokio_ftp::AsyncNativeTlsStream;
     pub use super::tokio_ftp::{
-        DataStream as AsyncDataStream, TokioPassiveStreamBuilder, TokioTlsStream,
+        ControlSocket, DataStream as AsyncDataStream, TokioPassiveStreamBuilder, TokioTlsStream,
+        TransferStream,
     };
 
     #[cfg(feature = "tokio-async-native-tls")]

--- a/crates/suppaftp/src/async_ftp/smol_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp.rs
@@ -138,6 +138,7 @@ where
     }
 
     /// Switch to secure mode if possible (FTPS), using a provided SSL configuration.
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] before sending `AUTH` if a transfer is alive.
     /// This method does nothing if the connect is already secured.
     ///
     /// ## Example
@@ -160,6 +161,10 @@ where
         tls_connector: impl AsyncTlsConnector<Stream = T> + Send + Sync + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
+        // Reject a live transfer before asking the server to change the control protocol.
+        if Arc::strong_count(&self.control) != 1 {
+            return Err(FtpError::DataConnectionAlreadyOpen);
+        }
         debug!("Initializing TLS auth");
         {
             let mut cc = self.control().await?;
@@ -333,9 +338,14 @@ where
     /// Perform clear command channel (CCC).
     /// Once the command is performed, the command channel will be encrypted no more.
     /// The data stream will still be secure.
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] before sending `CCC` if a transfer is alive.
     #[cfg(feature = "async-secure")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-secure")))]
     pub async fn clear_command_channel(mut self) -> FtpResult<Self> {
+        // Reject a live transfer before asking the server to change the control protocol.
+        if Arc::strong_count(&self.control) != 1 {
+            return Err(FtpError::DataConnectionAlreadyOpen);
+        }
         {
             let mut cc = self.control().await?;
             // Ask the server to stop securing data
@@ -461,8 +471,8 @@ where
     ///
     /// `reader` is an async pinned closure that takes the [`TransferStream<T>`] and returns
     /// both the result `U` and the [`TransferStream<T>`] back in a tuple `(U, TransferStream<T>)`.
-    /// The stream is then finished by this method, so the control connection is left in sync
-    /// whether `reader` succeeded or not.
+    /// The stream is finished on callback success. If `reader` returns an error and drops the
+    /// stream, the next command drains its completion reply before sending anything.
     ///
     /// > Warning: Don't call [`TransferStream::finish`] inside `reader`; return the stream instead.
     pub async fn retr<S, F, U>(&mut self, file_name: S, mut reader: F) -> FtpResult<U>
@@ -642,6 +652,7 @@ where
     /// The data connection is closed and the server's abort replies (`426` followed by `226`,
     /// or a single `226`) are consumed, so the control connection is ready for the next command.
     /// `transfer` must have been obtained from this client.
+    /// This operation is not cancellation-safe: reconnect if its future is cancelled after polling.
     ///
     /// # Errors
     ///
@@ -981,7 +992,12 @@ where
             .await?;
         Ok((
             response,
-            TransferStream::new(data_stream, Arc::clone(&self.control), direction),
+            TransferStream::new(
+                data_stream,
+                Arc::clone(&self.control),
+                direction,
+                Arc::clone(&cc.pending_transfer_reply),
+            ),
         ))
     }
 
@@ -1458,7 +1474,7 @@ mod test {
             let mut stream = stream.passive_stream_builder(move |addr| {
                 let container_t = container_t.clone();
                 Box::pin(async move {
-                    let mut addr = addr.clone();
+                    let mut addr = addr;
                     let port = addr.port();
                     let mapped = container_t.get_mapped_port(port);
 
@@ -2150,7 +2166,7 @@ mod test {
         let ftp_stream = ftp_stream.passive_stream_builder(move |addr| {
             let container_t = container_t.clone();
             Box::pin(async move {
-                let mut addr = addr.clone();
+                let mut addr = addr;
                 let port = addr.port();
                 let mapped = container_t.get_mapped_port(port);
 

--- a/crates/suppaftp/src/async_ftp/smol_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp.rs
@@ -2,8 +2,10 @@
 //!
 //! This module contains the definition for smol async implementation of suppaftp
 
+mod control;
 mod data_stream;
 mod tls;
+mod transfer_stream;
 
 use std::future::Future;
 #[cfg(not(feature = "async-secure"))]
@@ -11,15 +13,17 @@ use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::string::String;
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 // export
+pub use control::ControlSocket;
+use control::{ControlChannel, SharedControl};
 pub use data_stream::DataStream;
 use smol::future::FutureExt;
-use smol::io::{
-    AsyncBufReadExt, AsyncRead as Read, AsyncWrite as Write, AsyncWriteExt, BufReader, copy,
-};
+use smol::io::{AsyncBufReadExt, AsyncRead as Read, BufReader, copy};
+use smol::lock::MutexGuard;
 use smol::net::{AsyncToSocketAddrs as ToSocketAddrs, TcpListener, TcpStream};
 #[cfg(feature = "async-secure")]
 pub use tls::AsyncTlsConnector;
@@ -28,6 +32,8 @@ pub use tls::{AsyncNativeTlsConnector, AsyncNativeTlsStream};
 pub use tls::{AsyncNoTlsStream, SmolTlsStream};
 #[cfg(any(feature = "smol-rustls-aws-lc-rs", feature = "smol-rustls-ring"))]
 pub use tls::{AsyncRustlsConnector, AsyncRustlsStream};
+use transfer_stream::Direction;
+pub use transfer_stream::TransferStream;
 
 use super::super::Status;
 use super::super::regex::{EPSV_PORT_RE, MDTM_RE, SIZE_RE};
@@ -46,21 +52,21 @@ pub type SmolPassiveStreamBuilder = dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Out
     + Sync;
 
 /// Stream to interface with the FTP server. This interface is only for the command stream.
+///
+/// The control connection is shared with the [`TransferStream`]s handed out by the data
+/// commands, so that each transfer can close its data connection and read the completion reply
+/// on its own; see [`TransferStream`] for details.
 pub struct ImplAsyncFtpStream<T>
 where
     T: SmolTlsStream + Send,
 {
-    reader: BufReader<DataStream<T>>,
+    /// Control connection, locked for the duration of each command.
+    control: SharedControl<T>,
     mode: Mode,
     nat_workaround: bool,
     welcome_msg: Option<String>,
     active_timeout: Duration,
     passive_stream_builder: Box<SmolPassiveStreamBuilder>,
-    /// flags whether a data connection is currently open
-    ///
-    /// Since it isn't possible to have multiple data connections at the same time,
-    /// this flag is used to track whether a data connection is currently open.
-    data_connection_open: bool,
     #[cfg(not(feature = "async-secure"))]
     marker: PhantomData<T>,
     #[cfg(feature = "async-secure")]
@@ -105,11 +111,10 @@ where
     pub async fn connect_with_stream(stream: TcpStream) -> FtpResult<Self> {
         debug!("Established connection with server");
         let mut ftp_stream = ImplAsyncFtpStream {
-            reader: BufReader::new(DataStream::Tcp(stream)),
+            control: ControlChannel::shared(DataStream::Tcp(stream)),
             #[cfg(not(feature = "async-secure"))]
             marker: PhantomData {},
             mode: Mode::Passive,
-            data_connection_open: false,
             nat_workaround: false,
             passive_stream_builder: Self::default_passive_stream_builder(),
             welcome_msg: None,
@@ -120,7 +125,8 @@ where
             active_timeout: Duration::from_secs(60),
         };
         debug!("Reading server response...");
-        match ftp_stream.read_response(Status::Ready).await {
+        let ready = ftp_stream.read_response(Status::Ready).await;
+        match ready {
             Ok(response) => {
                 let welcome_msg = response.as_string().ok();
                 debug!("Server READY; response: {:?}", welcome_msg);
@@ -150,26 +156,29 @@ where
     #[cfg(feature = "async-secure")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-secure")))]
     pub async fn into_secure(
-        mut self,
+        self,
         tls_connector: impl AsyncTlsConnector<Stream = T> + Send + Sync + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Initializing TLS auth");
-        // Ask the server to start securing data.
-        self.perform(Command::Auth).await?;
-        self.read_response(Status::AuthOk).await?;
+        {
+            let mut cc = self.control().await?;
+            // Ask the server to start securing data.
+            cc.perform(Command::Auth).await?;
+            cc.read_response(Status::AuthOk).await?;
+        }
         debug!("TLS OK; initializing ssl stream");
+        let plain = control::into_exclusive(self.control)?
+            .reader
+            .into_inner()
+            .into_tcp_stream()?;
         let stream = tls_connector
-            .connect(
-                domain,
-                self.reader.into_inner().into_tcp_stream()?.to_owned(),
-            )
+            .connect(domain, plain)
             .await
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
-        let mut secured_ftp_tream = ImplAsyncFtpStream {
-            reader: BufReader::new(DataStream::Ssl(Box::new(stream))),
+        let secured_ftp_tream = ImplAsyncFtpStream {
+            control: ControlChannel::shared(DataStream::Ssl(Box::new(stream))),
             mode: self.mode,
-            data_connection_open: self.data_connection_open,
             nat_workaround: self.nat_workaround,
             passive_stream_builder: self.passive_stream_builder,
             tls_ctx: Some(Box::new(tls_connector)),
@@ -177,14 +186,15 @@ where
             welcome_msg: self.welcome_msg,
             active_timeout: self.active_timeout,
         };
-        // Set protection buffer size
-        secured_ftp_tream.perform(Command::Pbsz(0)).await?;
-        secured_ftp_tream.read_response(Status::CommandOk).await?;
-        // Change the level of data protectio to Private
-        secured_ftp_tream
-            .perform(Command::Prot(ProtectionLevel::Private))
-            .await?;
-        secured_ftp_tream.read_response(Status::CommandOk).await?;
+        {
+            let mut cc = secured_ftp_tream.control().await?;
+            // Set protection buffer size
+            cc.perform(Command::Pbsz(0)).await?;
+            cc.read_response(Status::CommandOk).await?;
+            // Change the level of data protectio to Private
+            cc.perform(Command::Prot(ProtectionLevel::Private)).await?;
+            cc.read_response(Status::CommandOk).await?;
+        }
         Ok(secured_ftp_tream)
     }
 
@@ -218,33 +228,18 @@ where
         debug!("Connecting to server (secure)");
         let stream = TcpStream::connect(addr)
             .await
-            .map_err(FtpError::ConnectionError)
-            .map(|stream| {
-                debug!("Established connection with server");
-                Self {
-                    reader: BufReader::new(DataStream::Tcp(stream)),
-                    mode: Mode::Passive,
-                    data_connection_open: false,
-                    nat_workaround: false,
-                    welcome_msg: None,
-                    passive_stream_builder: Self::default_passive_stream_builder(),
-                    tls_ctx: None,
-                    domain: None,
-                    active_timeout: Duration::from_secs(60),
-                }
-            })?;
+            .map_err(FtpError::ConnectionError)?;
         debug!("Established connection with server");
         debug!("TLS OK; initializing ssl stream");
         let stream = tls_connector
-            .connect(domain, stream.reader.into_inner().into_tcp_stream()?)
+            .connect(domain, stream)
             .await
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
         let mut stream = ImplAsyncFtpStream {
-            reader: BufReader::new(DataStream::Ssl(stream.into())),
+            control: ControlChannel::shared(DataStream::Ssl(Box::new(stream))),
             mode: Mode::Passive,
             nat_workaround: false,
-            data_connection_open: false,
             passive_stream_builder: Self::default_passive_stream_builder(),
             tls_ctx: Some(Box::new(tls_connector)),
             domain: Some(String::from(domain)),
@@ -252,14 +247,10 @@ where
             active_timeout: Duration::from_secs(60),
         };
         debug!("Reading server response...");
-        match stream.read_response(Status::Ready).await {
-            Ok(response) => {
-                let welcome_msg = response.as_string().ok();
-                debug!("Server READY; response: {:?}", welcome_msg);
-                stream.welcome_msg = welcome_msg;
-            }
-            Err(err) => return Err(err),
-        }
+        let response = stream.read_response(Status::Ready).await?;
+        let welcome_msg = response.as_string().ok();
+        debug!("Server READY; response: {:?}", welcome_msg);
+        stream.welcome_msg = welcome_msg;
 
         Ok(stream)
     }
@@ -302,24 +293,38 @@ where
         self.nat_workaround = nat_workaround;
     }
 
-    /// Returns a reference to the underlying TcpStream.
-    pub fn get_ref(&self) -> &TcpStream {
-        self.reader.get_ref().get_ref()
+    /// Returns a locked view of the underlying control [`TcpStream`].
+    ///
+    /// The returned [`ControlSocket`] dereferences to the socket and keeps the control connection
+    /// locked while alive, so drop it before finishing a [`TransferStream`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use suppaftp::smol::AsyncFtpStream;
+    ///
+    /// # async fn run() {
+    /// let stream = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+    /// stream.get_ref().await.set_nodelay(true).unwrap();
+    /// # }
+    /// ```
+    pub async fn get_ref(&self) -> ControlSocket<'_, T> {
+        ControlSocket::new(self.control.lock().await)
     }
 
     /// Log in to the FTP server.
     pub async fn login<S: AsRef<str>>(&mut self, user: S, password: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Signin in with user '{}'", user.as_ref());
-        self.perform(Command::User(user.as_ref().to_string()))
-            .await?;
-        let response = self
+        cc.perform(Command::User(user.as_ref().to_string())).await?;
+        let response = cc
             .read_response_in(&[Status::LoggedIn, Status::NeedPassword])
             .await?;
         if response.status == Status::NeedPassword {
             debug!("Password is required");
-            self.perform(Command::Pass(password.as_ref().to_string()))
+            cc.perform(Command::Pass(password.as_ref().to_string()))
                 .await?;
-            self.read_response(Status::LoggedIn).await?;
+            cc.read_response(Status::LoggedIn).await?;
         }
         debug!("Login OK");
         Ok(())
@@ -331,39 +336,48 @@ where
     #[cfg(feature = "async-secure")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-secure")))]
     pub async fn clear_command_channel(mut self) -> FtpResult<Self> {
-        // Ask the server to stop securing data
-        debug!("performing clear command channel");
-        self.perform(Command::ClearCommandChannel).await?;
-        self.read_response(Status::CommandOk).await?;
+        {
+            let mut cc = self.control().await?;
+            // Ask the server to stop securing data
+            debug!("performing clear command channel");
+            cc.perform(Command::ClearCommandChannel).await?;
+            cc.read_response(Status::CommandOk).await?;
+        }
         trace!("CCC OK");
-        self.reader = BufReader::new(DataStream::Tcp(self.reader.into_inner().into_tcp_stream()?));
+        let plain = control::into_exclusive(self.control)?
+            .reader
+            .into_inner()
+            .into_tcp_stream()?;
+        self.control = ControlChannel::shared(DataStream::Tcp(plain));
         Ok(self)
     }
 
     /// Change the current directory to the path specified.
     pub async fn cwd<S: AsRef<str>>(&mut self, path: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Changing working directory to {}", path.as_ref());
-        self.perform(Command::Cwd(path.as_ref().to_string()))
-            .await?;
-        self.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
+        cc.perform(Command::Cwd(path.as_ref().to_string())).await?;
+        cc.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
             .await
             .map(|_| ())
     }
 
     /// Move the current directory to the parent directory.
     pub async fn cdup(&mut self) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Going to parent directory");
-        self.perform(Command::Cdup).await?;
-        self.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
+        cc.perform(Command::Cdup).await?;
+        cc.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
             .await
             .map(|_| ())
     }
 
     /// Gets the current directory
     pub async fn pwd(&mut self) -> FtpResult<String> {
+        let mut cc = self.control().await?;
         debug!("Getting working directory");
-        self.perform(Command::Pwd).await?;
-        let response = self.read_response(Status::PathCreated).await?;
+        cc.perform(Command::Pwd).await?;
+        let response = cc.read_response(Status::PathCreated).await?;
         let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
         let status = response.status;
         match (body.find('"'), body.rfind('"')) {
@@ -377,27 +391,30 @@ where
 
     /// This does nothing. This is usually just used to keep the connection open.
     pub async fn noop(&mut self) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Pinging server");
-        self.perform(Command::Noop).await?;
-        self.read_response(Status::CommandOk).await.map(|_| ())
+        cc.perform(Command::Noop).await?;
+        cc.read_response(Status::CommandOk).await.map(|_| ())
     }
 
     /// The EPRT command allows for the specification of an extended address
     /// for the data connection. The extended address MUST consist of the
     /// network protocol as well as the network and transport addresses
     pub async fn eprt(&mut self, address: SocketAddr) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("EPRT with address {address}");
-        self.perform(Command::Eprt(address)).await?;
-        self.read_response(Status::CommandOk).await.map(|_| ())
+        cc.perform(Command::Eprt(address)).await?;
+        cc.read_response(Status::CommandOk).await.map(|_| ())
     }
 
     /// This creates a new directory on the server.
     pub async fn mkdir<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Creating directory at {}", pathname.as_ref());
-        self.perform(Command::Mkd(pathname.as_ref().to_string()))
+        cc.perform(Command::Mkd(pathname.as_ref().to_string()))
             .await?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 257.
-        self.read_response_in(&[Status::PathCreated, Status::CommandOk])
+        cc.read_response_in(&[Status::PathCreated, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -405,32 +422,35 @@ where
     /// Sets the type of file to be transferred. That is the implementation
     /// of `TYPE` command.
     pub async fn transfer_type(&mut self, file_type: FileType) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Setting transfer type {}", file_type);
-        self.perform(Command::Type(file_type)).await?;
-        self.read_response(Status::CommandOk).await.map(|_| ())
+        cc.perform(Command::Type(file_type)).await?;
+        cc.read_response(Status::CommandOk).await.map(|_| ())
     }
 
     /// Quits the current FTP session.
     pub async fn quit(&mut self) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Quitting stream");
-        self.perform(Command::Quit).await?;
-        self.read_response(Status::Closing).await.map(|_| ())
+        cc.perform(Command::Quit).await?;
+        cc.read_response(Status::Closing).await.map(|_| ())
     }
 
     /// Renames the file from_name to to_name
     pub async fn rename<S: AsRef<str>>(&mut self, from_name: S, to_name: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!(
             "Renaming '{}' to '{}'",
             from_name.as_ref(),
             to_name.as_ref()
         );
-        self.perform(Command::RenameFrom(from_name.as_ref().to_string()))
+        cc.perform(Command::RenameFrom(from_name.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestFilePending).await?;
-        self.perform(Command::RenameTo(to_name.as_ref().to_string()))
+        cc.read_response(Status::RequestFilePending).await?;
+        cc.perform(Command::RenameTo(to_name.as_ref().to_string()))
             .await?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
-        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
+        cc.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -439,89 +459,87 @@ where
     /// to download from FTP and `reader` is the function which operates with the
     /// data stream opened.
     ///
-    /// `reader` is an async pinned closure that takes the [`DataStream<T>`] and returns
-    /// both the result `U` and the [`DataStream<T>`] back in a tuple `(U, DataStream<T>)`.
+    /// `reader` is an async pinned closure that takes the [`TransferStream<T>`] and returns
+    /// both the result `U` and the [`TransferStream<T>`] back in a tuple `(U, TransferStream<T>)`.
+    /// The stream is then finished by this method, so the control connection is left in sync
+    /// whether `reader` succeeded or not.
     ///
-    /// This is necessary because the stream is then finalized with `finalize_retr_stream()`
-    /// within this method.
-    ///
-    /// > Warning: Don't call [`Self::finalize_retr_stream`] manually, otherwise this will cause an error.
+    /// > Warning: Don't call [`TransferStream::finish`] inside `reader`; return the stream instead.
     pub async fn retr<S, F, U>(&mut self, file_name: S, mut reader: F) -> FtpResult<U>
     where
         F: FnMut(
-            DataStream<T>,
-        ) -> Pin<Box<dyn Future<Output = FtpResult<(U, DataStream<T>)>> + Send>>,
+            TransferStream<T>,
+        )
+            -> Pin<Box<dyn Future<Output = FtpResult<(U, TransferStream<T>)>> + Send>>,
         S: AsRef<str>,
     {
-        match self.retr_as_stream(file_name).await {
-            Ok(stream) => {
-                let (result, stream) = reader(stream).await?;
-                self.finalize_retr_stream(stream).await?;
-                Ok(result)
-            }
-            Err(err) => Err(err),
-        }
+        let stream = self.retr_as_stream(file_name).await?;
+        let (result, stream) = reader(stream).await?;
+        stream.finish().await?;
+        Ok(result)
     }
 
-    /// Retrieves the file name specified from the server as a readable stream.
-    /// This method is a more complicated way to retrieve a file.
-    /// The reader returned should be dropped.
-    /// Also you will have to read the response to make sure it has the correct value.
-    /// Once file has been read, call `finalize_retr_stream()`
+    /// Retrieves the file `file_name` from the server as a readable [`TransferStream`].
+    ///
+    /// Read the payload from the returned stream, then call [`TransferStream::finish`] to close
+    /// the data connection and read the server's completion reply. Until then any other data
+    /// command fails with [`FtpError::DataConnectionAlreadyOpen`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use suppaftp::smol::AsyncFtpStream;
+    /// use smol::io::AsyncReadExt;
+    ///
+    /// # async fn run() {
+    /// let mut ftp = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+    /// ftp.login("test", "test").await.unwrap();
+    /// let mut download = ftp.retr_as_stream("hello.txt").await.unwrap();
+    /// let mut buf = Vec::new();
+    /// download.read_to_end(&mut buf).await.unwrap();
+    /// download.finish().await.unwrap();
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server refuses the `RETR` command.
     pub async fn retr_as_stream<S: AsRef<str>>(
         &mut self,
         file_name: S,
-    ) -> FtpResult<DataStream<T>> {
+    ) -> FtpResult<TransferStream<T>> {
         debug!("Retrieving '{}'", file_name.as_ref());
-        let (_, data_stream) = self
-            .data_command_with_response(
+        let (_, stream) = self
+            .open_transfer(
                 Command::Retr(file_name.as_ref().to_string()),
                 &[Status::AboutToSend, Status::AlreadyOpen],
+                Direction::Download,
             )
             .await?;
-        Ok(data_stream)
-    }
-
-    /// Finalize retr stream; must be called once the requested file, got previously with `retr_as_stream()` has been read.
-    ///
-    /// Write-side close errors are ignored after the payload has been read. The final FTP control
-    /// response determines whether the transfer succeeded.
-    pub async fn finalize_retr_stream(
-        &mut self,
-        mut stream: impl Read + Write + Unpin,
-    ) -> FtpResult<()> {
-        debug!("Finalizing retr stream");
-        // Close the write side so TLS streams send close_notify before being dropped. The server's
-        // completion response remains authoritative if closing an already-read stream fails.
-        let _ = stream.close().await;
-        // Drop stream NOTE: must be done first, otherwise server won't return any response
-        drop(stream);
-        self.data_connection_open = false;
-        trace!("dropped stream");
-        // Then read response
-        self.read_response_in(&[Status::ClosingDataConnection, Status::RequestedFileActionOk])
-            .await
-            .map(|_| ())
+        Ok(stream)
     }
 
     /// Removes the remote pathname from the server.
     pub async fn rmdir<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Removing directory {}", pathname.as_ref());
-        self.perform(Command::Rmd(pathname.as_ref().to_string()))
+        cc.perform(Command::Rmd(pathname.as_ref().to_string()))
             .await?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
-        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
+        cc.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
 
     /// Remove the remote file from the server.
     pub async fn rm<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Removing file {}", filename.as_ref());
-        self.perform(Command::Dele(filename.as_ref().to_string()))
+        cc.perform(Command::Dele(filename.as_ref().to_string()))
             .await?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
-        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
+        cc.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -538,55 +556,68 @@ where
         let bytes = copy(r, &mut data_stream)
             .await
             .map_err(FtpError::ConnectionError)?;
-        self.finalize_put_stream(data_stream).await?;
+        data_stream.finish().await?;
         Ok(bytes)
     }
 
-    /// Send PUT command and returns a BufWriter, which references the file created on the server
-    /// The returned stream must be then correctly manipulated to write the content of the source file to the remote destination
-    /// The stream must be then correctly dropped.
-    /// Once you've finished the write, YOU MUST CALL THIS METHOD: `finalize_put_stream`
+    /// Sends `STOR` and returns a writable [`TransferStream`] for the file `filename`.
+    ///
+    /// Write the payload to the returned stream, then call [`TransferStream::finish`] to close
+    /// the data connection and read the server's completion reply. Until then any other data
+    /// command fails with [`FtpError::DataConnectionAlreadyOpen`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use suppaftp::smol::AsyncFtpStream;
+    /// use smol::io::AsyncWriteExt;
+    ///
+    /// # async fn run() {
+    /// let mut ftp = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+    /// ftp.login("test", "test").await.unwrap();
+    /// let mut upload = ftp.put_with_stream("hello.txt").await.unwrap();
+    /// upload.write_all(b"hello, world!").await.unwrap();
+    /// upload.finish().await.unwrap();
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server refuses the `STOR` command.
     pub async fn put_with_stream<S: AsRef<str>>(
         &mut self,
         filename: S,
-    ) -> FtpResult<DataStream<T>> {
+    ) -> FtpResult<TransferStream<T>> {
         debug!("Put file {}", filename.as_ref());
         let (_, stream) = self
-            .data_command_with_response(
+            .open_transfer(
                 Command::Store(filename.as_ref().to_string()),
                 &[Status::AlreadyOpen, Status::AboutToSend],
+                Direction::Upload,
             )
             .await?;
         Ok(stream)
     }
 
-    /// Finalize put when using stream
-    /// This method must be called once the file has been written and
-    /// `put_with_stream` has been used to write the file
-    pub async fn finalize_put_stream(&mut self, mut stream: impl Write + Unpin) -> FtpResult<()> {
-        debug!("Finalizing put stream");
-        // Drop stream NOTE: must be done first, otherwise server won't return any response
-        stream.close().await.map_err(FtpError::ConnectionError)?;
-        drop(stream);
-        self.data_connection_open = false;
-        trace!("Stream dropped");
-        // Read response
-        self.read_response_in(&[Status::ClosingDataConnection, Status::RequestedFileActionOk])
-            .await
-            .map(|_| ())
-    }
-
-    /// Open specified file for appending data. Returns the stream to append data to specified file.
-    /// Once you've finished the write, YOU MUST CALL THIS METHOD: `finalize_put_stream`
+    /// Sends `APPE` and returns a writable [`TransferStream`] appending to the file `filename`.
+    ///
+    /// Behaves like [`ImplAsyncFtpStream::put_with_stream`], except that the data is appended.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server refuses the `APPE` command.
     pub async fn append_with_stream<S: AsRef<str>>(
         &mut self,
         filename: S,
-    ) -> FtpResult<DataStream<T>> {
+    ) -> FtpResult<TransferStream<T>> {
         debug!("Appending to file {}", filename.as_ref());
         let (_, stream) = self
-            .data_command_with_response(
+            .open_transfer(
                 Command::Appe(filename.as_ref().to_string()),
                 &[Status::AlreadyOpen, Status::AboutToSend],
+                Direction::Upload,
             )
             .await?;
         Ok(stream)
@@ -602,27 +633,35 @@ where
         let bytes = copy(r, &mut data_stream)
             .await
             .map_err(FtpError::ConnectionError)?;
-        self.finalize_put_stream(Box::new(data_stream)).await?;
+        data_stream.finish().await?;
         Ok(bytes)
     }
 
-    /// abort the previous FTP service command
-    pub async fn abort<R>(&mut self, data_stream: R) -> FtpResult<()>
-    where
-        R: Read + std::marker::Unpin + 'static,
-    {
+    /// Aborts the transfer running on `transfer` with the `ABOR` command.
+    ///
+    /// The data connection is closed and the server's abort replies (`426` followed by `226`,
+    /// or a single `226`) are consumed, so the control connection is ready for the next command.
+    /// `transfer` must have been obtained from this client.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::UnexpectedResponse`] if the server does not acknowledge the abort.
+    pub async fn abort(&mut self, transfer: TransferStream<T>) -> FtpResult<()> {
         debug!("Aborting active file transfer");
-        self.perform(Command::Abor).await?;
+        // Detach the socket first: the stream must not flag a pending reply on drop.
+        let data_stream = transfer.detach();
+        let mut cc = self.control().await?;
+        cc.perform(Command::Abor).await?;
         // Drop stream NOTE: must be done first, otherwise server won't return any response
         drop(data_stream);
-        self.data_connection_open = false;
+        cc.data_connection_open = false;
         trace!("dropped stream");
-        let response = self
+        let response = cc
             .read_response_in(&[Status::ClosingDataConnection, Status::TransferAborted])
             .await?;
         // If server sent 426 (TransferAborted), expect a follow-up 226
         if response.status == Status::TransferAborted {
-            self.read_response(Status::ClosingDataConnection).await?;
+            cc.read_response(Status::ClosingDataConnection).await?;
         }
         trace!("Transfer aborted");
         Ok(())
@@ -635,9 +674,10 @@ where
     ///
     /// It is possible to cancel the REST command, sending a REST command with offset 0
     pub async fn resume_transfer(&mut self, offset: usize) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Requesting to resume transfer at offset {}", offset);
-        self.perform(Command::Rest(offset)).await?;
-        self.read_response(Status::RequestFilePending).await?;
+        cc.perform(Command::Rest(offset)).await?;
+        cc.read_response(Status::RequestFilePending).await?;
         debug!("Resume transfer accepted");
         Ok(())
     }
@@ -691,11 +731,12 @@ where
     /// Execute `MLST` command which returns the machine-processable listing of a file.
     /// If `pathname` is omited then the list of files in the current directory will be
     pub async fn mlst(&mut self, pathname: Option<&str>) -> FtpResult<String> {
+        let mut cc = self.control().await?;
         debug!("Reading {} path information", pathname.unwrap_or("working"));
 
-        self.perform(Command::Mlst(pathname.map(|x| x.to_string())))
+        cc.perform(Command::Mlst(pathname.map(|x| x.to_string())))
             .await?;
-        let response = self
+        let response = cc
             .read_response_in(&[Status::RequestedFileActionOk])
             .await?;
         // read body at line 1
@@ -709,10 +750,11 @@ where
 
     /// Retrieves the modification time of the file at `pathname` if it exists.
     pub async fn mdtm<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<NaiveDateTime> {
+        let mut cc = self.control().await?;
         debug!("Getting modification time for {}", pathname.as_ref());
-        self.perform(Command::Mdtm(pathname.as_ref().to_string()))
+        cc.perform(Command::Mdtm(pathname.as_ref().to_string()))
             .await?;
-        let response: Response = self.read_response(Status::File).await?;
+        let response: Response = cc.read_response(Status::File).await?;
         let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
 
         match MDTM_RE.captures(&body) {
@@ -745,10 +787,11 @@ where
 
     /// Retrieves the size of the file in bytes at `pathname` if it exists.
     pub async fn size<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<usize> {
+        let mut cc = self.control().await?;
         debug!("Getting file size for {}", pathname.as_ref());
-        self.perform(Command::Size(pathname.as_ref().to_string()))
+        cc.perform(Command::Size(pathname.as_ref().to_string()))
             .await?;
-        let response: Response = self.read_response(Status::File).await?;
+        let response: Response = cc.read_response(Status::File).await?;
         let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
 
         match SIZE_RE.captures(&body) {
@@ -759,10 +802,11 @@ where
 
     /// Retrieves the features supported by the server, through the FEAT command.
     pub async fn feat(&mut self) -> FtpResult<Features> {
+        let mut cc = self.control().await?;
         debug!("Getting server supported features");
-        self.perform(Command::Feat).await?;
+        cc.perform(Command::Feat).await?;
 
-        let response = self.read_response(Status::System).await?;
+        let response = cc.read_response(Status::System).await?;
 
         let first_line = String::from_utf8_lossy(&response.body);
         debug!("FEAT response: {}", first_line);
@@ -770,7 +814,7 @@ where
 
         loop {
             let mut line = Vec::new();
-            let bytes_read = self.read_line(&mut line).await?;
+            let bytes_read = cc.read_line(&mut line).await?;
             if bytes_read == 0 {
                 break;
             }
@@ -791,22 +835,24 @@ where
         option: impl ToString,
         value: Option<impl ToString>,
     ) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Getting server supported features");
-        self.perform(Command::Opts(
+        cc.perform(Command::Opts(
             option.to_string(),
             value.map(|x| x.to_string()),
         ))
         .await?;
-        self.read_response(Status::CommandOk).await?;
+        cc.read_response(Status::CommandOk).await?;
 
         Ok(())
     }
 
     /// Execute a command on the server and return the response
     pub async fn site(&mut self, command: impl ToString) -> FtpResult<Response> {
+        let mut cc = self.control().await?;
         debug!("Sending SITE command: {}", command.to_string());
-        self.perform(Command::Site(command.to_string())).await?;
-        self.read_response(Status::CommandOk).await
+        cc.perform(Command::Site(command.to_string())).await?;
+        cc.read_response(Status::CommandOk).await
     }
 
     /// Perform custom command.
@@ -824,58 +870,44 @@ where
         command: impl ToString,
         expected_code: &[Status],
     ) -> FtpResult<Response> {
+        let mut cc = self.control().await?;
         let command = command.to_string();
         debug!("Sending custom command: {}", command);
-        self.perform(Command::Custom(command)).await?;
-        self.read_response_in(expected_code).await
+        cc.perform(Command::Custom(command)).await?;
+        cc.read_response_in(expected_code).await
     }
 
     /// Perform a custom command using the data connection.
-    /// It returns both the [`Response`] and the [`DataStream`].
     ///
-    /// The [`DataStream`] implements both [`Write`] and [`Read`] and so it can be written or read to interact with the
-    /// data channel.
+    /// It returns both the [`Response`] and a [`TransferStream`], which implements both
+    /// [`smol::io::AsyncWrite`] and [`smol::io::AsyncRead`] and so it can be written or read to interact
+    /// with the data channel.
     ///
-    /// If you want you can easily parse lines from the [`DataStream`] using [`Self::get_lines_from_stream`].
+    /// If you want you can easily parse lines from the stream using [`Self::get_lines_from_stream`].
     ///
-    /// The stream must eventually be closed using [`Self::close_data_connection`].
+    /// Once done, call [`TransferStream::finish`] to close the data connection and read the
+    /// server's completion reply.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server's reply is not in `expected_code`.
     pub async fn custom_data_command(
         &mut self,
         command: impl ToString,
         expected_code: &[Status],
-    ) -> FtpResult<(Response, DataStream<T>)> {
+    ) -> FtpResult<(Response, TransferStream<T>)> {
         let command = command.to_string();
         debug!("Sending custom data command: {}", command);
-        let (response, data_stream) = self
-            .data_command_with_response(Command::Custom(command), expected_code)
-            .await?;
-        Ok((response, data_stream))
-    }
-
-    /// Close data connection.
-    ///
-    /// Call this function when you're done with the stream obtained with [`Self::custom_data_command`].
-    ///
-    /// # Warning
-    ///
-    /// Passing any other [`Read`] which is not the [`DataStream`]
-    /// obtained with [`Self::custom_data_command`] may lead to undefined behavior.
-    pub async fn close_data_connection(&mut self, stream: impl Read) -> FtpResult<()> {
-        debug!("closing data connection");
-        // Drop stream NOTE: must be done first, otherwise server won't return any response
-        drop(stream);
-        self.data_connection_open = false;
-        trace!("dropped stream");
-        // Then read response
-        self.read_response_in(&[Status::ClosingDataConnection, Status::RequestedFileActionOk])
+        self.open_transfer(Command::Custom(command), expected_code, Direction::Download)
             .await
-            .map(|_| ())
     }
 
-    /// Read a [`DataStream`] line by line.
-    pub async fn get_lines_from_stream(
-        data_stream: &mut BufReader<DataStream<T>>,
-    ) -> FtpResult<Vec<String>> {
+    /// Read a data stream line by line.
+    pub async fn get_lines_from_stream<R>(data_stream: &mut R) -> FtpResult<Vec<String>>
+    where
+        R: AsyncBufReadExt + Unpin,
+    {
         let mut lines: Vec<String> = Vec::new();
 
         loop {
@@ -906,17 +938,66 @@ where
         Ok(lines)
     }
 
+    /// Reads one reply from the control connection and checks that its status is `expected_code`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::UnexpectedResponse`] if the reply has another status.
+    pub async fn read_response(&mut self, expected_code: Status) -> FtpResult<Response> {
+        self.control().await?.read_response(expected_code).await
+    }
+
+    /// Reads one reply from the control connection and checks that its status is in `expected_code`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::UnexpectedResponse`] if the reply has another status.
+    pub async fn read_response_in(&mut self, expected_code: &[Status]) -> FtpResult<Response> {
+        self.control().await?.read_response_in(expected_code).await
+    }
+
     // -- private
 
+    /// Locks the control connection for the duration of one command.
+    ///
+    /// Drains the reply of a transfer stream dropped without `finish()` first, so that the
+    /// control connection is in sync when the command is sent.
+    async fn control(&self) -> FtpResult<MutexGuard<'_, ControlChannel<T>>> {
+        let mut cc = self.control.lock().await;
+        cc.drain_pending_transfer_reply().await?;
+        Ok(cc)
+    }
+
+    /// Opens the data connection for `cmd` and wraps it into a self-finalizing [`TransferStream`].
+    async fn open_transfer(
+        &self,
+        cmd: Command,
+        expected_code: &[Status],
+        direction: Direction,
+    ) -> FtpResult<(Response, TransferStream<T>)> {
+        let mut cc = self.control().await?;
+        let (response, data_stream) = self
+            .data_command_with_response(&mut cc, cmd, expected_code)
+            .await?;
+        Ok((
+            response,
+            TransferStream::new(data_stream, Arc::clone(&self.control), direction),
+        ))
+    }
+
     /// Execute command which send data back in a separate stream
-    async fn data_command(&mut self, cmd: Command) -> FtpResult<DataStream<T>> {
+    async fn data_command(
+        &self,
+        cc: &mut ControlChannel<T>,
+        cmd: Command,
+    ) -> FtpResult<DataStream<T>> {
         // guard data connection
-        self.guard_multiple_data_connections()?;
+        cc.guard_multiple_data_connections()?;
 
         let stream = match self.mode {
             Mode::Active => {
-                let listener = self.active().await?;
-                self.perform(cmd).await?;
+                let listener = self.active(cc).await?;
+                cc.perform(cmd).await?;
 
                 let accept = async { Ok(listener.accept().await) };
                 let deadline = async {
@@ -938,13 +1019,13 @@ where
                 }
             }
             Mode::ExtendedPassive => {
-                let addr = self.epsv().await?;
-                self.perform(cmd).await?;
+                let addr = self.epsv(cc).await?;
+                cc.perform(cmd).await?;
                 (self.passive_stream_builder)(addr).await?
             }
             Mode::Passive => {
-                let addr = self.pasv().await?;
-                self.perform(cmd).await?;
+                let addr = self.pasv(cc).await?;
+                cc.perform(cmd).await?;
                 (self.passive_stream_builder)(addr).await?
             }
         };
@@ -967,7 +1048,7 @@ where
         };
 
         if result.is_ok() {
-            self.data_connection_open = true;
+            cc.data_connection_open = true;
         }
         result
     }
@@ -979,60 +1060,51 @@ where
     /// failed command never leaves the client believing a data connection is still open, which would
     /// otherwise make every subsequent data command fail with [`FtpError::DataConnectionAlreadyOpen`].
     async fn data_command_with_response(
-        &mut self,
+        &self,
+        cc: &mut ControlChannel<T>,
         cmd: Command,
         expected_code: &[Status],
     ) -> FtpResult<(Response, DataStream<T>)> {
-        let data_stream = self.data_command(cmd).await?;
-        match self.read_response_in(expected_code).await {
+        let data_stream = self.data_command(cc, cmd).await?;
+        match cc.read_response_in(expected_code).await {
             Ok(response) => Ok((response, data_stream)),
             Err(err) => {
                 // server rejected the command: drop the data stream and reset the open flag
                 drop(data_stream);
-                self.data_connection_open = false;
+                cc.data_connection_open = false;
                 Err(err)
             }
         }
     }
 
     /// Runs the EPSV to enter Extended passive mode.
-    async fn epsv(&mut self) -> FtpResult<SocketAddr> {
+    async fn epsv(&self, cc: &mut ControlChannel<T>) -> FtpResult<SocketAddr> {
         debug!("EPSV command");
-        self.perform(Command::Epsv).await?;
+        cc.perform(Command::Epsv).await?;
         // PASV response format : 229 Entering Extended Passive Mode (|||PORT|)
-        let response: Response = self.read_response(Status::ExtendedPassiveMode).await?;
+        let response: Response = cc.read_response(Status::ExtendedPassiveMode).await?;
         let response_str = response.as_string().map_err(|_| FtpError::BadResponse)?;
         let caps = EPSV_PORT_RE
             .captures(&response_str)
             .ok_or_else(|| FtpError::UnexpectedResponse(response.clone()))?;
         let new_port = caps[1].parse::<u16>().map_err(|_| FtpError::BadResponse)?;
         trace!("Got port number from EPSV: {}", new_port);
-        let mut remote = self
-            .reader
-            .get_ref()
-            .get_ref()
-            .peer_addr()
-            .map_err(FtpError::ConnectionError)?;
+        let mut remote = cc.socket().peer_addr().map_err(FtpError::ConnectionError)?;
         remote.set_port(new_port);
         trace!("Remote address for extended passive mode is {}", remote);
         Ok(remote)
     }
 
     /// Runs the PASV command.
-    async fn pasv(&mut self) -> FtpResult<SocketAddr> {
+    async fn pasv(&self, cc: &mut ControlChannel<T>) -> FtpResult<SocketAddr> {
         debug!("PASV command");
-        self.perform(Command::Pasv).await?;
+        cc.perform(Command::Pasv).await?;
         // PASV response format : 227 Entering Passive Mode (h1,h2,h3,h4,p1,p2).
-        let response: Response = self.read_response(Status::PassiveMode).await?;
+        let response: Response = cc.read_response(Status::PassiveMode).await?;
         let addr = FtpStream::parse_passive_address_from_response(response)?;
         trace!("Passive address: {}", addr);
         if self.nat_workaround {
-            let mut remote = self
-                .reader
-                .get_ref()
-                .get_ref()
-                .peer_addr()
-                .map_err(FtpError::ConnectionError)?;
+            let mut remote = cc.socket().peer_addr().map_err(FtpError::ConnectionError)?;
             remote.set_port(addr.port());
             trace!("Replacing site local address {} with {}", addr, remote);
             Ok(remote)
@@ -1042,7 +1114,7 @@ where
     }
 
     /// Create a new tcp listener and send a PORT command for it
-    async fn active(&mut self) -> FtpResult<TcpListener> {
+    async fn active(&self, cc: &mut ControlChannel<T>) -> FtpResult<TcpListener> {
         debug!("Starting local tcp listener...");
         let conn = TcpListener::bind("0.0.0.0:0")
             .await
@@ -1051,14 +1123,11 @@ where
         let addr = conn.local_addr().map_err(FtpError::ConnectionError)?;
         trace!("Local address is {}", addr);
 
-        let ip = match self.reader.get_mut() {
-            DataStream::Tcp(stream) => stream.local_addr().map_err(FtpError::ConnectionError)?.ip(),
-            DataStream::Ssl(stream) => stream
-                .get_ref()
-                .local_addr()
-                .map_err(FtpError::ConnectionError)?
-                .ip(),
-        };
+        let ip = cc
+            .socket()
+            .local_addr()
+            .map_err(FtpError::ConnectionError)?
+            .ip();
 
         debug!("Active mode, listening on {}:{}", ip, addr.port());
 
@@ -1068,123 +1137,27 @@ where
                 let lsb = addr.port() % 256;
                 let ip_port = format!("{},{},{}", ip.to_string().replace('.', ","), msb, lsb);
                 debug!("Running PORT command");
-                self.perform(Command::Port(ip_port)).await?;
+                cc.perform(Command::Port(ip_port)).await?;
             }
             std::net::IpAddr::V6(_) => {
                 debug!("Running EPRT command");
-                self.perform(Command::Eprt(SocketAddr::new(ip, addr.port())))
+                cc.perform(Command::Eprt(SocketAddr::new(ip, addr.port())))
                     .await?;
             }
         }
-        self.read_response(Status::CommandOk).await?;
+        cc.read_response(Status::CommandOk).await?;
 
         Ok(conn)
     }
 
-    /// Write data to stream
-    async fn perform(&mut self, command: Command) -> FtpResult<()> {
-        let command = command.to_string();
-        crate::command::validate_command_line(&command)?;
-        trace!("CC OUT: {}", command.trim_end_matches("\r\n"));
-
-        let stream = self.reader.get_mut();
-        stream
-            .write_all(command.as_bytes())
-            .await
-            .map_err(FtpError::ConnectionError)
-    }
-
-    /// Read response from stream
-    pub async fn read_response(&mut self, expected_code: Status) -> FtpResult<Response> {
-        self.read_response_in(&[expected_code]).await
-    }
-
-    /// Retrieve single line response
-    pub async fn read_response_in(&mut self, expected_code: &[Status]) -> FtpResult<Response> {
-        let mut line = Vec::new();
-        let mut body: Vec<u8> = Vec::new();
-        self.read_line(&mut line).await?;
-        body.extend(line.iter());
-
-        trace!("CC IN: {:?}", line);
-
-        if line.len() < 5 {
-            return Err(FtpError::BadResponse);
-        }
-
-        let code_word: u32 = self.code_from_buffer(&line, 3)?;
-        let mut code = Status::from(code_word);
-
-        trace!("Code parsed from response: {} ({})", code, code_word);
-
-        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
-        // including glFTPd, use a different operative code. FEAT remains special because
-        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
-        // M-DOCUMENTED-MAGIC: FTP replies start with a three-digit code and one separator.
-        let expected = [line[0], line[1], line[2], 0x20];
-        let feat_opener = [line[0], line[1], line[2], b'-'];
-        let is_terminal = |reply: &[u8]| {
-            reply.len() >= 4
-                && reply[0].is_ascii_digit()
-                && reply[1].is_ascii_digit()
-                && reply[2].is_ascii_digit()
-                && (reply[3] == b' '
-                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
-        };
-        trace!("CC IN: {:?}", line);
-        while !is_terminal(&line) {
-            line.clear();
-            let bytes_read = self.read_line(&mut line).await?;
-            if bytes_read == 0 {
-                return Err(FtpError::ConnectionError(std::io::Error::new(
-                    std::io::ErrorKind::UnexpectedEof,
-                    "connection closed during multiline response",
-                )));
-            }
-            body.extend(line.iter());
-            trace!("CC IN: {:?}", line);
-        }
-
-        if line[0..4] != expected {
-            code = Status::from(self.code_from_buffer(&line, 3)?);
-            trace!("Code updated from terminal response: {}", code);
-        }
-
-        let response: Response = Response::new(code, body);
-        // Return Ok or error with response
-        if expected_code.contains(&code) {
-            Ok(response)
-        } else {
-            Err(FtpError::UnexpectedResponse(response))
-        }
-    }
-
-    async fn read_line(&mut self, line: &mut Vec<u8>) -> FtpResult<usize> {
-        self.reader
-            .read_until(0x0A, line.as_mut())
-            .await
-            .map_err(FtpError::ConnectionError)?;
-        Ok(line.len())
-    }
-
-    /// Get code from buffer
-    fn code_from_buffer(&self, buf: &[u8], len: usize) -> Result<u32, FtpError> {
-        if buf.len() < len {
-            return Err(FtpError::BadResponse);
-        }
-        let buffer = buf[0..len].to_vec();
-        let as_string = String::from_utf8(buffer).map_err(|_| FtpError::BadResponse)?;
-        as_string.parse::<u32>().map_err(|_| FtpError::BadResponse)
-    }
-
     /// Execute a command which returns list of strings in a separate stream
-    async fn stream_lines(&mut self, cmd: Command, open_code: Status) -> FtpResult<Vec<String>> {
+    async fn stream_lines(&self, cmd: Command, open_code: Status) -> FtpResult<Vec<String>> {
         let (_, stream) = self
-            .data_command_with_response(cmd, &[open_code, Status::AlreadyOpen])
+            .open_transfer(cmd, &[open_code, Status::AlreadyOpen], Direction::Download)
             .await?;
         let mut data_stream = BufReader::new(stream);
         let lines = Self::get_lines_from_stream(&mut data_stream).await;
-        self.finalize_retr_stream(data_stream).await?;
+        data_stream.into_inner().finish().await?;
         lines
     }
 
@@ -1202,33 +1175,19 @@ where
             })
         })
     }
-
-    /// guard against multiple data connections
-    ///
-    /// If `data_connection_open` is true, returns an [`FtpError::DataConnectionAlreadyOpen`] indicating that a data connection is already open.
-    /// Otherwise, returns Ok(()).
-    fn guard_multiple_data_connections(&self) -> FtpResult<()> {
-        if self.data_connection_open {
-            Err(FtpError::DataConnectionAlreadyOpen)
-        } else {
-            Ok(())
-        }
-    }
 }
 
 #[cfg(test)]
 mod test {
-    use std::pin::Pin;
     use std::str::FromStr as _;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::task::{Context, Poll};
+    use std::time::Instant;
 
     #[cfg(feature = "async-secure")]
     use pretty_assertions::assert_eq;
     use rand::distr::Alphanumeric;
     use rand::{RngExt, rng};
-    use smol::io::AsyncReadExt;
+    use smol::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::super::smol::AsyncFtpStream;
     use super::*;
@@ -1236,104 +1195,12 @@ mod test {
     use crate::types::FormatControl;
     use crate::{FtpError, Status};
 
-    #[derive(Debug)]
-    struct CloseTrackingStream {
-        close_attempted: Arc<AtomicBool>,
-        dropped: Arc<AtomicBool>,
-    }
-
-    impl smol::io::AsyncRead for CloseTrackingStream {
-        fn poll_read(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            _buf: &mut [u8],
-        ) -> Poll<std::io::Result<usize>> {
-            Poll::Ready(Ok(0))
-        }
-    }
-
-    impl smol::io::AsyncWrite for CloseTrackingStream {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<std::io::Result<usize>> {
-            Poll::Ready(Ok(buf.len()))
-        }
-
-        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-
-        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            self.close_attempted.store(true, Ordering::SeqCst);
-            Poll::Ready(Err(std::io::Error::other("close failed")))
-        }
-    }
-
-    impl Drop for CloseTrackingStream {
-        fn drop(&mut self) {
-            self.dropped.store(true, Ordering::SeqCst);
-        }
-    }
-
     #[test]
     fn connect() {
         smol::block_on(async {
             crate::log_init();
             let (stream, _container) = setup_stream().await;
             finalize_stream(stream).await;
-        })
-    }
-
-    #[test]
-    fn finalize_retr_stream_attempts_close_before_reading_response() {
-        smol::block_on(async {
-            use smol::io::AsyncWriteExt as _;
-
-            let close_attempted = Arc::new(AtomicBool::new(false));
-            let dropped = Arc::new(AtomicBool::new(false));
-            let listener = TcpListener::bind("127.0.0.1:0")
-                .await
-                .expect("failed to bind");
-            let port = listener.local_addr().expect("missing local address").port();
-            let server_close_attempted = Arc::clone(&close_attempted);
-            let server_dropped = Arc::clone(&dropped);
-            let server = smol::spawn(async move {
-                let (mut control, _) = listener.accept().await.expect("no incoming connection");
-                control.write_all(b"220 Welcome\r\n").await.unwrap();
-
-                let deadline = std::time::Instant::now() + Duration::from_secs(1);
-                while !server_dropped.load(Ordering::SeqCst) && std::time::Instant::now() < deadline
-                {
-                    smol::Timer::after(Duration::from_millis(1)).await;
-                }
-
-                let response: &[u8] = if server_close_attempted.load(Ordering::SeqCst)
-                    && server_dropped.load(Ordering::SeqCst)
-                {
-                    b"226 Transfer complete\r\n"
-                } else {
-                    b"426 Data connection was not closed gracefully\r\n"
-                };
-                control.write_all(response).await.unwrap();
-            });
-
-            let control = TcpStream::connect(("127.0.0.1", port))
-                .await
-                .expect("failed to connect");
-            let mut ftp = AsyncFtpStream::connect_with_stream(control)
-                .await
-                .expect("failed handshake");
-            let data = CloseTrackingStream {
-                close_attempted: Arc::clone(&close_attempted),
-                dropped: Arc::clone(&dropped),
-            };
-
-            ftp.finalize_retr_stream(data)
-                .await
-                .expect("FTP completion should override the local close error");
-            server.await;
         })
     }
 
@@ -1391,7 +1258,7 @@ mod test {
     fn get_ref() {
         smol::block_on(async {
             let (stream, _container) = setup_stream().await;
-            assert!(stream.get_ref().set_ttl(255).is_ok());
+            assert!(stream.get_ref().await.set_ttl(255).is_ok());
             finalize_stream(stream).await;
         })
     }
@@ -1528,7 +1395,7 @@ mod test {
             // Verify file matches
             assert_eq!(buffer.as_slice(), "test data\ntest data\n".as_bytes());
             // Finalize
-            assert!(stream.finalize_retr_stream(reader).await.is_ok());
+            assert!(reader.finish().await.is_ok());
             // Get size
             assert_eq!(stream.size("test.txt").await.unwrap(), 20);
             // Size of non-existing file
@@ -1622,7 +1489,7 @@ mod test {
                 6
             );
             // Finalize
-            assert!(stream.finalize_put_stream(transfer_stream).await.is_ok());
+            assert!(transfer_stream.finish().await.is_ok());
             // Get size
             //assert_eq!(stream.size("test.bin").await.unwrap(), 11);
             // Remove file
@@ -1706,7 +1573,7 @@ mod test {
                 .await
                 .expect("Failed to get lines from stream");
             // finalize
-            assert!(stream.close_data_connection(reader).await.is_ok());
+            assert!(reader.into_inner().finish().await.is_ok());
         })
     }
 
@@ -1736,7 +1603,7 @@ mod test {
             let mut reader = Cursor::new("test data\n".as_bytes());
             assert!(stream.append_file("test.txt", &mut reader).await.is_ok());
             let data_stream = stream.retr_as_stream("test.txt").await.unwrap();
-            assert!(stream.finalize_retr_stream(data_stream).await.is_ok());
+            assert!(data_stream.finish().await.is_ok());
             assert!(stream.list(None).await.is_ok());
             assert!(stream.nlst(None).await.is_ok());
 
@@ -1798,7 +1665,7 @@ mod test {
                 .await
                 .expect("Failed to get lines from stream");
             // finalize
-            assert!(stream.close_data_connection(reader).await.is_ok());
+            assert!(reader.into_inner().finish().await.is_ok());
 
             // Now it should be possible to open another data connection
             let (response, data_stream) = stream
@@ -1811,7 +1678,7 @@ mod test {
                 .await
                 .expect("Failed to get lines from stream");
             // finalize
-            assert!(stream.close_data_connection(reader).await.is_ok());
+            assert!(reader.into_inner().finish().await.is_ok());
         })
     }
 
@@ -1856,14 +1723,14 @@ mod test {
             smol::io::AsyncWriteExt::write_all(&mut data_stream, b"part2")
                 .await
                 .unwrap();
-            stream.finalize_put_stream(data_stream).await.unwrap();
+            data_stream.finish().await.unwrap();
             // Verify content
             let mut reader = stream.retr_as_stream("append_stream.txt").await.unwrap();
             let mut buffer = Vec::new();
             smol::io::AsyncReadExt::read_to_end(&mut reader, &mut buffer)
                 .await
                 .unwrap();
-            stream.finalize_retr_stream(reader).await.unwrap();
+            reader.finish().await.unwrap();
             assert_eq!(buffer, b"part1part2");
             assert!(stream.rm("append_stream.txt").await.is_ok());
             finalize_stream(stream).await;
@@ -2082,6 +1949,182 @@ mod test {
                 });
 
             is_sync::<AsyncFtpStream>(ftp_stream);
+        })
+    }
+
+    #[test]
+    fn should_upload_via_stream_and_finish() {
+        smol::block_on(async {
+            let (mut stream, _container) = setup_stream().await;
+            assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+            let mut upload = stream.put_with_stream("upload.bin").await.unwrap();
+            smol::io::AsyncWriteExt::write_all(&mut upload, b"0123456789")
+                .await
+                .unwrap();
+            upload
+                .finish()
+                .await
+                .expect("finish should read the transfer reply");
+            // The control connection is in sync: the next commands work.
+            assert_eq!(stream.size("upload.bin").await.unwrap(), 10);
+            assert_eq!(stream.nlst(None).await.unwrap().as_slice(), &["upload.bin"]);
+            assert!(stream.rm("upload.bin").await.is_ok());
+            finalize_stream(stream).await;
+        })
+    }
+
+    #[test]
+    fn should_download_via_stream_and_finish() {
+        smol::block_on(async {
+            let (mut stream, _container) = setup_stream().await;
+            assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+            let mut reader = smol::io::Cursor::new("download me".as_bytes());
+            assert!(stream.put_file("download.txt", &mut reader).await.is_ok());
+            let mut download = stream.retr_as_stream("download.txt").await.unwrap();
+            let mut buffer = Vec::new();
+            download.read_to_end(&mut buffer).await.unwrap();
+            download
+                .finish()
+                .await
+                .expect("finish should read the transfer reply");
+            assert_eq!(buffer, b"download me");
+            // The control connection is in sync: the next commands work.
+            assert!(stream.pwd().await.is_ok());
+            assert_eq!(stream.size("download.txt").await.unwrap(), 11);
+            assert!(stream.rm("download.txt").await.is_ok());
+            finalize_stream(stream).await;
+        })
+    }
+
+    #[test]
+    fn should_drain_reply_of_dropped_stream_on_next_command() {
+        smol::block_on(async {
+            let (mut stream, _container) = setup_stream().await;
+            assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+            let mut upload = stream.put_with_stream("dropped.bin").await.unwrap();
+            smol::io::AsyncWriteExt::write_all(&mut upload, b"dropped")
+                .await
+                .unwrap();
+            smol::io::AsyncWriteExt::flush(&mut upload).await.unwrap();
+            // Drop without finish(): the reply is consumed by the next command.
+            drop(upload);
+            assert_eq!(stream.size("dropped.bin").await.unwrap(), 7);
+            let mut download = stream.retr_as_stream("dropped.bin").await.unwrap();
+            let mut buffer = Vec::new();
+            download.read_to_end(&mut buffer).await.unwrap();
+            download.finish().await.unwrap();
+            assert_eq!(buffer, b"dropped");
+            assert!(stream.rm("dropped.bin").await.is_ok());
+            finalize_stream(stream).await;
+        })
+    }
+
+    #[test]
+    fn should_read_a_single_reply_on_finish_then_drop() {
+        smol::block_on(async {
+            let (mut stream, _container) = setup_stream().await;
+            assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+            let mut upload = stream.put_with_stream("single.bin").await.unwrap();
+            smol::io::AsyncWriteExt::write_all(&mut upload, b"single")
+                .await
+                .unwrap();
+            // A second (spurious) reply read would block: bound finish() with a timeout.
+            let timeout = Duration::from_millis(500);
+            let started = Instant::now();
+            let finished =
+                smol::future::or(async { upload.finish().await.map(|()| true) }, async {
+                    smol::Timer::after(timeout).await;
+                    Ok(false)
+                })
+                .await;
+            assert!(
+                matches!(finished, Ok(true)),
+                "finish() blocked: a second reply read was attempted"
+            );
+            assert!(started.elapsed() < timeout);
+            // The control connection is in sync: the next commands work.
+            assert!(stream.noop().await.is_ok());
+            assert_eq!(stream.size("single.bin").await.unwrap(), 6);
+            assert!(stream.rm("single.bin").await.is_ok());
+            finalize_stream(stream).await;
+        })
+    }
+
+    #[test]
+    fn should_reject_data_commands_while_a_transfer_stream_is_alive() {
+        smol::block_on(async {
+            let (mut stream, _container) = setup_stream().await;
+            assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+            let mut upload = stream.put_with_stream("alive.bin").await.unwrap();
+            smol::io::AsyncWriteExt::write_all(&mut upload, b"alive")
+                .await
+                .unwrap();
+            assert!(matches!(
+                stream.list(None).await,
+                Err(FtpError::DataConnectionAlreadyOpen)
+            ));
+            assert!(matches!(
+                stream.retr_as_stream("alive.bin").await,
+                Err(FtpError::DataConnectionAlreadyOpen)
+            ));
+            assert!(matches!(
+                stream.put_with_stream("other.bin").await,
+                Err(FtpError::DataConnectionAlreadyOpen)
+            ));
+            upload.finish().await.unwrap();
+            // Once finished, data commands work again.
+            assert_eq!(stream.nlst(None).await.unwrap().as_slice(), &["alive.bin"]);
+            assert!(stream.rm("alive.bin").await.is_ok());
+            finalize_stream(stream).await;
+        })
+    }
+
+    #[test]
+    fn should_finish_transfer_stream_on_another_task() {
+        smol::block_on(async {
+            let (mut stream, _container) = setup_stream().await;
+            assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+            let mut upload = stream.put_with_stream("spawned.bin").await.unwrap();
+            let task = smol::spawn(async move {
+                smol::io::AsyncWriteExt::write_all(&mut upload, b"from another task")
+                    .await
+                    .unwrap();
+                upload.finish().await
+            });
+            task.await.expect("finish should succeed on another task");
+            assert_eq!(stream.size("spawned.bin").await.unwrap(), 17);
+            assert!(stream.rm("spawned.bin").await.is_ok());
+            finalize_stream(stream).await;
+        })
+    }
+
+    #[test]
+    fn should_finalize_transfer_when_retr_callback_fails() {
+        smol::block_on(async {
+            let (mut stream, _container) = setup_stream().await;
+            assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+            let mut reader = smol::io::Cursor::new("callback".as_bytes());
+            assert!(
+                stream
+                    .put_file("callback_err.txt", &mut reader)
+                    .await
+                    .is_ok()
+            );
+            let result: FtpResult<()> = stream
+                .retr("callback_err.txt", |reader| {
+                    Box::pin(async move {
+                        // Hand the stream back on failure so `retr` can finish it.
+                        drop(reader);
+                        Err(FtpError::BadResponse)
+                    })
+                })
+                .await;
+            assert!(matches!(result, Err(FtpError::BadResponse)));
+            // The dropped stream flagged a pending reply, which the next command drains.
+            assert_eq!(stream.size("callback_err.txt").await.unwrap(), 8);
+            assert!(stream.list(None).await.is_ok());
+            assert!(stream.rm("callback_err.txt").await.is_ok());
+            finalize_stream(stream).await;
         })
     }
 

--- a/crates/suppaftp/src/async_ftp/smol_ftp/control.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp/control.rs
@@ -13,6 +13,7 @@
 
 use std::ops::Deref;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use smol::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use smol::lock::{Mutex, MutexGuard};
@@ -45,7 +46,10 @@ where
     /// command against opening a second one.
     pub(super) data_connection_open: bool,
     /// Whether a transfer stream was dropped without `finish()` and its reply is still unread.
-    pub(super) pending_transfer_reply: bool,
+    pub(super) pending_transfer_reply: Arc<AtomicBool>,
+    /// Reply bytes survive cancellation while waiting for a complete line or multiline reply.
+    response_line: Vec<u8>,
+    response_body: Vec<u8>,
 }
 
 /// Unwraps a shared control channel that is no longer referenced by any transfer.
@@ -73,7 +77,9 @@ where
         Self {
             reader: BufReader::new(stream),
             data_connection_open: false,
-            pending_transfer_reply: false,
+            pending_transfer_reply: Arc::new(AtomicBool::new(false)),
+            response_line: Vec::new(),
+            response_body: Vec::new(),
         }
     }
 
@@ -110,61 +116,60 @@ where
         &mut self,
         expected_code: &[Status],
     ) -> FtpResult<Response> {
-        let mut line = Vec::new();
-        let mut body: Vec<u8> = Vec::new();
-        self.read_line(&mut line).await?;
-        body.extend(line.iter());
-
-        trace!("CC IN: {:?}", line);
-
-        if line.len() < 5 {
-            return Err(FtpError::BadResponse);
-        }
-
-        let code_word: u32 = code_from_buffer(&line, 3)?;
-        let mut code = Status::from(code_word);
-
-        trace!("Code parsed from response: {} ({})", code, code_word);
-
-        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
-        // including glFTPd, use a different operative code. FEAT remains special because
-        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
-        // FTP replies start with a three-digit code and one separator.
-        let expected = [line[0], line[1], line[2], 0x20];
-        let feat_opener = [line[0], line[1], line[2], b'-'];
-        let is_terminal = |reply: &[u8]| {
-            reply.len() >= 4
-                && reply[0].is_ascii_digit()
-                && reply[1].is_ascii_digit()
-                && reply[2].is_ascii_digit()
-                && (reply[3] == b' '
-                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
-        };
-        trace!("CC IN: {:?}", line);
-        while !is_terminal(&line) {
-            line.clear();
-            let bytes_read = self.read_line(&mut line).await?;
-            if bytes_read == 0 {
+        loop {
+            let bytes_read = self
+                .reader
+                .read_until(b'\n', &mut self.response_line)
+                .await
+                .map_err(FtpError::ConnectionError)?;
+            if bytes_read == 0 && !self.response_body.is_empty() {
                 return Err(FtpError::ConnectionError(std::io::Error::new(
                     std::io::ErrorKind::UnexpectedEof,
                     "connection closed during multiline response",
                 )));
             }
-            body.extend(line.iter());
-            trace!("CC IN: {:?}", line);
-        }
+            self.response_body.extend_from_slice(&self.response_line);
+            trace!("CC IN: {line:?}", line = self.response_line);
 
-        if line[0..4] != expected {
-            code = Status::from(code_from_buffer(&line, 3)?);
-            trace!("Code updated from terminal response: {}", code);
-        }
-
-        let response: Response = Response::new(code, body);
-        // Return Ok or error with response
-        if expected_code.contains(&code) {
-            Ok(response)
-        } else {
-            Err(FtpError::UnexpectedResponse(response))
+            if self.response_body.len() < 5 {
+                self.response_line.clear();
+                self.response_body.clear();
+                return Err(FtpError::BadResponse);
+            }
+            let opening_code = match code_from_buffer(&self.response_body, 3) {
+                Ok(code) => code,
+                Err(err) => {
+                    self.response_line.clear();
+                    self.response_body.clear();
+                    return Err(err);
+                }
+            };
+            let opening = &self.response_body[..3];
+            let line = &self.response_line;
+            // Accept mismatched terminal codes for servers such as glFTPd. FEAT leaves its
+            // continuation lines for `feat()` to consume after returning the `211-` opener.
+            let terminal = line.len() >= 4
+                && line[..3].iter().all(u8::is_ascii_digit)
+                && (line[3] == b' '
+                    || (expected_code.contains(&Status::System)
+                        && line[..3] == *opening
+                        && line[3] == b'-'));
+            if terminal {
+                let code = if line[..3] == *opening {
+                    opening_code
+                } else {
+                    code_from_buffer(line, 3)?
+                };
+                let status = Status::from(code);
+                self.response_line.clear();
+                let response = Response::new(status, std::mem::take(&mut self.response_body));
+                return if expected_code.contains(&status) {
+                    Ok(response)
+                } else {
+                    Err(FtpError::UnexpectedResponse(response))
+                };
+            }
+            self.response_line.clear();
         }
     }
 
@@ -192,7 +197,9 @@ where
     pub(super) async fn complete_transfer(&mut self) -> FtpResult<()> {
         self.data_connection_open = false;
         trace!("data connection closed; reading transfer reply");
-        self.read_response_in(TRANSFER_COMPLETE).await.map(|_| ())
+        let reply = self.read_response_in(TRANSFER_COMPLETE).await.map(|_| ());
+        self.pending_transfer_reply.store(false, Ordering::Release);
+        reply
     }
 
     /// Consumes the reply of a transfer stream that was dropped without `finish()`.
@@ -203,13 +210,12 @@ where
     ///
     /// Returns [`FtpError::ConnectionError`] if the control connection cannot be read.
     pub(super) async fn drain_pending_transfer_reply(&mut self) -> FtpResult<()> {
-        if !self.pending_transfer_reply {
+        if !self.pending_transfer_reply.load(Ordering::Acquire) {
             return Ok(());
         }
-        self.pending_transfer_reply = false;
         debug!("reading the reply of a transfer stream dropped without finish()");
-        match self.read_response_in(TRANSFER_COMPLETE).await {
-            Ok(_) => Ok(()),
+        match self.complete_transfer().await {
+            Ok(()) => Ok(()),
             Err(FtpError::UnexpectedResponse(response)) => {
                 warn!("a dropped transfer stream failed: {response}");
                 Ok(())
@@ -272,5 +278,71 @@ where
 
     fn deref(&self) -> &Self::Target {
         self.guard.socket()
+    }
+}
+
+#[cfg(all(test, feature = "async-secure"))]
+mod tls_transition_tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::super::tls::{AsyncNoTlsStream, AsyncTlsConnector};
+    use crate::smol::AsyncFtpStream;
+    use crate::{FtpError, FtpResult};
+
+    #[derive(Debug)]
+    struct UnusedConnector;
+
+    #[async_trait::async_trait]
+    impl AsyncTlsConnector for UnusedConnector {
+        type Stream = AsyncNoTlsStream;
+
+        async fn connect(&self, _: &str, _: smol::net::TcpStream) -> FtpResult<Self::Stream> {
+            panic!("TLS must not start while a transfer owns the control connection")
+        }
+    }
+
+    #[test]
+    fn should_reject_tls_changes_before_sending_commands() {
+        smol::block_on(async {
+            for secure in [false, true] {
+                let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+                let address = listener.local_addr().unwrap();
+                let server = thread::spawn(move || {
+                    let (socket, _) = listener.accept().unwrap();
+                    socket
+                        .set_read_timeout(Some(Duration::from_secs(5)))
+                        .unwrap();
+                    let mut reader = BufReader::new(socket);
+                    reader.get_mut().write_all(b"220 ready\r\n").unwrap();
+                    let mut command = String::new();
+                    reader.read_line(&mut command).unwrap();
+                    if !command.is_empty() {
+                        let reply: &[u8] = if secure {
+                            b"234 start TLS\r\n"
+                        } else {
+                            b"200 cleared\r\n"
+                        };
+                        reader.get_mut().write_all(reply).unwrap();
+                        reader.read_to_end(&mut Vec::new()).unwrap();
+                    }
+                    command
+                });
+                let ftp = AsyncFtpStream::connect(address).await.unwrap();
+                // A live transfer retains this handle even when a TLS transition consumes the client.
+                let transfer_control = Arc::clone(&ftp.control);
+                let result = if secure {
+                    ftp.into_secure(UnusedConnector, "localhost").await
+                } else {
+                    ftp.clear_command_channel().await
+                };
+                assert!(matches!(result, Err(FtpError::DataConnectionAlreadyOpen)));
+                drop(transfer_control);
+                assert_eq!(server.join().unwrap(), "");
+            }
+        });
     }
 }

--- a/crates/suppaftp/src/async_ftp/smol_ftp/control.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp/control.rs
@@ -1,0 +1,276 @@
+//! Control-connection state shared between the smol FTP client and its in-flight data transfer.
+//!
+//! The control connection (command socket, reply reader, and the "data connection open" flag)
+//! lives behind an [`Arc`]`<`[`Mutex`]`>` so that a [`super::TransferStream`] can finalize itself:
+//! once the data socket is shut down, the stream locks the control connection, clears the flag
+//! and reads the server's completion reply. FTP allows a single data connection per session, so
+//! the lock never serializes anything that could have run concurrently before.
+//!
+//! Async `Drop` cannot await, so a transfer stream that is dropped without
+//! [`super::TransferStream::finish`] only closes its socket and flags a *pending transfer reply*;
+//! the next command drains that reply before sending anything, keeping the control connection in
+//! sync.
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use smol::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use smol::lock::{Mutex, MutexGuard};
+use smol::net::TcpStream;
+
+use super::data_stream::DataStream;
+use super::tls::SmolTlsStream;
+use crate::Status;
+use crate::command::Command;
+use crate::types::{FtpError, FtpResult, Response};
+
+/// Replies that complete a data transfer: `226` or `250`.
+pub(super) const TRANSFER_COMPLETE: &[Status] =
+    &[Status::ClosingDataConnection, Status::RequestedFileActionOk];
+
+/// Shared, lockable handle to a [`ControlChannel`].
+pub(super) type SharedControl<T> = Arc<Mutex<ControlChannel<T>>>;
+
+/// Command socket plus the reply reader and the data-connection bookkeeping.
+#[derive(Debug)]
+pub(super) struct ControlChannel<T>
+where
+    T: SmolTlsStream + Send,
+{
+    /// Buffered reader over the control socket; writes go through [`BufReader::get_mut`].
+    pub(super) reader: BufReader<DataStream<T>>,
+    /// Whether a data connection is currently open.
+    ///
+    /// FTP forbids more than one data connection at a time, so this flag guards every data
+    /// command against opening a second one.
+    pub(super) data_connection_open: bool,
+    /// Whether a transfer stream was dropped without `finish()` and its reply is still unread.
+    pub(super) pending_transfer_reply: bool,
+}
+
+/// Unwraps a shared control channel that is no longer referenced by any transfer.
+///
+/// # Errors
+///
+/// Returns [`FtpError::DataConnectionAlreadyOpen`] if a [`super::TransferStream`] still holds a
+/// reference to the control channel.
+#[cfg(feature = "async-secure")]
+pub(super) fn into_exclusive<T>(control: SharedControl<T>) -> FtpResult<ControlChannel<T>>
+where
+    T: SmolTlsStream + Send,
+{
+    Arc::try_unwrap(control)
+        .map(Mutex::into_inner)
+        .map_err(|_| FtpError::DataConnectionAlreadyOpen)
+}
+
+impl<T> ControlChannel<T>
+where
+    T: SmolTlsStream + Send,
+{
+    /// Wraps `stream` as a fresh control channel with no data connection open.
+    pub(super) fn new(stream: DataStream<T>) -> Self {
+        Self {
+            reader: BufReader::new(stream),
+            data_connection_open: false,
+            pending_transfer_reply: false,
+        }
+    }
+
+    /// Wraps `stream` into a [`SharedControl`].
+    pub(super) fn shared(stream: DataStream<T>) -> SharedControl<T> {
+        Arc::new(Mutex::new(Self::new(stream)))
+    }
+
+    /// Returns the control socket.
+    pub(super) fn socket(&self) -> &TcpStream {
+        self.reader.get_ref().get_ref()
+    }
+
+    /// Sends `command` on the control connection.
+    pub(super) async fn perform(&mut self, command: Command) -> FtpResult<()> {
+        let command = command.to_string();
+        crate::command::validate_command_line(&command)?;
+        trace!("CC OUT: {}", command.trim_end_matches("\r\n"));
+
+        self.reader
+            .get_mut()
+            .write_all(command.as_bytes())
+            .await
+            .map_err(FtpError::ConnectionError)
+    }
+
+    /// Reads one reply and checks that its status is `expected_code`.
+    pub(super) async fn read_response(&mut self, expected_code: Status) -> FtpResult<Response> {
+        self.read_response_in(&[expected_code]).await
+    }
+
+    /// Reads one (possibly multi-line) reply and checks that its status is in `expected_code`.
+    pub(super) async fn read_response_in(
+        &mut self,
+        expected_code: &[Status],
+    ) -> FtpResult<Response> {
+        let mut line = Vec::new();
+        let mut body: Vec<u8> = Vec::new();
+        self.read_line(&mut line).await?;
+        body.extend(line.iter());
+
+        trace!("CC IN: {:?}", line);
+
+        if line.len() < 5 {
+            return Err(FtpError::BadResponse);
+        }
+
+        let code_word: u32 = code_from_buffer(&line, 3)?;
+        let mut code = Status::from(code_word);
+
+        trace!("Code parsed from response: {} ({})", code, code_word);
+
+        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
+        // including glFTPd, use a different operative code. FEAT remains special because
+        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
+        // FTP replies start with a three-digit code and one separator.
+        let expected = [line[0], line[1], line[2], 0x20];
+        let feat_opener = [line[0], line[1], line[2], b'-'];
+        let is_terminal = |reply: &[u8]| {
+            reply.len() >= 4
+                && reply[0].is_ascii_digit()
+                && reply[1].is_ascii_digit()
+                && reply[2].is_ascii_digit()
+                && (reply[3] == b' '
+                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
+        };
+        trace!("CC IN: {:?}", line);
+        while !is_terminal(&line) {
+            line.clear();
+            let bytes_read = self.read_line(&mut line).await?;
+            if bytes_read == 0 {
+                return Err(FtpError::ConnectionError(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed during multiline response",
+                )));
+            }
+            body.extend(line.iter());
+            trace!("CC IN: {:?}", line);
+        }
+
+        if line[0..4] != expected {
+            code = Status::from(code_from_buffer(&line, 3)?);
+            trace!("Code updated from terminal response: {}", code);
+        }
+
+        let response: Response = Response::new(code, body);
+        // Return Ok or error with response
+        if expected_code.contains(&code) {
+            Ok(response)
+        } else {
+            Err(FtpError::UnexpectedResponse(response))
+        }
+    }
+
+    /// Reads bytes from the control connection until `\n` or EOF is found.
+    pub(super) async fn read_line(&mut self, line: &mut Vec<u8>) -> FtpResult<usize> {
+        self.reader
+            .read_until(0x0A, line.as_mut())
+            .await
+            .map_err(FtpError::ConnectionError)?;
+        Ok(line.len())
+    }
+
+    /// Fails with [`FtpError::DataConnectionAlreadyOpen`] if a data connection is open.
+    pub(super) fn guard_multiple_data_connections(&self) -> FtpResult<()> {
+        if self.data_connection_open {
+            Err(FtpError::DataConnectionAlreadyOpen)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Marks the data connection as closed and reads the transfer completion reply.
+    ///
+    /// The data socket must already be closed, otherwise the server never sends the reply.
+    pub(super) async fn complete_transfer(&mut self) -> FtpResult<()> {
+        self.data_connection_open = false;
+        trace!("data connection closed; reading transfer reply");
+        self.read_response_in(TRANSFER_COMPLETE).await.map(|_| ())
+    }
+
+    /// Consumes the reply of a transfer stream that was dropped without `finish()`.
+    ///
+    /// The transfer outcome was abandoned by the caller, so a failure reply is only logged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::ConnectionError`] if the control connection cannot be read.
+    pub(super) async fn drain_pending_transfer_reply(&mut self) -> FtpResult<()> {
+        if !self.pending_transfer_reply {
+            return Ok(());
+        }
+        self.pending_transfer_reply = false;
+        debug!("reading the reply of a transfer stream dropped without finish()");
+        match self.read_response_in(TRANSFER_COMPLETE).await {
+            Ok(_) => Ok(()),
+            Err(FtpError::UnexpectedResponse(response)) => {
+                warn!("a dropped transfer stream failed: {response}");
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+}
+
+/// Parses the leading `len` bytes of `buf` as a numeric reply code.
+fn code_from_buffer(buf: &[u8], len: usize) -> FtpResult<u32> {
+    if buf.len() < len {
+        return Err(FtpError::BadResponse);
+    }
+    let buffer = buf[0..len].to_vec();
+    let as_string = String::from_utf8(buffer).map_err(|_| FtpError::BadResponse)?;
+    as_string.parse::<u32>().map_err(|_| FtpError::BadResponse)
+}
+
+/// Locked view of the control socket of an [`super::ImplAsyncFtpStream`].
+///
+/// Dereferences to the underlying [`TcpStream`], so socket options can be set on the control
+/// connection. The control connection stays locked for as long as this value is alive: drop it
+/// before finishing a [`super::TransferStream`], which needs the same lock to read the transfer
+/// reply.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use suppaftp::smol::AsyncFtpStream;
+///
+/// # async fn run() {
+/// let stream = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+/// stream.get_ref().await.set_nodelay(true).unwrap();
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct ControlSocket<'a, T>
+where
+    T: SmolTlsStream + Send,
+{
+    guard: MutexGuard<'a, ControlChannel<T>>,
+}
+
+impl<'a, T> ControlSocket<'a, T>
+where
+    T: SmolTlsStream + Send,
+{
+    /// Wraps a locked control channel.
+    pub(super) fn new(guard: MutexGuard<'a, ControlChannel<T>>) -> Self {
+        Self { guard }
+    }
+}
+
+impl<T> Deref for ControlSocket<'_, T>
+where
+    T: SmolTlsStream + Send,
+{
+    type Target = TcpStream;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard.socket()
+    }
+}

--- a/crates/suppaftp/src/async_ftp/smol_ftp/data_stream.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp/data_stream.rs
@@ -14,6 +14,7 @@ use smol::net::TcpStream;
 use super::SmolTlsStream;
 
 /// Data Stream used for communications. It can be both of type Tcp in case of plain communication or Ssl in case of FTPS
+#[derive(Debug)]
 #[pin_project(project = DataStreamProj)]
 pub enum DataStream<T>
 where

--- a/crates/suppaftp/src/async_ftp/smol_ftp/transfer_stream.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp/transfer_stream.rs
@@ -1,6 +1,8 @@
 //! Self-finalizing data stream for smol FTP transfers.
 
 use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use smol::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -36,7 +38,10 @@ pub(super) enum Direction {
 /// A stream that is merely dropped cannot await, so it closes its socket (without a TLS
 /// `close_notify`, which strict servers may report as a failed transfer) and defers the reply:
 /// the next command on the client consumes it before sending anything, so the control connection
-/// never desynchronizes. The transfer outcome is lost in that case and only logged.
+/// can be reused after successful cleanup. The transfer outcome is lost in that case and only logged.
+///
+/// Finish the transfer before issuing any other command on the client, even when finishing
+/// on another thread or task. Flush buffered writers before recovering their inner transfer.
 ///
 /// While a `TransferStream` is alive the client refuses to open another data connection with
 /// [`FtpError::DataConnectionAlreadyOpen`]. The stream owns no reference to the client and is
@@ -74,6 +79,8 @@ where
     data: Option<DataStream<T>>,
     control: SharedControl<T>,
     direction: Direction,
+    pending_reply: Arc<AtomicBool>,
+    finished: bool,
 }
 
 impl<T> TransferStream<T>
@@ -85,11 +92,14 @@ where
         data: DataStream<T>,
         control: SharedControl<T>,
         direction: Direction,
+        pending_reply: Arc<AtomicBool>,
     ) -> Self {
         Self {
             data: Some(data),
             control,
             direction,
+            pending_reply,
+            finished: false,
         }
     }
 
@@ -111,6 +121,12 @@ where
     ///
     /// After this call the client can issue the next command.
     ///
+    /// # Cancellation
+    ///
+    /// Cancelling this future closes the data socket and leaves its completion reply for the
+    /// next command to drain. Partially read replies are retained, including when that next
+    /// command is itself cancelled during cleanup. The transfer result is lost on cancellation.
+    ///
     /// # Errors
     ///
     /// Returns [`FtpError::ConnectionError`] if an upload cannot be closed cleanly or the
@@ -125,6 +141,7 @@ where
         let closed = data.close().await;
         drop(data);
         let reply = self.control.lock().await.complete_transfer().await;
+        self.finished = true;
         if self.direction == Direction::Upload {
             closed.map_err(FtpError::ConnectionError)?;
         }
@@ -135,6 +152,7 @@ where
     ///
     /// Used by [`super::ImplAsyncFtpStream::abort`], which reads the reply itself.
     pub(super) fn detach(mut self) -> DataStream<T> {
+        self.finished = true;
         self.data
             .take()
             .expect("data stream is present until the transfer is finished")
@@ -142,7 +160,7 @@ where
 
     /// Whether the transfer has already been finalized.
     fn is_finished(&self) -> bool {
-        self.data.is_none()
+        self.finished
     }
 }
 
@@ -191,17 +209,178 @@ where
         // Closing the socket makes the server send the completion reply; it cannot be awaited
         // here, so it is left for the next command to drain.
         drop(self.data.take());
-        match self.control.try_lock() {
-            Some(mut cc) => {
-                cc.data_connection_open = false;
-                cc.pending_transfer_reply = true;
-                warn!(
-                    "transfer stream dropped without finish(); its reply is read by the next command"
-                );
-            }
-            None => warn!(
-                "transfer stream dropped without finish() while the control connection is busy; the control connection is out of sync"
-            ),
-        }
+        // This notification must work even while a socket guard or another task holds the lock.
+        self.pending_reply.store(true, Ordering::Release);
+        warn!("transfer stream dropped without finish(); its reply is read by the next command");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc::{self, Sender};
+    use std::thread::{self, JoinHandle};
+    use std::time::Duration;
+
+    use crate::smol::AsyncFtpStream;
+
+    async fn delayed_transfer_reply(
+        prefix: &'static [u8],
+        suffix: &'static [u8],
+    ) -> (AsyncFtpStream, Sender<()>, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (release, wait) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            socket
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut control = BufReader::new(socket);
+            control.get_mut().write_all(b"220 ready\r\n").unwrap();
+            let mut command = String::new();
+            control.read_line(&mut command).unwrap();
+            assert_eq!(command, "PASV\r\n");
+            let data_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let port = data_listener.local_addr().unwrap().port();
+            write!(
+                control.get_mut(),
+                "227 passive (127,0,0,1,{high},{low})\r\n",
+                high = port / 256,
+                low = port % 256
+            )
+            .unwrap();
+            command.clear();
+            control.read_line(&mut command).unwrap();
+            assert_eq!(command, "STOR test.bin\r\n");
+            let (mut data, _) = data_listener.accept().unwrap();
+            data.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+            control.get_mut().write_all(b"150 send data\r\n").unwrap();
+            data.read_to_end(&mut Vec::new()).unwrap();
+            control.get_mut().write_all(prefix).unwrap();
+            wait.recv_timeout(Duration::from_secs(5)).unwrap();
+            control.get_mut().write_all(suffix).unwrap();
+            command.clear();
+            control.read_line(&mut command).unwrap();
+            assert_eq!(command, "NOOP\r\n");
+            control.get_mut().write_all(b"200 noop\r\n").unwrap();
+        });
+        let ftp = AsyncFtpStream::connect(address).await.unwrap();
+        (ftp, release, server)
+    }
+
+    #[test]
+    fn should_recover_drop_while_control_socket_is_locked() {
+        smol::block_on(async {
+            let (mut ftp, release, server) = delayed_transfer_reply(b"", b"226 complete\r\n").await;
+            let transfer = ftp.put_with_stream("test.bin").await.unwrap();
+            let guard = ftp.get_ref().await;
+            drop(transfer);
+            drop(guard);
+            release.send(()).unwrap();
+            ftp.noop().await.unwrap();
+            ftp.control()
+                .await
+                .unwrap()
+                .guard_multiple_data_connections()
+                .unwrap();
+            server.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn should_recover_cancelled_finish_waiting_for_control_lock() {
+        smol::block_on(async {
+            use std::future::{Future, poll_fn};
+            use std::task::Poll;
+
+            let (mut ftp, release, server) = delayed_transfer_reply(b"", b"226 complete\r\n").await;
+            let transfer = ftp.put_with_stream("test.bin").await.unwrap();
+            let guard = ftp.get_ref().await;
+            let mut finish = Box::pin(transfer.finish());
+            poll_fn(|cx| {
+                assert!(finish.as_mut().poll(cx).is_pending());
+                Poll::Ready(())
+            })
+            .await;
+            drop(finish);
+            drop(guard);
+            release.send(()).unwrap();
+            ftp.noop().await.unwrap();
+            ftp.control()
+                .await
+                .unwrap()
+                .guard_multiple_data_connections()
+                .unwrap();
+            server.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn should_resume_partial_reply_after_cancelled_finish() {
+        smol::block_on(async {
+            let (mut ftp, release, server) = delayed_transfer_reply(
+                b"226-transferred\r\nintermediate line\r\n226 comp",
+                b"lete\r\n",
+            )
+            .await;
+            let transfer = ftp.put_with_stream("test.bin").await.unwrap();
+            assert!(
+                smol::future::race(
+                    async {
+                        let _ = transfer.finish().await;
+                        false
+                    },
+                    async {
+                        smol::Timer::after(Duration::from_millis(50)).await;
+                        true
+                    }
+                )
+                .await
+            );
+            release.send(()).unwrap();
+            ftp.noop().await.unwrap();
+            ftp.control()
+                .await
+                .unwrap()
+                .guard_multiple_data_connections()
+                .unwrap();
+            server.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn should_resume_partial_reply_after_cancelled_drain() {
+        smol::block_on(async {
+            let (mut ftp, release, server) = delayed_transfer_reply(
+                b"226-transferred\r\nintermediate line\r\n226 comp",
+                b"lete\r\n",
+            )
+            .await;
+            let transfer = ftp.put_with_stream("test.bin").await.unwrap();
+            drop(transfer);
+            assert!(
+                smol::future::race(
+                    async {
+                        let _ = ftp.noop().await;
+                        false
+                    },
+                    async {
+                        smol::Timer::after(Duration::from_millis(50)).await;
+                        true
+                    }
+                )
+                .await
+            );
+            release.send(()).unwrap();
+            ftp.noop().await.unwrap();
+            ftp.control()
+                .await
+                .unwrap()
+                .guard_multiple_data_connections()
+                .unwrap();
+            server.join().unwrap();
+        });
     }
 }

--- a/crates/suppaftp/src/async_ftp/smol_ftp/transfer_stream.rs
+++ b/crates/suppaftp/src/async_ftp/smol_ftp/transfer_stream.rs
@@ -1,0 +1,207 @@
+//! Self-finalizing data stream for smol FTP transfers.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use smol::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+
+use super::control::SharedControl;
+use super::data_stream::DataStream;
+use super::tls::SmolTlsStream;
+use crate::types::{FtpError, FtpResult};
+
+/// Whether the transfer writes to or reads from the server.
+///
+/// Uploads are only complete once the write side has been closed successfully, so a close error
+/// fails an upload; downloads have already read the whole payload, so a close error is ignored
+/// and the server's completion reply is authoritative.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Direction {
+    /// `STOR` / `APPE`: data flows to the server.
+    Upload,
+    /// `RETR`, listings and custom data commands: data flows from the server.
+    Download,
+}
+
+/// Data connection of an FTP transfer that finalizes itself.
+///
+/// Returned by [`ImplAsyncFtpStream::put_with_stream`], [`ImplAsyncFtpStream::append_with_stream`],
+/// [`ImplAsyncFtpStream::retr_as_stream`] and [`ImplAsyncFtpStream::custom_data_command`]. It
+/// implements [`AsyncRead`] and [`AsyncWrite`] by delegating to the underlying [`DataStream`].
+///
+/// Once the payload has been written or read, call [`TransferStream::finish`]: it closes the
+/// data socket and reads the server's completion reply on the control connection, which is the
+/// only way to learn whether the transfer succeeded.
+///
+/// A stream that is merely dropped cannot await, so it closes its socket (without a TLS
+/// `close_notify`, which strict servers may report as a failed transfer) and defers the reply:
+/// the next command on the client consumes it before sending anything, so the control connection
+/// never desynchronizes. The transfer outcome is lost in that case and only logged.
+///
+/// While a `TransferStream` is alive the client refuses to open another data connection with
+/// [`FtpError::DataConnectionAlreadyOpen`]. The stream owns no reference to the client and is
+/// [`Send`] whenever the TLS stream is, so it can be moved to another task and finished there.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use smol::io::AsyncWriteExt;
+/// use suppaftp::smol::AsyncFtpStream;
+///
+/// # async fn run() {
+/// let mut ftp = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+/// ftp.login("test", "test").await.unwrap();
+/// let mut upload = ftp.put_with_stream("hello.txt").await.unwrap();
+/// upload.write_all(b"hello, world!").await.unwrap();
+/// // Reads the `226` reply; the control connection is ready for the next command.
+/// upload.finish().await.unwrap();
+/// assert_eq!(ftp.size("hello.txt").await.unwrap(), 13);
+/// # }
+/// ```
+///
+/// [`ImplAsyncFtpStream::put_with_stream`]: super::ImplAsyncFtpStream::put_with_stream
+/// [`ImplAsyncFtpStream::append_with_stream`]: super::ImplAsyncFtpStream::append_with_stream
+/// [`ImplAsyncFtpStream::retr_as_stream`]: super::ImplAsyncFtpStream::retr_as_stream
+/// [`ImplAsyncFtpStream::custom_data_command`]: super::ImplAsyncFtpStream::custom_data_command
+/// [`FtpError::DataConnectionAlreadyOpen`]: crate::FtpError::DataConnectionAlreadyOpen
+#[must_use = "call `finish().await` to close the data connection and read the transfer reply"]
+#[derive(Debug)]
+pub struct TransferStream<T>
+where
+    T: SmolTlsStream + Send,
+{
+    /// Data socket; `None` once the transfer has been finalized or detached.
+    data: Option<DataStream<T>>,
+    control: SharedControl<T>,
+    direction: Direction,
+}
+
+impl<T> TransferStream<T>
+where
+    T: SmolTlsStream + Send,
+{
+    /// Wraps an open data connection so that it completes the transfer on `control`.
+    pub(super) fn new(
+        data: DataStream<T>,
+        control: SharedControl<T>,
+        direction: Direction,
+    ) -> Self {
+        Self {
+            data: Some(data),
+            control,
+            direction,
+        }
+    }
+
+    /// Returns a reference to the underlying [`DataStream`].
+    pub fn get_ref(&self) -> &DataStream<T> {
+        self.data
+            .as_ref()
+            .expect("data stream is present until the transfer is finished")
+    }
+
+    /// Returns a mutable reference to the underlying [`DataStream`].
+    pub fn get_mut(&mut self) -> &mut DataStream<T> {
+        self.data
+            .as_mut()
+            .expect("data stream is present until the transfer is finished")
+    }
+
+    /// Closes the data connection and reads the transfer completion reply.
+    ///
+    /// After this call the client can issue the next command.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::ConnectionError`] if an upload cannot be closed cleanly or the
+    /// control connection cannot be read, and [`FtpError::UnexpectedResponse`] if the server
+    /// reports that the transfer failed (any reply other than `226` or `250`).
+    pub async fn finish(mut self) -> FtpResult<()> {
+        let Some(mut data) = self.data.take() else {
+            return Ok(());
+        };
+        // Close the write side so TLS streams send close_notify before being dropped, then close
+        // the socket: the server only sends the completion reply once the data connection is gone.
+        let closed = data.close().await;
+        drop(data);
+        let reply = self.control.lock().await.complete_transfer().await;
+        if self.direction == Direction::Upload {
+            closed.map_err(FtpError::ConnectionError)?;
+        }
+        reply
+    }
+
+    /// Detaches the data socket; the returned stream no longer completes the transfer on drop.
+    ///
+    /// Used by [`super::ImplAsyncFtpStream::abort`], which reads the reply itself.
+    pub(super) fn detach(mut self) -> DataStream<T> {
+        self.data
+            .take()
+            .expect("data stream is present until the transfer is finished")
+    }
+
+    /// Whether the transfer has already been finalized.
+    fn is_finished(&self) -> bool {
+        self.data.is_none()
+    }
+}
+
+impl<T> AsyncRead for TransferStream<T>
+where
+    T: SmolTlsStream + Send,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(Pin::into_inner(self).get_mut()).poll_read(cx, buf)
+    }
+}
+
+impl<T> AsyncWrite for TransferStream<T>
+where
+    T: SmolTlsStream + Send,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(Pin::into_inner(self).get_mut()).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(Pin::into_inner(self).get_mut()).poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(Pin::into_inner(self).get_mut()).poll_close(cx)
+    }
+}
+
+impl<T> Drop for TransferStream<T>
+where
+    T: SmolTlsStream + Send,
+{
+    fn drop(&mut self) {
+        if self.is_finished() {
+            return;
+        }
+        // Closing the socket makes the server send the completion reply; it cannot be awaited
+        // here, so it is left for the next command to drain.
+        drop(self.data.take());
+        match self.control.try_lock() {
+            Some(mut cc) => {
+                cc.data_connection_open = false;
+                cc.pending_transfer_reply = true;
+                warn!(
+                    "transfer stream dropped without finish(); its reply is read by the next command"
+                );
+            }
+            None => warn!(
+                "transfer stream dropped without finish() while the control connection is busy; the control connection is out of sync"
+            ),
+        }
+    }
+}

--- a/crates/suppaftp/src/async_ftp/tokio_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp.rs
@@ -130,6 +130,7 @@ where
     }
 
     /// Switch to secure mode if possible (FTPS), using a provided SSL configuration.
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] before sending `AUTH` if a transfer is alive.
     /// This method does nothing if the connect is already secured.
     ///
     /// ## Example
@@ -152,6 +153,10 @@ where
         tls_connector: impl AsyncTlsConnector<Stream = T> + Send + Sync + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
+        // Reject a live transfer before asking the server to change the control protocol.
+        if Arc::strong_count(&self.control) != 1 {
+            return Err(FtpError::DataConnectionAlreadyOpen);
+        }
         debug!("Initializing TLS auth");
         {
             let mut cc = self.control().await?;
@@ -325,9 +330,14 @@ where
     /// Perform clear command channel (CCC).
     /// Once the command is performed, the command channel will be encrypted no more.
     /// The data stream will still be secure.
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] before sending `CCC` if a transfer is alive.
     #[cfg(feature = "async-secure")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-secure")))]
     pub async fn clear_command_channel(mut self) -> FtpResult<Self> {
+        // Reject a live transfer before asking the server to change the control protocol.
+        if Arc::strong_count(&self.control) != 1 {
+            return Err(FtpError::DataConnectionAlreadyOpen);
+        }
         {
             let mut cc = self.control().await?;
             // Ask the server to stop securing data
@@ -453,8 +463,8 @@ where
     ///
     /// `reader` is an async pinned closure that takes the [`TransferStream<T>`] and returns
     /// both the result `U` and the [`TransferStream<T>`] back in a tuple `(U, TransferStream<T>)`.
-    /// The stream is then finished by this method, so the control connection is left in sync
-    /// whether `reader` succeeded or not.
+    /// The stream is finished on callback success. If `reader` returns an error and drops the
+    /// stream, the next command drains its completion reply before sending anything.
     ///
     /// > Warning: Don't call [`TransferStream::finish`] inside `reader`; return the stream instead.
     pub async fn retr<S, F, U>(&mut self, file_name: S, mut reader: F) -> FtpResult<U>
@@ -634,6 +644,7 @@ where
     /// The data connection is closed and the server's abort replies (`426` followed by `226`,
     /// or a single `226`) are consumed, so the control connection is ready for the next command.
     /// `transfer` must have been obtained from this client.
+    /// This operation is not cancellation-safe: reconnect if its future is cancelled after polling.
     ///
     /// # Errors
     ///
@@ -973,7 +984,12 @@ where
             .await?;
         Ok((
             response,
-            TransferStream::new(data_stream, Arc::clone(&self.control), direction),
+            TransferStream::new(
+                data_stream,
+                Arc::clone(&self.control),
+                direction,
+                Arc::clone(&cc.pending_transfer_reply),
+            ),
         ))
     }
 
@@ -1412,7 +1428,7 @@ mod test {
             let container_t = container_t.clone();
             let handle = handle.clone();
             Box::pin(async move {
-                let mut addr = addr.clone();
+                let mut addr = addr;
                 let port = addr.port();
 
                 let mapped = tokio::task::spawn_blocking(move || {
@@ -1420,10 +1436,9 @@ mod test {
                 })
                 .await
                 .map_err(|e| {
-                    FtpError::ConnectionError(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("spawn_blocking failed: {e}"),
-                    ))
+                    FtpError::ConnectionError(std::io::Error::other(format!(
+                        "spawn_blocking failed: {e}"
+                    )))
                 })
                 .expect("failed to join");
 
@@ -2041,7 +2056,7 @@ mod test {
             let container_t = container_t.clone();
             let handle = handle.clone();
             Box::pin(async move {
-                let mut addr = addr.clone();
+                let mut addr = addr;
                 let port = addr.port();
 
                 let mapped = tokio::task::spawn_blocking(move || {
@@ -2049,10 +2064,9 @@ mod test {
                 })
                 .await
                 .map_err(|e| {
-                    FtpError::ConnectionError(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("spawn_blocking failed: {e}"),
-                    ))
+                    FtpError::ConnectionError(std::io::Error::other(format!(
+                        "spawn_blocking failed: {e}"
+                    )))
                 })
                 .expect("failed to join");
 

--- a/crates/suppaftp/src/async_ftp/tokio_ftp.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp.rs
@@ -2,8 +2,10 @@
 //!
 //! This module contains the definition for tokio async implementation of suppaftp
 
+mod control;
 mod data_stream;
 mod tls;
+mod transfer_stream;
 
 use std::future::Future;
 #[cfg(not(feature = "async-secure"))]
@@ -11,10 +13,13 @@ use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::string::String;
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 // export
+pub use control::ControlSocket;
+use control::{ControlChannel, SharedControl};
 pub use data_stream::DataStream;
 #[cfg(feature = "async-secure")]
 pub use tls::AsyncTlsConnector;
@@ -23,8 +28,11 @@ pub use tls::{AsyncNativeTlsConnector, AsyncNativeTlsStream};
 pub use tls::{AsyncNoTlsStream, TokioTlsStream};
 #[cfg(any(feature = "tokio-rustls-aws-lc-rs", feature = "tokio-rustls-ring"))]
 pub use tls::{AsyncRustlsConnector, AsyncRustlsStream};
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, copy};
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader, copy};
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio::sync::MutexGuard;
+use transfer_stream::Direction;
+pub use transfer_stream::TransferStream;
 
 use super::super::Status;
 use super::super::regex::{EPSV_PORT_RE, MDTM_RE, SIZE_RE};
@@ -43,21 +51,21 @@ pub type TokioPassiveStreamBuilder = dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Ou
     + Sync;
 
 /// Stream to interface with the FTP server. This interface is only for the command stream.
+///
+/// The control connection is shared with the [`TransferStream`]s handed out by the data
+/// commands, so that each transfer can close its data connection and read the completion reply
+/// on its own; see [`TransferStream`] for details.
 pub struct ImplAsyncFtpStream<T>
 where
     T: TokioTlsStream + Send,
 {
-    reader: BufReader<DataStream<T>>,
+    /// Control connection, locked for the duration of each command.
+    control: SharedControl<T>,
     mode: Mode,
     nat_workaround: bool,
     welcome_msg: Option<String>,
     active_timeout: Duration,
     passive_stream_builder: Box<TokioPassiveStreamBuilder>,
-    /// flags whether a data connection is currently open
-    ///
-    /// Since it isn't possible to have multiple data connections at the same time,
-    /// this flag is used to track whether a data connection is currently open.
-    data_connection_open: bool,
     #[cfg(not(feature = "async-secure"))]
     marker: PhantomData<T>,
     #[cfg(feature = "async-secure")]
@@ -95,12 +103,11 @@ where
     pub async fn connect_with_stream(stream: TcpStream) -> FtpResult<Self> {
         debug!("Established connection with server");
         let mut ftp_stream = ImplAsyncFtpStream {
-            reader: BufReader::new(DataStream::Tcp(stream)),
+            control: ControlChannel::shared(DataStream::Tcp(stream)),
             #[cfg(not(feature = "async-secure"))]
             marker: PhantomData {},
             mode: Mode::Passive,
             nat_workaround: false,
-            data_connection_open: false,
             passive_stream_builder: Self::default_passive_stream_builder(),
             welcome_msg: None,
             #[cfg(feature = "async-secure")]
@@ -110,7 +117,8 @@ where
             active_timeout: Duration::from_secs(60),
         };
         debug!("Reading server response...");
-        match ftp_stream.read_response(Status::Ready).await {
+        let ready = ftp_stream.read_response(Status::Ready).await;
+        match ready {
             Ok(response) => {
                 let welcome_msg = response.as_string().ok();
                 debug!("Server READY; response: {:?}", welcome_msg);
@@ -140,38 +148,45 @@ where
     #[cfg(feature = "async-secure")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-secure")))]
     pub async fn into_secure(
-        mut self,
+        self,
         tls_connector: impl AsyncTlsConnector<Stream = T> + Send + Sync + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Initializing TLS auth");
-        // Ask the server to start securing data.
-        self.perform(Command::Auth).await?;
-        self.read_response(Status::AuthOk).await?;
+        {
+            let mut cc = self.control().await?;
+            // Ask the server to start securing data.
+            cc.perform(Command::Auth).await?;
+            cc.read_response(Status::AuthOk).await?;
+        }
         debug!("TLS OK; initializing ssl stream");
+        let plain = control::into_exclusive(self.control)?
+            .reader
+            .into_inner()
+            .into_tcp_stream()?;
         let stream = tls_connector
-            .connect(domain, self.reader.into_inner().into_tcp_stream()?)
+            .connect(domain, plain)
             .await
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
-        let mut secured_ftp_tream = ImplAsyncFtpStream {
-            reader: BufReader::new(DataStream::Ssl(Box::new(stream))),
+        let secured_ftp_tream = ImplAsyncFtpStream {
+            control: ControlChannel::shared(DataStream::Ssl(Box::new(stream))),
             mode: self.mode,
             nat_workaround: self.nat_workaround,
             passive_stream_builder: self.passive_stream_builder,
-            data_connection_open: self.data_connection_open,
             tls_ctx: Some(Box::new(tls_connector)),
             domain: Some(String::from(domain)),
             welcome_msg: self.welcome_msg,
             active_timeout: self.active_timeout,
         };
-        // Set protection buffer size
-        secured_ftp_tream.perform(Command::Pbsz(0)).await?;
-        secured_ftp_tream.read_response(Status::CommandOk).await?;
-        // Change the level of data protectio to Private
-        secured_ftp_tream
-            .perform(Command::Prot(ProtectionLevel::Private))
-            .await?;
-        secured_ftp_tream.read_response(Status::CommandOk).await?;
+        {
+            let mut cc = secured_ftp_tream.control().await?;
+            // Set protection buffer size
+            cc.perform(Command::Pbsz(0)).await?;
+            cc.read_response(Status::CommandOk).await?;
+            // Change the level of data protectio to Private
+            cc.perform(Command::Prot(ProtectionLevel::Private)).await?;
+            cc.read_response(Status::CommandOk).await?;
+        }
         Ok(secured_ftp_tream)
     }
 
@@ -205,33 +220,18 @@ where
         debug!("Connecting to server (secure)");
         let stream = TcpStream::connect(addr)
             .await
-            .map_err(FtpError::ConnectionError)
-            .map(|stream| {
-                debug!("Established connection with server");
-                Self {
-                    reader: BufReader::new(DataStream::Tcp(stream)),
-                    mode: Mode::Passive,
-                    nat_workaround: false,
-                    welcome_msg: None,
-                    data_connection_open: false,
-                    passive_stream_builder: Self::default_passive_stream_builder(),
-                    tls_ctx: None,
-                    domain: None,
-                    active_timeout: Duration::from_secs(60),
-                }
-            })?;
+            .map_err(FtpError::ConnectionError)?;
         debug!("Established connection with server");
         debug!("TLS OK; initializing ssl stream");
         let stream = tls_connector
-            .connect(domain, stream.reader.into_inner().into_tcp_stream()?)
+            .connect(domain, stream)
             .await
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
         let mut stream = ImplAsyncFtpStream {
-            reader: BufReader::new(DataStream::Ssl(stream.into())),
+            control: ControlChannel::shared(DataStream::Ssl(Box::new(stream))),
             mode: Mode::Passive,
             nat_workaround: false,
-            data_connection_open: false,
             passive_stream_builder: Self::default_passive_stream_builder(),
             tls_ctx: Some(Box::new(tls_connector)),
             domain: Some(String::from(domain)),
@@ -239,14 +239,10 @@ where
             active_timeout: Duration::from_secs(60),
         };
         debug!("Reading server response...");
-        match stream.read_response(Status::Ready).await {
-            Ok(response) => {
-                let welcome_msg = response.as_string().ok();
-                debug!("Server READY; response: {:?}", welcome_msg);
-                stream.welcome_msg = welcome_msg;
-            }
-            Err(err) => return Err(err),
-        }
+        let response = stream.read_response(Status::Ready).await?;
+        let welcome_msg = response.as_string().ok();
+        debug!("Server READY; response: {:?}", welcome_msg);
+        stream.welcome_msg = welcome_msg;
 
         Ok(stream)
     }
@@ -289,24 +285,38 @@ where
         self.nat_workaround = nat_workaround;
     }
 
-    /// Returns a reference to the underlying TcpStream.
-    pub fn get_ref(&self) -> &TcpStream {
-        self.reader.get_ref().get_ref()
+    /// Returns a locked view of the underlying control [`TcpStream`].
+    ///
+    /// The returned [`ControlSocket`] dereferences to the socket and keeps the control connection
+    /// locked while alive, so drop it before finishing a [`TransferStream`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use suppaftp::tokio::AsyncFtpStream;
+    ///
+    /// # async fn run() {
+    /// let stream = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+    /// stream.get_ref().await.set_nodelay(true).unwrap();
+    /// # }
+    /// ```
+    pub async fn get_ref(&self) -> ControlSocket<'_, T> {
+        ControlSocket::new(self.control.lock().await)
     }
 
     /// Log in to the FTP server.
     pub async fn login<S: AsRef<str>>(&mut self, user: S, password: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Signin in with user '{}'", user.as_ref());
-        self.perform(Command::User(user.as_ref().to_string()))
-            .await?;
-        let response = self
+        cc.perform(Command::User(user.as_ref().to_string())).await?;
+        let response = cc
             .read_response_in(&[Status::LoggedIn, Status::NeedPassword])
             .await?;
         if response.status == Status::NeedPassword {
             debug!("Password is required");
-            self.perform(Command::Pass(password.as_ref().to_string()))
+            cc.perform(Command::Pass(password.as_ref().to_string()))
                 .await?;
-            self.read_response(Status::LoggedIn).await?;
+            cc.read_response(Status::LoggedIn).await?;
         }
         debug!("Login OK");
         Ok(())
@@ -318,39 +328,48 @@ where
     #[cfg(feature = "async-secure")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-secure")))]
     pub async fn clear_command_channel(mut self) -> FtpResult<Self> {
-        // Ask the server to stop securing data
-        debug!("performing clear command channel");
-        self.perform(Command::ClearCommandChannel).await?;
-        self.read_response(Status::CommandOk).await?;
+        {
+            let mut cc = self.control().await?;
+            // Ask the server to stop securing data
+            debug!("performing clear command channel");
+            cc.perform(Command::ClearCommandChannel).await?;
+            cc.read_response(Status::CommandOk).await?;
+        }
         trace!("CCC OK");
-        self.reader = BufReader::new(DataStream::Tcp(self.reader.into_inner().into_tcp_stream()?));
+        let plain = control::into_exclusive(self.control)?
+            .reader
+            .into_inner()
+            .into_tcp_stream()?;
+        self.control = ControlChannel::shared(DataStream::Tcp(plain));
         Ok(self)
     }
 
     /// Change the current directory to the path specified.
     pub async fn cwd<S: AsRef<str>>(&mut self, path: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Changing working directory to {}", path.as_ref());
-        self.perform(Command::Cwd(path.as_ref().to_string()))
-            .await?;
-        self.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
+        cc.perform(Command::Cwd(path.as_ref().to_string())).await?;
+        cc.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
             .await
             .map(|_| ())
     }
 
     /// Move the current directory to the parent directory.
     pub async fn cdup(&mut self) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Going to parent directory");
-        self.perform(Command::Cdup).await?;
-        self.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
+        cc.perform(Command::Cdup).await?;
+        cc.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
             .await
             .map(|_| ())
     }
 
     /// Gets the current directory
     pub async fn pwd(&mut self) -> FtpResult<String> {
+        let mut cc = self.control().await?;
         debug!("Getting working directory");
-        self.perform(Command::Pwd).await?;
-        let response = self.read_response(Status::PathCreated).await?;
+        cc.perform(Command::Pwd).await?;
+        let response = cc.read_response(Status::PathCreated).await?;
         let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
         let status = response.status;
         match (body.find('"'), body.rfind('"')) {
@@ -364,27 +383,30 @@ where
 
     /// This does nothing. This is usually just used to keep the connection open.
     pub async fn noop(&mut self) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Pinging server");
-        self.perform(Command::Noop).await?;
-        self.read_response(Status::CommandOk).await.map(|_| ())
+        cc.perform(Command::Noop).await?;
+        cc.read_response(Status::CommandOk).await.map(|_| ())
     }
 
     /// The EPRT command allows for the specification of an extended address
     /// for the data connection. The extended address MUST consist of the
     /// network protocol as well as the network and transport addresses
     pub async fn eprt(&mut self, address: SocketAddr) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("EPRT with address {address}");
-        self.perform(Command::Eprt(address)).await?;
-        self.read_response(Status::CommandOk).await.map(|_| ())
+        cc.perform(Command::Eprt(address)).await?;
+        cc.read_response(Status::CommandOk).await.map(|_| ())
     }
 
     /// This creates a new directory on the server.
     pub async fn mkdir<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Creating directory at {}", pathname.as_ref());
-        self.perform(Command::Mkd(pathname.as_ref().to_string()))
+        cc.perform(Command::Mkd(pathname.as_ref().to_string()))
             .await?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 257.
-        self.read_response_in(&[Status::PathCreated, Status::CommandOk])
+        cc.read_response_in(&[Status::PathCreated, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -392,32 +414,35 @@ where
     /// Sets the type of file to be transferred. That is the implementation
     /// of `TYPE` command.
     pub async fn transfer_type(&mut self, file_type: FileType) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Setting transfer type {}", file_type);
-        self.perform(Command::Type(file_type)).await?;
-        self.read_response(Status::CommandOk).await.map(|_| ())
+        cc.perform(Command::Type(file_type)).await?;
+        cc.read_response(Status::CommandOk).await.map(|_| ())
     }
 
     /// Quits the current FTP session.
     pub async fn quit(&mut self) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Quitting stream");
-        self.perform(Command::Quit).await?;
-        self.read_response(Status::Closing).await.map(|_| ())
+        cc.perform(Command::Quit).await?;
+        cc.read_response(Status::Closing).await.map(|_| ())
     }
 
     /// Renames the file from_name to to_name
     pub async fn rename<S: AsRef<str>>(&mut self, from_name: S, to_name: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!(
             "Renaming '{}' to '{}'",
             from_name.as_ref(),
             to_name.as_ref()
         );
-        self.perform(Command::RenameFrom(from_name.as_ref().to_string()))
+        cc.perform(Command::RenameFrom(from_name.as_ref().to_string()))
             .await?;
-        self.read_response(Status::RequestFilePending).await?;
-        self.perform(Command::RenameTo(to_name.as_ref().to_string()))
+        cc.read_response(Status::RequestFilePending).await?;
+        cc.perform(Command::RenameTo(to_name.as_ref().to_string()))
             .await?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
-        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
+        cc.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -426,89 +451,87 @@ where
     /// to download from FTP and `reader` is the function which operates with the
     /// data stream opened.
     ///
-    /// `reader` is an async pinned closure that takes the [`DataStream<T>`] and returns
-    /// both the result `U` and the [`DataStream<T>`] back in a tuple `(U, DataStream<T>)`.
+    /// `reader` is an async pinned closure that takes the [`TransferStream<T>`] and returns
+    /// both the result `U` and the [`TransferStream<T>`] back in a tuple `(U, TransferStream<T>)`.
+    /// The stream is then finished by this method, so the control connection is left in sync
+    /// whether `reader` succeeded or not.
     ///
-    /// This is necessary because the stream is then finalized with `finalize_retr_stream()`
-    /// within this method.
-    ///
-    /// > Warning: Don't call [`Self::finalize_retr_stream`] manually, otherwise this will cause an error.
+    /// > Warning: Don't call [`TransferStream::finish`] inside `reader`; return the stream instead.
     pub async fn retr<S, F, U>(&mut self, file_name: S, mut reader: F) -> FtpResult<U>
     where
         F: FnMut(
-            DataStream<T>,
-        ) -> Pin<Box<dyn Future<Output = FtpResult<(U, DataStream<T>)>> + Send>>,
+            TransferStream<T>,
+        )
+            -> Pin<Box<dyn Future<Output = FtpResult<(U, TransferStream<T>)>> + Send>>,
         S: AsRef<str>,
     {
-        match self.retr_as_stream(file_name).await {
-            Ok(stream) => {
-                let (result, stream) = reader(stream).await?;
-                self.finalize_retr_stream(stream).await?;
-                Ok(result)
-            }
-            Err(err) => Err(err),
-        }
+        let stream = self.retr_as_stream(file_name).await?;
+        let (result, stream) = reader(stream).await?;
+        stream.finish().await?;
+        Ok(result)
     }
 
-    /// Retrieves the file name specified from the server as a readable stream.
-    /// This method is a more complicated way to retrieve a file.
-    /// The reader returned should be dropped.
-    /// Also you will have to read the response to make sure it has the correct value.
-    /// Once file has been read, call `finalize_retr_stream()`
+    /// Retrieves the file `file_name` from the server as a readable [`TransferStream`].
+    ///
+    /// Read the payload from the returned stream, then call [`TransferStream::finish`] to close
+    /// the data connection and read the server's completion reply. Until then any other data
+    /// command fails with [`FtpError::DataConnectionAlreadyOpen`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use suppaftp::tokio::AsyncFtpStream;
+    /// use tokio::io::AsyncReadExt;
+    ///
+    /// # async fn run() {
+    /// let mut ftp = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+    /// ftp.login("test", "test").await.unwrap();
+    /// let mut download = ftp.retr_as_stream("hello.txt").await.unwrap();
+    /// let mut buf = Vec::new();
+    /// download.read_to_end(&mut buf).await.unwrap();
+    /// download.finish().await.unwrap();
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server refuses the `RETR` command.
     pub async fn retr_as_stream<S: AsRef<str>>(
         &mut self,
         file_name: S,
-    ) -> FtpResult<DataStream<T>> {
+    ) -> FtpResult<TransferStream<T>> {
         debug!("Retrieving '{}'", file_name.as_ref());
-        let (_, data_stream) = self
-            .data_command_with_response(
+        let (_, stream) = self
+            .open_transfer(
                 Command::Retr(file_name.as_ref().to_string()),
                 &[Status::AboutToSend, Status::AlreadyOpen],
+                Direction::Download,
             )
             .await?;
-        Ok(data_stream)
-    }
-
-    /// Finalize retr stream; must be called once the requested file, got previously with `retr_as_stream()` has been read.
-    ///
-    /// Write-side shutdown errors are ignored after the payload has been read. The final FTP
-    /// control response determines whether the transfer succeeded.
-    pub async fn finalize_retr_stream(
-        &mut self,
-        mut stream: impl AsyncRead + AsyncWrite + Unpin,
-    ) -> FtpResult<()> {
-        debug!("Finalizing retr stream");
-        // Close the write side so TLS streams send close_notify before being dropped. The server's
-        // completion response remains authoritative if closing an already-read stream fails.
-        let _ = stream.shutdown().await;
-        // Drop stream NOTE: must be done first, otherwise server won't return any response
-        drop(stream);
-        self.data_connection_open = false;
-        trace!("dropped stream");
-        // Then read response
-        self.read_response_in(&[Status::ClosingDataConnection, Status::RequestedFileActionOk])
-            .await
-            .map(|_| ())
+        Ok(stream)
     }
 
     /// Removes the remote pathname from the server.
     pub async fn rmdir<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Removing directory {}", pathname.as_ref());
-        self.perform(Command::Rmd(pathname.as_ref().to_string()))
+        cc.perform(Command::Rmd(pathname.as_ref().to_string()))
             .await?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
-        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
+        cc.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
 
     /// Remove the remote file from the server.
     pub async fn rm<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Removing file {}", filename.as_ref());
-        self.perform(Command::Dele(filename.as_ref().to_string()))
+        cc.perform(Command::Dele(filename.as_ref().to_string()))
             .await?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
-        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
+        cc.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .await
             .map(|_| ())
     }
@@ -525,58 +548,68 @@ where
         let bytes = copy(r, &mut data_stream)
             .await
             .map_err(FtpError::ConnectionError)?;
-        self.finalize_put_stream(data_stream).await?;
+        data_stream.finish().await?;
         Ok(bytes)
     }
 
-    /// Send PUT command and returns a BufWriter, which references the file created on the server
-    /// The returned stream must be then correctly manipulated to write the content of the source file to the remote destination
-    /// The stream must be then correctly dropped.
-    /// Once you've finished the write, YOU MUST CALL THIS METHOD: `finalize_put_stream`
+    /// Sends `STOR` and returns a writable [`TransferStream`] for the file `filename`.
+    ///
+    /// Write the payload to the returned stream, then call [`TransferStream::finish`] to close
+    /// the data connection and read the server's completion reply. Until then any other data
+    /// command fails with [`FtpError::DataConnectionAlreadyOpen`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use suppaftp::tokio::AsyncFtpStream;
+    /// use tokio::io::AsyncWriteExt;
+    ///
+    /// # async fn run() {
+    /// let mut ftp = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+    /// ftp.login("test", "test").await.unwrap();
+    /// let mut upload = ftp.put_with_stream("hello.txt").await.unwrap();
+    /// upload.write_all(b"hello, world!").await.unwrap();
+    /// upload.finish().await.unwrap();
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server refuses the `STOR` command.
     pub async fn put_with_stream<S: AsRef<str>>(
         &mut self,
         filename: S,
-    ) -> FtpResult<DataStream<T>> {
+    ) -> FtpResult<TransferStream<T>> {
         debug!("Put file {}", filename.as_ref());
         let (_, stream) = self
-            .data_command_with_response(
+            .open_transfer(
                 Command::Store(filename.as_ref().to_string()),
                 &[Status::AlreadyOpen, Status::AboutToSend],
+                Direction::Upload,
             )
             .await?;
         Ok(stream)
     }
 
-    /// Finalize put when using stream
-    /// This method must be called once the file has been written and
-    /// `put_with_stream` has been used to write the file
-    pub async fn finalize_put_stream(
-        &mut self,
-        mut stream: impl AsyncWriteExt + Unpin,
-    ) -> FtpResult<()> {
-        debug!("Finalizing put stream");
-        // Drop stream NOTE: must be done first, otherwise server won't return any response
-        stream.shutdown().await.map_err(FtpError::ConnectionError)?;
-        drop(stream);
-        self.data_connection_open = false;
-        trace!("Stream dropped");
-        // Read response
-        self.read_response_in(&[Status::ClosingDataConnection, Status::RequestedFileActionOk])
-            .await
-            .map(|_| ())
-    }
-
-    /// Open specified file for appending data. Returns the stream to append data to specified file.
-    /// Once you've finished the write, YOU MUST CALL THIS METHOD: `finalize_put_stream`
+    /// Sends `APPE` and returns a writable [`TransferStream`] appending to the file `filename`.
+    ///
+    /// Behaves like [`ImplAsyncFtpStream::put_with_stream`], except that the data is appended.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server refuses the `APPE` command.
     pub async fn append_with_stream<S: AsRef<str>>(
         &mut self,
         filename: S,
-    ) -> FtpResult<DataStream<T>> {
+    ) -> FtpResult<TransferStream<T>> {
         debug!("Appending to file {}", filename.as_ref());
         let (_, stream) = self
-            .data_command_with_response(
+            .open_transfer(
                 Command::Appe(filename.as_ref().to_string()),
                 &[Status::AlreadyOpen, Status::AboutToSend],
+                Direction::Upload,
             )
             .await?;
         Ok(stream)
@@ -592,27 +625,35 @@ where
         let bytes = copy(r, &mut data_stream)
             .await
             .map_err(FtpError::ConnectionError)?;
-        self.finalize_put_stream(Box::new(data_stream)).await?;
+        data_stream.finish().await?;
         Ok(bytes)
     }
 
-    /// abort the previous FTP service command
-    pub async fn abort<R>(&mut self, data_stream: R) -> FtpResult<()>
-    where
-        R: AsyncRead + std::marker::Unpin + 'static,
-    {
+    /// Aborts the transfer running on `transfer` with the `ABOR` command.
+    ///
+    /// The data connection is closed and the server's abort replies (`426` followed by `226`,
+    /// or a single `226`) are consumed, so the control connection is ready for the next command.
+    /// `transfer` must have been obtained from this client.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::UnexpectedResponse`] if the server does not acknowledge the abort.
+    pub async fn abort(&mut self, transfer: TransferStream<T>) -> FtpResult<()> {
         debug!("Aborting active file transfer");
-        self.perform(Command::Abor).await?;
+        // Detach the socket first: the stream must not flag a pending reply on drop.
+        let data_stream = transfer.detach();
+        let mut cc = self.control().await?;
+        cc.perform(Command::Abor).await?;
         // Drop stream NOTE: must be done first, otherwise server won't return any response
         drop(data_stream);
-        self.data_connection_open = false;
+        cc.data_connection_open = false;
         trace!("dropped stream");
-        let response = self
+        let response = cc
             .read_response_in(&[Status::ClosingDataConnection, Status::TransferAborted])
             .await?;
         // If server sent 426 (TransferAborted), expect a follow-up 226
         if response.status == Status::TransferAborted {
-            self.read_response(Status::ClosingDataConnection).await?;
+            cc.read_response(Status::ClosingDataConnection).await?;
         }
         trace!("Transfer aborted");
         Ok(())
@@ -625,9 +666,10 @@ where
     ///
     /// It is possible to cancel the REST command, sending a REST command with offset 0
     pub async fn resume_transfer(&mut self, offset: usize) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Requesting to resume transfer at offset {}", offset);
-        self.perform(Command::Rest(offset)).await?;
-        self.read_response(Status::RequestFilePending).await?;
+        cc.perform(Command::Rest(offset)).await?;
+        cc.read_response(Status::RequestFilePending).await?;
         debug!("Resume transfer accepted");
         Ok(())
     }
@@ -681,11 +723,12 @@ where
     /// Execute `MLST` command which returns the machine-processable listing of a file.
     /// If `pathname` is omited then the list of files in the current directory will be
     pub async fn mlst(&mut self, pathname: Option<&str>) -> FtpResult<String> {
+        let mut cc = self.control().await?;
         debug!("Reading {} path information", pathname.unwrap_or("working"));
 
-        self.perform(Command::Mlst(pathname.map(|x| x.to_string())))
+        cc.perform(Command::Mlst(pathname.map(|x| x.to_string())))
             .await?;
-        let response = self
+        let response = cc
             .read_response_in(&[Status::RequestedFileActionOk])
             .await?;
         // read body at line 1
@@ -699,10 +742,11 @@ where
 
     /// Retrieves the modification time of the file at `pathname` if it exists.
     pub async fn mdtm<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<NaiveDateTime> {
+        let mut cc = self.control().await?;
         debug!("Getting modification time for {}", pathname.as_ref());
-        self.perform(Command::Mdtm(pathname.as_ref().to_string()))
+        cc.perform(Command::Mdtm(pathname.as_ref().to_string()))
             .await?;
-        let response: Response = self.read_response(Status::File).await?;
+        let response: Response = cc.read_response(Status::File).await?;
         let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
 
         match MDTM_RE.captures(&body) {
@@ -735,10 +779,11 @@ where
 
     /// Retrieves the size of the file in bytes at `pathname` if it exists.
     pub async fn size<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<usize> {
+        let mut cc = self.control().await?;
         debug!("Getting file size for {}", pathname.as_ref());
-        self.perform(Command::Size(pathname.as_ref().to_string()))
+        cc.perform(Command::Size(pathname.as_ref().to_string()))
             .await?;
-        let response: Response = self.read_response(Status::File).await?;
+        let response: Response = cc.read_response(Status::File).await?;
         let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
 
         match SIZE_RE.captures(&body) {
@@ -749,10 +794,11 @@ where
 
     /// Retrieves the features supported by the server, through the FEAT command.
     pub async fn feat(&mut self) -> FtpResult<Features> {
+        let mut cc = self.control().await?;
         debug!("Getting server supported features");
-        self.perform(Command::Feat).await?;
+        cc.perform(Command::Feat).await?;
 
-        let response = self.read_response(Status::System).await?;
+        let response = cc.read_response(Status::System).await?;
 
         let first_line = String::from_utf8_lossy(&response.body);
         debug!("FEAT response: {}", first_line);
@@ -760,7 +806,7 @@ where
 
         loop {
             let mut line = Vec::new();
-            let bytes_read = self.read_line(&mut line).await?;
+            let bytes_read = cc.read_line(&mut line).await?;
             if bytes_read == 0 {
                 break;
             }
@@ -781,22 +827,24 @@ where
         option: impl ToString,
         value: Option<impl ToString>,
     ) -> FtpResult<()> {
+        let mut cc = self.control().await?;
         debug!("Getting server supported features");
-        self.perform(Command::Opts(
+        cc.perform(Command::Opts(
             option.to_string(),
             value.map(|x| x.to_string()),
         ))
         .await?;
-        self.read_response(Status::CommandOk).await?;
+        cc.read_response(Status::CommandOk).await?;
 
         Ok(())
     }
 
     /// Execute a command on the server and return the response
     pub async fn site(&mut self, command: impl ToString) -> FtpResult<Response> {
+        let mut cc = self.control().await?;
         debug!("Sending SITE command: {}", command.to_string());
-        self.perform(Command::Site(command.to_string())).await?;
-        self.read_response(Status::CommandOk).await
+        cc.perform(Command::Site(command.to_string())).await?;
+        cc.read_response(Status::CommandOk).await
     }
 
     /// Perform custom command.
@@ -814,58 +862,44 @@ where
         command: impl ToString,
         expected_code: &[Status],
     ) -> FtpResult<Response> {
+        let mut cc = self.control().await?;
         let command = command.to_string();
         debug!("Sending custom command: {}", command);
-        self.perform(Command::Custom(command)).await?;
-        self.read_response_in(expected_code).await
+        cc.perform(Command::Custom(command)).await?;
+        cc.read_response_in(expected_code).await
     }
 
     /// Perform a custom command using the data connection.
-    /// It returns both the [`Response`] and the [`DataStream`].
     ///
-    /// The [`DataStream`] implements both [`tokio::io::AsyncWrite`] and [`AsyncRead`] and so it can be written or read to interact with the
-    /// data channel.
+    /// It returns both the [`Response`] and a [`TransferStream`], which implements both
+    /// [`tokio::io::AsyncWrite`] and [`AsyncRead`] and so it can be written or read to interact
+    /// with the data channel.
     ///
-    /// If you want you can easily parse lines from the [`DataStream`] using [`Self::get_lines_from_stream`].
+    /// If you want you can easily parse lines from the stream using [`Self::get_lines_from_stream`].
     ///
-    /// The stream must eventually be closed using [`Self::close_data_connection`].
+    /// Once done, call [`TransferStream::finish`] to close the data connection and read the
+    /// server's completion reply.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server's reply is not in `expected_code`.
     pub async fn custom_data_command(
         &mut self,
         command: impl ToString,
         expected_code: &[Status],
-    ) -> FtpResult<(Response, DataStream<T>)> {
+    ) -> FtpResult<(Response, TransferStream<T>)> {
         let command = command.to_string();
         debug!("Sending custom data command: {}", command);
-        let (response, data_stream) = self
-            .data_command_with_response(Command::Custom(command), expected_code)
-            .await?;
-        Ok((response, data_stream))
-    }
-
-    /// Close data connection.
-    ///
-    /// Call this function when you're done with the stream obtained with [`Self::custom_data_command`].
-    ///
-    /// # Warning
-    ///
-    /// Passing any other [`AsyncRead`] which is not the [`DataStream`]
-    /// obtained with [`Self::custom_data_command`] may lead to undefined behavior.
-    pub async fn close_data_connection(&mut self, stream: impl AsyncRead) -> FtpResult<()> {
-        debug!("closing data connection");
-        // Drop stream NOTE: must be done first, otherwise server won't return any response
-        drop(stream);
-        self.data_connection_open = false;
-        trace!("dropped stream");
-        // Then read response
-        self.read_response_in(&[Status::ClosingDataConnection, Status::RequestedFileActionOk])
+        self.open_transfer(Command::Custom(command), expected_code, Direction::Download)
             .await
-            .map(|_| ())
     }
 
-    /// Read a [`DataStream`] line by line.
-    pub async fn get_lines_from_stream(
-        data_stream: &mut BufReader<DataStream<T>>,
-    ) -> FtpResult<Vec<String>> {
+    /// Read a data stream line by line.
+    pub async fn get_lines_from_stream<R>(data_stream: &mut R) -> FtpResult<Vec<String>>
+    where
+        R: AsyncBufReadExt + Unpin,
+    {
         let mut lines: Vec<String> = Vec::new();
 
         loop {
@@ -896,17 +930,66 @@ where
         Ok(lines)
     }
 
+    /// Reads one reply from the control connection and checks that its status is `expected_code`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::UnexpectedResponse`] if the reply has another status.
+    pub async fn read_response(&mut self, expected_code: Status) -> FtpResult<Response> {
+        self.control().await?.read_response(expected_code).await
+    }
+
+    /// Reads one reply from the control connection and checks that its status is in `expected_code`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::UnexpectedResponse`] if the reply has another status.
+    pub async fn read_response_in(&mut self, expected_code: &[Status]) -> FtpResult<Response> {
+        self.control().await?.read_response_in(expected_code).await
+    }
+
     // -- private
 
+    /// Locks the control connection for the duration of one command.
+    ///
+    /// Drains the reply of a transfer stream dropped without `finish()` first, so that the
+    /// control connection is in sync when the command is sent.
+    async fn control(&self) -> FtpResult<MutexGuard<'_, ControlChannel<T>>> {
+        let mut cc = self.control.lock().await;
+        cc.drain_pending_transfer_reply().await?;
+        Ok(cc)
+    }
+
+    /// Opens the data connection for `cmd` and wraps it into a self-finalizing [`TransferStream`].
+    async fn open_transfer(
+        &self,
+        cmd: Command,
+        expected_code: &[Status],
+        direction: Direction,
+    ) -> FtpResult<(Response, TransferStream<T>)> {
+        let mut cc = self.control().await?;
+        let (response, data_stream) = self
+            .data_command_with_response(&mut cc, cmd, expected_code)
+            .await?;
+        Ok((
+            response,
+            TransferStream::new(data_stream, Arc::clone(&self.control), direction),
+        ))
+    }
+
     /// Execute command which send data back in a separate stream
-    async fn data_command(&mut self, cmd: Command) -> FtpResult<DataStream<T>> {
+    async fn data_command(
+        &self,
+        cc: &mut ControlChannel<T>,
+        cmd: Command,
+    ) -> FtpResult<DataStream<T>> {
         // guard data connection
-        self.guard_multiple_data_connections()?;
+        cc.guard_multiple_data_connections()?;
 
         let stream = match self.mode {
             Mode::Active => {
-                let listener = self.active().await?;
-                self.perform(cmd).await?;
+                let listener = self.active(cc).await?;
+                cc.perform(cmd).await?;
 
                 match tokio::time::timeout(self.active_timeout, listener.accept()).await {
                     Ok(Ok((stream, addr))) => {
@@ -923,13 +1006,13 @@ where
                 }
             }
             Mode::ExtendedPassive => {
-                let addr = self.epsv().await?;
-                self.perform(cmd).await?;
+                let addr = self.epsv(cc).await?;
+                cc.perform(cmd).await?;
                 (self.passive_stream_builder)(addr).await?
             }
             Mode::Passive => {
-                let addr = self.pasv().await?;
-                self.perform(cmd).await?;
+                let addr = self.pasv(cc).await?;
+                cc.perform(cmd).await?;
                 (self.passive_stream_builder)(addr).await?
             }
         };
@@ -952,7 +1035,7 @@ where
         };
 
         if result.is_ok() {
-            self.data_connection_open = true;
+            cc.data_connection_open = true;
         }
         result
     }
@@ -964,60 +1047,51 @@ where
     /// failed command never leaves the client believing a data connection is still open, which would
     /// otherwise make every subsequent data command fail with [`FtpError::DataConnectionAlreadyOpen`].
     async fn data_command_with_response(
-        &mut self,
+        &self,
+        cc: &mut ControlChannel<T>,
         cmd: Command,
         expected_code: &[Status],
     ) -> FtpResult<(Response, DataStream<T>)> {
-        let data_stream = self.data_command(cmd).await?;
-        match self.read_response_in(expected_code).await {
+        let data_stream = self.data_command(cc, cmd).await?;
+        match cc.read_response_in(expected_code).await {
             Ok(response) => Ok((response, data_stream)),
             Err(err) => {
                 // server rejected the command: drop the data stream and reset the open flag
                 drop(data_stream);
-                self.data_connection_open = false;
+                cc.data_connection_open = false;
                 Err(err)
             }
         }
     }
 
     /// Runs the EPSV to enter Extended passive mode.
-    async fn epsv(&mut self) -> FtpResult<SocketAddr> {
+    async fn epsv(&self, cc: &mut ControlChannel<T>) -> FtpResult<SocketAddr> {
         debug!("EPSV command");
-        self.perform(Command::Epsv).await?;
+        cc.perform(Command::Epsv).await?;
         // PASV response format : 229 Entering Extended Passive Mode (|||PORT|)
-        let response: Response = self.read_response(Status::ExtendedPassiveMode).await?;
+        let response: Response = cc.read_response(Status::ExtendedPassiveMode).await?;
         let response_str = response.as_string().map_err(|_| FtpError::BadResponse)?;
         let caps = EPSV_PORT_RE
             .captures(&response_str)
             .ok_or_else(|| FtpError::UnexpectedResponse(response.clone()))?;
         let new_port = caps[1].parse::<u16>().map_err(|_| FtpError::BadResponse)?;
         trace!("Got port number from EPSV: {}", new_port);
-        let mut remote = self
-            .reader
-            .get_ref()
-            .get_ref()
-            .peer_addr()
-            .map_err(FtpError::ConnectionError)?;
+        let mut remote = cc.socket().peer_addr().map_err(FtpError::ConnectionError)?;
         remote.set_port(new_port);
         trace!("Remote address for extended passive mode is {}", remote);
         Ok(remote)
     }
 
     /// Runs the PASV command.
-    async fn pasv(&mut self) -> FtpResult<SocketAddr> {
+    async fn pasv(&self, cc: &mut ControlChannel<T>) -> FtpResult<SocketAddr> {
         debug!("PASV command");
-        self.perform(Command::Pasv).await?;
+        cc.perform(Command::Pasv).await?;
         // PASV response format : 227 Entering Passive Mode (h1,h2,h3,h4,p1,p2).
-        let response: Response = self.read_response(Status::PassiveMode).await?;
+        let response: Response = cc.read_response(Status::PassiveMode).await?;
         let addr = FtpStream::parse_passive_address_from_response(response)?;
         trace!("Passive address: {}", addr);
         if self.nat_workaround {
-            let mut remote = self
-                .reader
-                .get_ref()
-                .get_ref()
-                .peer_addr()
-                .map_err(FtpError::ConnectionError)?;
+            let mut remote = cc.socket().peer_addr().map_err(FtpError::ConnectionError)?;
             remote.set_port(addr.port());
             trace!("Replacing site local address {} with {}", addr, remote);
             Ok(remote)
@@ -1027,7 +1101,7 @@ where
     }
 
     /// Create a new tcp listener and send a PORT command for it
-    async fn active(&mut self) -> FtpResult<TcpListener> {
+    async fn active(&self, cc: &mut ControlChannel<T>) -> FtpResult<TcpListener> {
         debug!("Starting local tcp listener...");
         let conn = TcpListener::bind("0.0.0.0:0")
             .await
@@ -1036,14 +1110,11 @@ where
         let addr = conn.local_addr().map_err(FtpError::ConnectionError)?;
         trace!("Local address is {}", addr);
 
-        let ip = match self.reader.get_mut() {
-            DataStream::Tcp(stream) => stream.local_addr().map_err(FtpError::ConnectionError)?.ip(),
-            DataStream::Ssl(stream) => stream
-                .get_ref()
-                .local_addr()
-                .map_err(FtpError::ConnectionError)?
-                .ip(),
-        };
+        let ip = cc
+            .socket()
+            .local_addr()
+            .map_err(FtpError::ConnectionError)?
+            .ip();
 
         debug!("Active mode, listening on {}:{}", ip, addr.port());
 
@@ -1053,123 +1124,27 @@ where
                 let lsb = addr.port() % 256;
                 let ip_port = format!("{},{},{}", ip.to_string().replace('.', ","), msb, lsb);
                 debug!("Running PORT command");
-                self.perform(Command::Port(ip_port)).await?;
+                cc.perform(Command::Port(ip_port)).await?;
             }
             std::net::IpAddr::V6(_) => {
                 debug!("Running EPRT command");
-                self.perform(Command::Eprt(SocketAddr::new(ip, addr.port())))
+                cc.perform(Command::Eprt(SocketAddr::new(ip, addr.port())))
                     .await?;
             }
         }
-        self.read_response(Status::CommandOk).await?;
+        cc.read_response(Status::CommandOk).await?;
 
         Ok(conn)
     }
 
-    /// Write data to stream
-    async fn perform(&mut self, command: Command) -> FtpResult<()> {
-        let command = command.to_string();
-        crate::command::validate_command_line(&command)?;
-        trace!("CC OUT: {}", command.trim_end_matches("\r\n"));
-
-        let stream = self.reader.get_mut();
-        stream
-            .write_all(command.as_bytes())
-            .await
-            .map_err(FtpError::ConnectionError)
-    }
-
-    /// Read response from stream
-    pub async fn read_response(&mut self, expected_code: Status) -> FtpResult<Response> {
-        self.read_response_in(&[expected_code]).await
-    }
-
-    /// Retrieve single line response
-    pub async fn read_response_in(&mut self, expected_code: &[Status]) -> FtpResult<Response> {
-        let mut line = Vec::new();
-        let mut body: Vec<u8> = Vec::new();
-        self.read_line(&mut line).await?;
-        body.extend(line.iter());
-
-        trace!("CC IN: {:?}", line);
-
-        if line.len() < 5 {
-            return Err(FtpError::BadResponse);
-        }
-
-        let code_word: u32 = self.code_from_buffer(&line, 3)?;
-        let mut code = Status::from(code_word);
-
-        trace!("Code parsed from response: {} ({})", code, code_word);
-
-        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
-        // including glFTPd, use a different operative code. FEAT remains special because
-        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
-        // M-DOCUMENTED-MAGIC: FTP replies start with a three-digit code and one separator.
-        let expected = [line[0], line[1], line[2], 0x20];
-        let feat_opener = [line[0], line[1], line[2], b'-'];
-        let is_terminal = |reply: &[u8]| {
-            reply.len() >= 4
-                && reply[0].is_ascii_digit()
-                && reply[1].is_ascii_digit()
-                && reply[2].is_ascii_digit()
-                && (reply[3] == b' '
-                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
-        };
-        trace!("CC IN: {:?}", line);
-        while !is_terminal(&line) {
-            line.clear();
-            let bytes_read = self.read_line(&mut line).await?;
-            if bytes_read == 0 {
-                return Err(FtpError::ConnectionError(std::io::Error::new(
-                    std::io::ErrorKind::UnexpectedEof,
-                    "connection closed during multiline response",
-                )));
-            }
-            body.extend(line.iter());
-            trace!("CC IN: {:?}", line);
-        }
-
-        if line[0..4] != expected {
-            code = Status::from(self.code_from_buffer(&line, 3)?);
-            trace!("Code updated from terminal response: {}", code);
-        }
-
-        let response: Response = Response::new(code, body);
-        // Return Ok or error with response
-        if expected_code.contains(&code) {
-            Ok(response)
-        } else {
-            Err(FtpError::UnexpectedResponse(response))
-        }
-    }
-
-    async fn read_line(&mut self, line: &mut Vec<u8>) -> FtpResult<usize> {
-        self.reader
-            .read_until(0x0A, line.as_mut())
-            .await
-            .map_err(FtpError::ConnectionError)?;
-        Ok(line.len())
-    }
-
-    /// Get code from buffer
-    fn code_from_buffer(&self, buf: &[u8], len: usize) -> Result<u32, FtpError> {
-        if buf.len() < len {
-            return Err(FtpError::BadResponse);
-        }
-        let buffer = buf[0..len].to_vec();
-        let as_string = String::from_utf8(buffer).map_err(|_| FtpError::BadResponse)?;
-        as_string.parse::<u32>().map_err(|_| FtpError::BadResponse)
-    }
-
     /// Execute a command which returns list of strings in a separate stream
-    async fn stream_lines(&mut self, cmd: Command, open_code: Status) -> FtpResult<Vec<String>> {
+    async fn stream_lines(&self, cmd: Command, open_code: Status) -> FtpResult<Vec<String>> {
         let (_, stream) = self
-            .data_command_with_response(cmd, &[open_code, Status::AlreadyOpen])
+            .open_transfer(cmd, &[open_code, Status::AlreadyOpen], Direction::Download)
             .await?;
         let mut data_stream = BufReader::new(stream);
         let lines = Self::get_lines_from_stream(&mut data_stream).await;
-        self.finalize_retr_stream(data_stream).await?;
+        data_stream.into_inner().finish().await?;
         lines
     }
 
@@ -1182,133 +1157,30 @@ where
             })
         })
     }
-
-    /// guard against multiple data connections
-    ///
-    /// If `data_connection_open` is true, returns an [`FtpError::DataConnectionAlreadyOpen`] indicating that a data connection is already open.
-    /// Otherwise, returns Ok(()).
-    fn guard_multiple_data_connections(&self) -> FtpResult<()> {
-        if self.data_connection_open {
-            Err(FtpError::DataConnectionAlreadyOpen)
-        } else {
-            Ok(())
-        }
-    }
 }
 
 #[cfg(test)]
 mod test {
     use std::io::Cursor;
-    use std::pin::Pin;
     use std::str::FromStr as _;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::task::{Context, Poll};
+    use std::time::Instant;
 
     use pretty_assertions::assert_eq;
     use rand::distr::Alphanumeric;
     use rand::{RngExt, rng};
-    use tokio::io::AsyncReadExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::super::tokio::AsyncFtpStream;
     use super::*;
     use crate::test_container::AsyncPureFtpRunner;
     use crate::types::FormatControl;
 
-    #[derive(Debug)]
-    struct ShutdownTrackingStream {
-        shutdown_attempted: Arc<AtomicBool>,
-        dropped: Arc<AtomicBool>,
-    }
-
-    impl tokio::io::AsyncRead for ShutdownTrackingStream {
-        fn poll_read(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            _buf: &mut tokio::io::ReadBuf<'_>,
-        ) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-    }
-
-    impl tokio::io::AsyncWrite for ShutdownTrackingStream {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<std::io::Result<usize>> {
-            Poll::Ready(Ok(buf.len()))
-        }
-
-        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-
-        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            self.shutdown_attempted.store(true, Ordering::SeqCst);
-            Poll::Ready(Err(std::io::Error::other("shutdown failed")))
-        }
-    }
-
-    impl Drop for ShutdownTrackingStream {
-        fn drop(&mut self) {
-            self.dropped.store(true, Ordering::SeqCst);
-        }
-    }
-
     #[tokio::test]
     async fn connect() {
         crate::log_init();
         let (stream, _container) = setup_stream().await;
         finalize_stream(stream).await;
-    }
-
-    #[tokio::test]
-    async fn finalize_retr_stream_attempts_shutdown_before_reading_response() {
-        use tokio::io::AsyncWriteExt as _;
-
-        let shutdown_attempted = Arc::new(AtomicBool::new(false));
-        let dropped = Arc::new(AtomicBool::new(false));
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("failed to bind");
-        let port = listener.local_addr().expect("missing local address").port();
-        let server_shutdown_attempted = Arc::clone(&shutdown_attempted);
-        let server_dropped = Arc::clone(&dropped);
-        let server = tokio::spawn(async move {
-            let (mut control, _) = listener.accept().await.expect("no incoming connection");
-            control.write_all(b"220 Welcome\r\n").await.unwrap();
-
-            let deadline = std::time::Instant::now() + Duration::from_secs(1);
-            while !server_dropped.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
-                tokio::task::yield_now().await;
-            }
-
-            let response: &[u8] = if server_shutdown_attempted.load(Ordering::SeqCst)
-                && server_dropped.load(Ordering::SeqCst)
-            {
-                b"226 Transfer complete\r\n"
-            } else {
-                b"426 Data connection was not closed gracefully\r\n"
-            };
-            control.write_all(response).await.unwrap();
-        });
-
-        let control = TcpStream::connect(("127.0.0.1", port))
-            .await
-            .expect("failed to connect");
-        let mut ftp = AsyncFtpStream::connect_with_stream(control)
-            .await
-            .expect("failed handshake");
-        let data = ShutdownTrackingStream {
-            shutdown_attempted: Arc::clone(&shutdown_attempted),
-            dropped: Arc::clone(&dropped),
-        };
-
-        ftp.finalize_retr_stream(data)
-            .await
-            .expect("FTP completion should override the local shutdown error");
-        server.await.expect("server task panicked");
     }
 
     #[tokio::test]
@@ -1356,7 +1228,7 @@ mod test {
     #[tokio::test]
     async fn get_ref() {
         let (stream, _container) = setup_stream().await;
-        assert!(stream.get_ref().set_ttl(255).is_ok());
+        assert!(stream.get_ref().await.set_ttl(255).is_ok());
         finalize_stream(stream).await;
     }
 
@@ -1477,7 +1349,7 @@ mod test {
         // Verify file matches
         assert_eq!(buffer.as_slice(), "test data\ntest data\n".as_bytes());
         // Finalize
-        assert!(stream.finalize_retr_stream(reader).await.is_ok());
+        assert!(reader.finish().await.is_ok());
         // Get size
         assert_eq!(stream.size("test.txt").await.unwrap(), 20);
         // Size of non-existing file
@@ -1581,7 +1453,7 @@ mod test {
             6
         );
         // Finalize
-        assert!(stream.finalize_put_stream(transfer_stream).await.is_ok());
+        assert!(transfer_stream.finish().await.is_ok());
         // Get size
         //assert_eq!(stream.size("test.bin").await.unwrap(), 11);
         // Remove file
@@ -1652,7 +1524,7 @@ mod test {
         let mut reader = Cursor::new("test data\n".as_bytes());
         assert!(stream.append_file("test.txt", &mut reader).await.is_ok());
         let data_stream = stream.retr_as_stream("test.txt").await.unwrap();
-        assert!(stream.finalize_retr_stream(data_stream).await.is_ok());
+        assert!(data_stream.finish().await.is_ok());
         assert!(stream.list(None).await.is_ok());
         assert!(stream.nlst(None).await.is_ok());
 
@@ -1710,7 +1582,7 @@ mod test {
             .await
             .expect("Failed to get lines from stream");
         // finalize
-        assert!(stream.close_data_connection(reader).await.is_ok());
+        assert!(reader.into_inner().finish().await.is_ok());
 
         // Now it should be possible to open another data connection
         let (response, data_stream) = stream
@@ -1723,7 +1595,7 @@ mod test {
             .await
             .expect("Failed to get lines from stream");
         // finalize
-        assert!(stream.close_data_connection(reader).await.is_ok());
+        assert!(reader.into_inner().finish().await.is_ok());
     }
 
     #[tokio::test]
@@ -1762,14 +1634,14 @@ mod test {
             .await
             .unwrap();
         data_stream.write_all(b"part2").await.unwrap();
-        stream.finalize_put_stream(data_stream).await.unwrap();
+        data_stream.finish().await.unwrap();
         // Verify content
         let mut reader = stream.retr_as_stream("append_stream.txt").await.unwrap();
         let mut buffer = Vec::new();
         tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut buffer)
             .await
             .unwrap();
-        stream.finalize_retr_stream(reader).await.unwrap();
+        reader.finish().await.unwrap();
         assert_eq!(buffer, b"part1part2");
         assert!(stream.rm("append_stream.txt").await.is_ok());
         finalize_stream(stream).await;
@@ -1943,7 +1815,7 @@ mod test {
             .await
             .expect("Failed to get lines from stream");
         // finalize
-        assert!(stream.close_data_connection(reader).await.is_ok());
+        assert!(reader.into_inner().finish().await.is_ok());
     }
 
     #[tokio::test]
@@ -1985,6 +1857,165 @@ mod test {
             });
 
         is_sync::<AsyncFtpStream>(ftp_stream);
+    }
+
+    #[tokio::test]
+    async fn should_upload_via_stream_and_finish() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let (mut stream, _container) = setup_stream().await;
+        assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+        let mut upload = stream.put_with_stream("upload.bin").await.unwrap();
+        upload.write_all(b"0123456789").await.unwrap();
+        upload
+            .finish()
+            .await
+            .expect("finish should read the transfer reply");
+        // The control connection is in sync: the next commands work.
+        assert_eq!(stream.size("upload.bin").await.unwrap(), 10);
+        assert_eq!(stream.nlst(None).await.unwrap().as_slice(), &["upload.bin"]);
+        assert!(stream.rm("upload.bin").await.is_ok());
+        finalize_stream(stream).await;
+    }
+
+    #[tokio::test]
+    async fn should_download_via_stream_and_finish() {
+        let (mut stream, _container) = setup_stream().await;
+        assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+        let mut reader = Cursor::new("download me".as_bytes());
+        assert!(stream.put_file("download.txt", &mut reader).await.is_ok());
+        let mut download = stream.retr_as_stream("download.txt").await.unwrap();
+        let mut buffer = Vec::new();
+        download.read_to_end(&mut buffer).await.unwrap();
+        download
+            .finish()
+            .await
+            .expect("finish should read the transfer reply");
+        assert_eq!(buffer, b"download me");
+        // The control connection is in sync: the next commands work.
+        assert!(stream.pwd().await.is_ok());
+        assert_eq!(stream.size("download.txt").await.unwrap(), 11);
+        assert!(stream.rm("download.txt").await.is_ok());
+        finalize_stream(stream).await;
+    }
+
+    #[tokio::test]
+    async fn should_drain_reply_of_dropped_stream_on_next_command() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let (mut stream, _container) = setup_stream().await;
+        assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+        let mut upload = stream.put_with_stream("dropped.bin").await.unwrap();
+        upload.write_all(b"dropped").await.unwrap();
+        upload.flush().await.unwrap();
+        // Drop without finish(): the reply is consumed by the next command.
+        drop(upload);
+        assert_eq!(stream.size("dropped.bin").await.unwrap(), 7);
+        let mut download = stream.retr_as_stream("dropped.bin").await.unwrap();
+        let mut buffer = Vec::new();
+        download.read_to_end(&mut buffer).await.unwrap();
+        download.finish().await.unwrap();
+        assert_eq!(buffer, b"dropped");
+        assert!(stream.rm("dropped.bin").await.is_ok());
+        finalize_stream(stream).await;
+    }
+
+    #[tokio::test]
+    async fn should_read_a_single_reply_on_finish_then_drop() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let (mut stream, _container) = setup_stream().await;
+        assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+        let mut upload = stream.put_with_stream("single.bin").await.unwrap();
+        upload.write_all(b"single").await.unwrap();
+        // A second (spurious) reply read would block: bound finish() with a timeout.
+        let timeout = Duration::from_millis(500);
+        let started = Instant::now();
+        tokio::time::timeout(timeout, upload.finish())
+            .await
+            .expect("finish() blocked: a second reply read was attempted")
+            .expect("finish should read exactly one reply");
+        assert!(started.elapsed() < timeout);
+        // The control connection is in sync: the next commands work.
+        assert!(stream.noop().await.is_ok());
+        assert_eq!(stream.size("single.bin").await.unwrap(), 6);
+        assert!(stream.rm("single.bin").await.is_ok());
+        finalize_stream(stream).await;
+    }
+
+    #[tokio::test]
+    async fn should_reject_data_commands_while_a_transfer_stream_is_alive() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let (mut stream, _container) = setup_stream().await;
+        assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+        let mut upload = stream.put_with_stream("alive.bin").await.unwrap();
+        upload.write_all(b"alive").await.unwrap();
+        assert!(matches!(
+            stream.list(None).await,
+            Err(FtpError::DataConnectionAlreadyOpen)
+        ));
+        assert!(matches!(
+            stream.retr_as_stream("alive.bin").await,
+            Err(FtpError::DataConnectionAlreadyOpen)
+        ));
+        assert!(matches!(
+            stream.put_with_stream("other.bin").await,
+            Err(FtpError::DataConnectionAlreadyOpen)
+        ));
+        upload.finish().await.unwrap();
+        // Once finished, data commands work again.
+        assert_eq!(stream.nlst(None).await.unwrap().as_slice(), &["alive.bin"]);
+        assert!(stream.rm("alive.bin").await.is_ok());
+        finalize_stream(stream).await;
+    }
+
+    #[tokio::test]
+    async fn should_finish_transfer_stream_on_another_task() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let (mut stream, _container) = setup_stream().await;
+        assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+        let mut upload = stream.put_with_stream("spawned.bin").await.unwrap();
+        let handle = tokio::spawn(async move {
+            upload.write_all(b"from another task").await.unwrap();
+            upload.finish().await
+        });
+        handle
+            .await
+            .expect("uploader task panicked")
+            .expect("finish should succeed on another task");
+        assert_eq!(stream.size("spawned.bin").await.unwrap(), 17);
+        assert!(stream.rm("spawned.bin").await.is_ok());
+        finalize_stream(stream).await;
+    }
+
+    #[tokio::test]
+    async fn should_finalize_transfer_when_retr_callback_fails() {
+        let (mut stream, _container) = setup_stream().await;
+        assert!(stream.transfer_type(FileType::Binary).await.is_ok());
+        let mut reader = Cursor::new("callback".as_bytes());
+        assert!(
+            stream
+                .put_file("callback_err.txt", &mut reader)
+                .await
+                .is_ok()
+        );
+        let result: FtpResult<()> = stream
+            .retr("callback_err.txt", |reader| {
+                Box::pin(async move {
+                    // Hand the stream back on failure so `retr` can finish it.
+                    drop(reader);
+                    Err(FtpError::BadResponse)
+                })
+            })
+            .await;
+        assert!(matches!(result, Err(FtpError::BadResponse)));
+        // The dropped stream flagged a pending reply, which the next command drains.
+        assert_eq!(stream.size("callback_err.txt").await.unwrap(), 8);
+        assert!(stream.list(None).await.is_ok());
+        assert!(stream.rm("callback_err.txt").await.is_ok());
+        finalize_stream(stream).await;
     }
 
     // -- test utils

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/control.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/control.rs
@@ -1,0 +1,276 @@
+//! Control-connection state shared between the tokio FTP client and its in-flight data transfer.
+//!
+//! The control connection (command socket, reply reader, and the "data connection open" flag)
+//! lives behind an [`Arc`]`<`[`Mutex`]`>` so that a [`super::TransferStream`] can finalize itself:
+//! once the data socket is shut down, the stream locks the control connection, clears the flag
+//! and reads the server's completion reply. FTP allows a single data connection per session, so
+//! the lock never serializes anything that could have run concurrently before.
+//!
+//! Async `Drop` cannot await, so a transfer stream that is dropped without
+//! [`super::TransferStream::finish`] only closes its socket and flags a *pending transfer reply*;
+//! the next command drains that reply before sending anything, keeping the control connection in
+//! sync.
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::sync::{Mutex, MutexGuard};
+
+use super::data_stream::DataStream;
+use super::tls::TokioTlsStream;
+use crate::Status;
+use crate::command::Command;
+use crate::types::{FtpError, FtpResult, Response};
+
+/// Replies that complete a data transfer: `226` or `250`.
+pub(super) const TRANSFER_COMPLETE: &[Status] =
+    &[Status::ClosingDataConnection, Status::RequestedFileActionOk];
+
+/// Shared, lockable handle to a [`ControlChannel`].
+pub(super) type SharedControl<T> = Arc<Mutex<ControlChannel<T>>>;
+
+/// Command socket plus the reply reader and the data-connection bookkeeping.
+#[derive(Debug)]
+pub(super) struct ControlChannel<T>
+where
+    T: TokioTlsStream + Send,
+{
+    /// Buffered reader over the control socket; writes go through [`BufReader::get_mut`].
+    pub(super) reader: BufReader<DataStream<T>>,
+    /// Whether a data connection is currently open.
+    ///
+    /// FTP forbids more than one data connection at a time, so this flag guards every data
+    /// command against opening a second one.
+    pub(super) data_connection_open: bool,
+    /// Whether a transfer stream was dropped without `finish()` and its reply is still unread.
+    pub(super) pending_transfer_reply: bool,
+}
+
+/// Unwraps a shared control channel that is no longer referenced by any transfer.
+///
+/// # Errors
+///
+/// Returns [`FtpError::DataConnectionAlreadyOpen`] if a [`super::TransferStream`] still holds a
+/// reference to the control channel.
+#[cfg(feature = "async-secure")]
+pub(super) fn into_exclusive<T>(control: SharedControl<T>) -> FtpResult<ControlChannel<T>>
+where
+    T: TokioTlsStream + Send,
+{
+    Arc::try_unwrap(control)
+        .map(Mutex::into_inner)
+        .map_err(|_| FtpError::DataConnectionAlreadyOpen)
+}
+
+impl<T> ControlChannel<T>
+where
+    T: TokioTlsStream + Send,
+{
+    /// Wraps `stream` as a fresh control channel with no data connection open.
+    pub(super) fn new(stream: DataStream<T>) -> Self {
+        Self {
+            reader: BufReader::new(stream),
+            data_connection_open: false,
+            pending_transfer_reply: false,
+        }
+    }
+
+    /// Wraps `stream` into a [`SharedControl`].
+    pub(super) fn shared(stream: DataStream<T>) -> SharedControl<T> {
+        Arc::new(Mutex::new(Self::new(stream)))
+    }
+
+    /// Returns the control socket.
+    pub(super) fn socket(&self) -> &TcpStream {
+        self.reader.get_ref().get_ref()
+    }
+
+    /// Sends `command` on the control connection.
+    pub(super) async fn perform(&mut self, command: Command) -> FtpResult<()> {
+        let command = command.to_string();
+        crate::command::validate_command_line(&command)?;
+        trace!("CC OUT: {}", command.trim_end_matches("\r\n"));
+
+        self.reader
+            .get_mut()
+            .write_all(command.as_bytes())
+            .await
+            .map_err(FtpError::ConnectionError)
+    }
+
+    /// Reads one reply and checks that its status is `expected_code`.
+    pub(super) async fn read_response(&mut self, expected_code: Status) -> FtpResult<Response> {
+        self.read_response_in(&[expected_code]).await
+    }
+
+    /// Reads one (possibly multi-line) reply and checks that its status is in `expected_code`.
+    pub(super) async fn read_response_in(
+        &mut self,
+        expected_code: &[Status],
+    ) -> FtpResult<Response> {
+        let mut line = Vec::new();
+        let mut body: Vec<u8> = Vec::new();
+        self.read_line(&mut line).await?;
+        body.extend(line.iter());
+
+        trace!("CC IN: {:?}", line);
+
+        if line.len() < 5 {
+            return Err(FtpError::BadResponse);
+        }
+
+        let code_word: u32 = code_from_buffer(&line, 3)?;
+        let mut code = Status::from(code_word);
+
+        trace!("Code parsed from response: {} ({})", code, code_word);
+
+        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
+        // including glFTPd, use a different operative code. FEAT remains special because
+        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
+        // FTP replies start with a three-digit code and one separator.
+        let expected = [line[0], line[1], line[2], 0x20];
+        let feat_opener = [line[0], line[1], line[2], b'-'];
+        let is_terminal = |reply: &[u8]| {
+            reply.len() >= 4
+                && reply[0].is_ascii_digit()
+                && reply[1].is_ascii_digit()
+                && reply[2].is_ascii_digit()
+                && (reply[3] == b' '
+                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
+        };
+        trace!("CC IN: {:?}", line);
+        while !is_terminal(&line) {
+            line.clear();
+            let bytes_read = self.read_line(&mut line).await?;
+            if bytes_read == 0 {
+                return Err(FtpError::ConnectionError(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed during multiline response",
+                )));
+            }
+            body.extend(line.iter());
+            trace!("CC IN: {:?}", line);
+        }
+
+        if line[0..4] != expected {
+            code = Status::from(code_from_buffer(&line, 3)?);
+            trace!("Code updated from terminal response: {}", code);
+        }
+
+        let response: Response = Response::new(code, body);
+        // Return Ok or error with response
+        if expected_code.contains(&code) {
+            Ok(response)
+        } else {
+            Err(FtpError::UnexpectedResponse(response))
+        }
+    }
+
+    /// Reads bytes from the control connection until `\n` or EOF is found.
+    pub(super) async fn read_line(&mut self, line: &mut Vec<u8>) -> FtpResult<usize> {
+        self.reader
+            .read_until(0x0A, line.as_mut())
+            .await
+            .map_err(FtpError::ConnectionError)?;
+        Ok(line.len())
+    }
+
+    /// Fails with [`FtpError::DataConnectionAlreadyOpen`] if a data connection is open.
+    pub(super) fn guard_multiple_data_connections(&self) -> FtpResult<()> {
+        if self.data_connection_open {
+            Err(FtpError::DataConnectionAlreadyOpen)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Marks the data connection as closed and reads the transfer completion reply.
+    ///
+    /// The data socket must already be closed, otherwise the server never sends the reply.
+    pub(super) async fn complete_transfer(&mut self) -> FtpResult<()> {
+        self.data_connection_open = false;
+        trace!("data connection closed; reading transfer reply");
+        self.read_response_in(TRANSFER_COMPLETE).await.map(|_| ())
+    }
+
+    /// Consumes the reply of a transfer stream that was dropped without `finish()`.
+    ///
+    /// The transfer outcome was abandoned by the caller, so a failure reply is only logged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::ConnectionError`] if the control connection cannot be read.
+    pub(super) async fn drain_pending_transfer_reply(&mut self) -> FtpResult<()> {
+        if !self.pending_transfer_reply {
+            return Ok(());
+        }
+        self.pending_transfer_reply = false;
+        debug!("reading the reply of a transfer stream dropped without finish()");
+        match self.read_response_in(TRANSFER_COMPLETE).await {
+            Ok(_) => Ok(()),
+            Err(FtpError::UnexpectedResponse(response)) => {
+                warn!("a dropped transfer stream failed: {response}");
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+}
+
+/// Parses the leading `len` bytes of `buf` as a numeric reply code.
+fn code_from_buffer(buf: &[u8], len: usize) -> FtpResult<u32> {
+    if buf.len() < len {
+        return Err(FtpError::BadResponse);
+    }
+    let buffer = buf[0..len].to_vec();
+    let as_string = String::from_utf8(buffer).map_err(|_| FtpError::BadResponse)?;
+    as_string.parse::<u32>().map_err(|_| FtpError::BadResponse)
+}
+
+/// Locked view of the control socket of an [`super::ImplAsyncFtpStream`].
+///
+/// Dereferences to the underlying [`TcpStream`], so socket options can be set on the control
+/// connection. The control connection stays locked for as long as this value is alive: drop it
+/// before finishing a [`super::TransferStream`], which needs the same lock to read the transfer
+/// reply.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use suppaftp::tokio::AsyncFtpStream;
+///
+/// # async fn run() {
+/// let stream = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+/// stream.get_ref().await.set_nodelay(true).unwrap();
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct ControlSocket<'a, T>
+where
+    T: TokioTlsStream + Send,
+{
+    guard: MutexGuard<'a, ControlChannel<T>>,
+}
+
+impl<'a, T> ControlSocket<'a, T>
+where
+    T: TokioTlsStream + Send,
+{
+    /// Wraps a locked control channel.
+    pub(super) fn new(guard: MutexGuard<'a, ControlChannel<T>>) -> Self {
+        Self { guard }
+    }
+}
+
+impl<T> Deref for ControlSocket<'_, T>
+where
+    T: TokioTlsStream + Send,
+{
+    type Target = TcpStream;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard.socket()
+    }
+}

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/control.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/control.rs
@@ -13,6 +13,7 @@
 
 use std::ops::Deref;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
@@ -45,7 +46,10 @@ where
     /// command against opening a second one.
     pub(super) data_connection_open: bool,
     /// Whether a transfer stream was dropped without `finish()` and its reply is still unread.
-    pub(super) pending_transfer_reply: bool,
+    pub(super) pending_transfer_reply: Arc<AtomicBool>,
+    /// Reply bytes survive cancellation while waiting for a complete line or multiline reply.
+    response_line: Vec<u8>,
+    response_body: Vec<u8>,
 }
 
 /// Unwraps a shared control channel that is no longer referenced by any transfer.
@@ -73,7 +77,9 @@ where
         Self {
             reader: BufReader::new(stream),
             data_connection_open: false,
-            pending_transfer_reply: false,
+            pending_transfer_reply: Arc::new(AtomicBool::new(false)),
+            response_line: Vec::new(),
+            response_body: Vec::new(),
         }
     }
 
@@ -110,61 +116,60 @@ where
         &mut self,
         expected_code: &[Status],
     ) -> FtpResult<Response> {
-        let mut line = Vec::new();
-        let mut body: Vec<u8> = Vec::new();
-        self.read_line(&mut line).await?;
-        body.extend(line.iter());
-
-        trace!("CC IN: {:?}", line);
-
-        if line.len() < 5 {
-            return Err(FtpError::BadResponse);
-        }
-
-        let code_word: u32 = code_from_buffer(&line, 3)?;
-        let mut code = Status::from(code_word);
-
-        trace!("Code parsed from response: {} ({})", code, code_word);
-
-        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
-        // including glFTPd, use a different operative code. FEAT remains special because
-        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
-        // FTP replies start with a three-digit code and one separator.
-        let expected = [line[0], line[1], line[2], 0x20];
-        let feat_opener = [line[0], line[1], line[2], b'-'];
-        let is_terminal = |reply: &[u8]| {
-            reply.len() >= 4
-                && reply[0].is_ascii_digit()
-                && reply[1].is_ascii_digit()
-                && reply[2].is_ascii_digit()
-                && (reply[3] == b' '
-                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
-        };
-        trace!("CC IN: {:?}", line);
-        while !is_terminal(&line) {
-            line.clear();
-            let bytes_read = self.read_line(&mut line).await?;
-            if bytes_read == 0 {
+        loop {
+            let bytes_read = self
+                .reader
+                .read_until(b'\n', &mut self.response_line)
+                .await
+                .map_err(FtpError::ConnectionError)?;
+            if bytes_read == 0 && !self.response_body.is_empty() {
                 return Err(FtpError::ConnectionError(std::io::Error::new(
                     std::io::ErrorKind::UnexpectedEof,
                     "connection closed during multiline response",
                 )));
             }
-            body.extend(line.iter());
-            trace!("CC IN: {:?}", line);
-        }
+            self.response_body.extend_from_slice(&self.response_line);
+            trace!("CC IN: {line:?}", line = self.response_line);
 
-        if line[0..4] != expected {
-            code = Status::from(code_from_buffer(&line, 3)?);
-            trace!("Code updated from terminal response: {}", code);
-        }
-
-        let response: Response = Response::new(code, body);
-        // Return Ok or error with response
-        if expected_code.contains(&code) {
-            Ok(response)
-        } else {
-            Err(FtpError::UnexpectedResponse(response))
+            if self.response_body.len() < 5 {
+                self.response_line.clear();
+                self.response_body.clear();
+                return Err(FtpError::BadResponse);
+            }
+            let opening_code = match code_from_buffer(&self.response_body, 3) {
+                Ok(code) => code,
+                Err(err) => {
+                    self.response_line.clear();
+                    self.response_body.clear();
+                    return Err(err);
+                }
+            };
+            let opening = &self.response_body[..3];
+            let line = &self.response_line;
+            // Accept mismatched terminal codes for servers such as glFTPd. FEAT leaves its
+            // continuation lines for `feat()` to consume after returning the `211-` opener.
+            let terminal = line.len() >= 4
+                && line[..3].iter().all(u8::is_ascii_digit)
+                && (line[3] == b' '
+                    || (expected_code.contains(&Status::System)
+                        && line[..3] == *opening
+                        && line[3] == b'-'));
+            if terminal {
+                let code = if line[..3] == *opening {
+                    opening_code
+                } else {
+                    code_from_buffer(line, 3)?
+                };
+                let status = Status::from(code);
+                self.response_line.clear();
+                let response = Response::new(status, std::mem::take(&mut self.response_body));
+                return if expected_code.contains(&status) {
+                    Ok(response)
+                } else {
+                    Err(FtpError::UnexpectedResponse(response))
+                };
+            }
+            self.response_line.clear();
         }
     }
 
@@ -192,7 +197,9 @@ where
     pub(super) async fn complete_transfer(&mut self) -> FtpResult<()> {
         self.data_connection_open = false;
         trace!("data connection closed; reading transfer reply");
-        self.read_response_in(TRANSFER_COMPLETE).await.map(|_| ())
+        let reply = self.read_response_in(TRANSFER_COMPLETE).await.map(|_| ());
+        self.pending_transfer_reply.store(false, Ordering::Release);
+        reply
     }
 
     /// Consumes the reply of a transfer stream that was dropped without `finish()`.
@@ -203,13 +210,12 @@ where
     ///
     /// Returns [`FtpError::ConnectionError`] if the control connection cannot be read.
     pub(super) async fn drain_pending_transfer_reply(&mut self) -> FtpResult<()> {
-        if !self.pending_transfer_reply {
+        if !self.pending_transfer_reply.load(Ordering::Acquire) {
             return Ok(());
         }
-        self.pending_transfer_reply = false;
         debug!("reading the reply of a transfer stream dropped without finish()");
-        match self.read_response_in(TRANSFER_COMPLETE).await {
-            Ok(_) => Ok(()),
+        match self.complete_transfer().await {
+            Ok(()) => Ok(()),
             Err(FtpError::UnexpectedResponse(response)) => {
                 warn!("a dropped transfer stream failed: {response}");
                 Ok(())
@@ -272,5 +278,69 @@ where
 
     fn deref(&self) -> &Self::Target {
         self.guard.socket()
+    }
+}
+
+#[cfg(all(test, feature = "async-secure"))]
+mod tls_transition_tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::super::tls::{AsyncNoTlsStream, AsyncTlsConnector};
+    use crate::tokio::AsyncFtpStream;
+    use crate::{FtpError, FtpResult};
+
+    #[derive(Debug)]
+    struct UnusedConnector;
+
+    #[async_trait::async_trait]
+    impl AsyncTlsConnector for UnusedConnector {
+        type Stream = AsyncNoTlsStream;
+
+        async fn connect(&self, _: &str, _: tokio::net::TcpStream) -> FtpResult<Self::Stream> {
+            panic!("TLS must not start while a transfer owns the control connection")
+        }
+    }
+
+    #[tokio::test]
+    async fn should_reject_tls_changes_before_sending_commands() {
+        for secure in [false, true] {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let address = listener.local_addr().unwrap();
+            let server = thread::spawn(move || {
+                let (socket, _) = listener.accept().unwrap();
+                socket
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                let mut reader = BufReader::new(socket);
+                reader.get_mut().write_all(b"220 ready\r\n").unwrap();
+                let mut command = String::new();
+                reader.read_line(&mut command).unwrap();
+                if !command.is_empty() {
+                    let reply: &[u8] = if secure {
+                        b"234 start TLS\r\n"
+                    } else {
+                        b"200 cleared\r\n"
+                    };
+                    reader.get_mut().write_all(reply).unwrap();
+                    reader.read_to_end(&mut Vec::new()).unwrap();
+                }
+                command
+            });
+            let ftp = AsyncFtpStream::connect(address).await.unwrap();
+            // A live transfer retains this handle even when a TLS transition consumes the client.
+            let transfer_control = Arc::clone(&ftp.control);
+            let result = if secure {
+                ftp.into_secure(UnusedConnector, "localhost").await
+            } else {
+                ftp.clear_command_channel().await
+            };
+            assert!(matches!(result, Err(FtpError::DataConnectionAlreadyOpen)));
+            drop(transfer_control);
+            assert_eq!(server.join().unwrap(), "");
+        }
     }
 }

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/data_stream.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/data_stream.rs
@@ -14,6 +14,7 @@ use tokio::net::TcpStream;
 use super::TokioTlsStream;
 
 /// Data Stream used for communications. It can be both of type Tcp in case of plain communication or Ssl in case of FTPS
+#[derive(Debug)]
 #[pin_project(project = DataStreamProj)]
 pub enum DataStream<T>
 where

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/transfer_stream.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/transfer_stream.rs
@@ -1,6 +1,8 @@
 //! Self-finalizing data stream for tokio FTP transfers.
 
 use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
@@ -36,7 +38,10 @@ pub(super) enum Direction {
 /// A stream that is merely dropped cannot await, so it closes its socket (without a TLS
 /// `close_notify`, which strict servers may report as a failed transfer) and defers the reply:
 /// the next command on the client consumes it before sending anything, so the control connection
-/// never desynchronizes. The transfer outcome is lost in that case and only logged.
+/// can be reused after successful cleanup. The transfer outcome is lost in that case and only logged.
+///
+/// Finish the transfer before issuing any other command on the client, even when finishing
+/// on another thread or task. Flush buffered writers before recovering their inner transfer.
 ///
 /// While a `TransferStream` is alive the client refuses to open another data connection with
 /// [`FtpError::DataConnectionAlreadyOpen`]. The stream owns no reference to the client and is
@@ -74,6 +79,8 @@ where
     data: Option<DataStream<T>>,
     control: SharedControl<T>,
     direction: Direction,
+    pending_reply: Arc<AtomicBool>,
+    finished: bool,
 }
 
 impl<T> TransferStream<T>
@@ -85,11 +92,14 @@ where
         data: DataStream<T>,
         control: SharedControl<T>,
         direction: Direction,
+        pending_reply: Arc<AtomicBool>,
     ) -> Self {
         Self {
             data: Some(data),
             control,
             direction,
+            pending_reply,
+            finished: false,
         }
     }
 
@@ -111,6 +121,12 @@ where
     ///
     /// After this call the client can issue the next command.
     ///
+    /// # Cancellation
+    ///
+    /// Cancelling this future closes the data socket and leaves its completion reply for the
+    /// next command to drain. Partially read replies are retained, including when that next
+    /// command is itself cancelled during cleanup. The transfer result is lost on cancellation.
+    ///
     /// # Errors
     ///
     /// Returns [`FtpError::ConnectionError`] if an upload cannot be shut down cleanly or the
@@ -125,6 +141,7 @@ where
         let shutdown = data.shutdown().await;
         drop(data);
         let reply = self.control.lock().await.complete_transfer().await;
+        self.finished = true;
         if self.direction == Direction::Upload {
             shutdown.map_err(FtpError::ConnectionError)?;
         }
@@ -135,6 +152,7 @@ where
     ///
     /// Used by [`super::ImplAsyncFtpStream::abort`], which reads the reply itself.
     pub(super) fn detach(mut self) -> DataStream<T> {
+        self.finished = true;
         self.data
             .take()
             .expect("data stream is present until the transfer is finished")
@@ -142,7 +160,7 @@ where
 
     /// Whether the transfer has already been finalized.
     fn is_finished(&self) -> bool {
-        self.data.is_none()
+        self.finished
     }
 }
 
@@ -191,17 +209,154 @@ where
         // Closing the socket makes the server send the completion reply; it cannot be awaited
         // here, so it is left for the next command to drain.
         drop(self.data.take());
-        match self.control.try_lock() {
-            Ok(mut cc) => {
-                cc.data_connection_open = false;
-                cc.pending_transfer_reply = true;
-                warn!(
-                    "transfer stream dropped without finish(); its reply is read by the next command"
-                );
-            }
-            Err(_) => warn!(
-                "transfer stream dropped without finish() while the control connection is busy; the control connection is out of sync"
-            ),
-        }
+        // This notification must work even while a socket guard or another task holds the lock.
+        self.pending_reply.store(true, Ordering::Release);
+        warn!("transfer stream dropped without finish(); its reply is read by the next command");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc::{self, Sender};
+    use std::thread::{self, JoinHandle};
+    use std::time::Duration;
+
+    use crate::tokio::AsyncFtpStream;
+
+    async fn delayed_transfer_reply(
+        prefix: &'static [u8],
+        suffix: &'static [u8],
+    ) -> (AsyncFtpStream, Sender<()>, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (release, wait) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            socket
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut control = BufReader::new(socket);
+            control.get_mut().write_all(b"220 ready\r\n").unwrap();
+            let mut command = String::new();
+            control.read_line(&mut command).unwrap();
+            assert_eq!(command, "PASV\r\n");
+            let data_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let port = data_listener.local_addr().unwrap().port();
+            write!(
+                control.get_mut(),
+                "227 passive (127,0,0,1,{high},{low})\r\n",
+                high = port / 256,
+                low = port % 256
+            )
+            .unwrap();
+            command.clear();
+            control.read_line(&mut command).unwrap();
+            assert_eq!(command, "STOR test.bin\r\n");
+            let (mut data, _) = data_listener.accept().unwrap();
+            data.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+            control.get_mut().write_all(b"150 send data\r\n").unwrap();
+            data.read_to_end(&mut Vec::new()).unwrap();
+            control.get_mut().write_all(prefix).unwrap();
+            wait.recv_timeout(Duration::from_secs(5)).unwrap();
+            control.get_mut().write_all(suffix).unwrap();
+            command.clear();
+            control.read_line(&mut command).unwrap();
+            assert_eq!(command, "NOOP\r\n");
+            control.get_mut().write_all(b"200 noop\r\n").unwrap();
+        });
+        let ftp = AsyncFtpStream::connect(address).await.unwrap();
+        (ftp, release, server)
+    }
+
+    #[tokio::test]
+    async fn should_recover_drop_while_control_socket_is_locked() {
+        let (mut ftp, release, server) = delayed_transfer_reply(b"", b"226 complete\r\n").await;
+        let transfer = ftp.put_with_stream("test.bin").await.unwrap();
+        let guard = ftp.get_ref().await;
+        drop(transfer);
+        drop(guard);
+        release.send(()).unwrap();
+        ftp.noop().await.unwrap();
+        ftp.control()
+            .await
+            .unwrap()
+            .guard_multiple_data_connections()
+            .unwrap();
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_recover_cancelled_finish_waiting_for_control_lock() {
+        use std::future::{Future, poll_fn};
+        use std::task::Poll;
+
+        let (mut ftp, release, server) = delayed_transfer_reply(b"", b"226 complete\r\n").await;
+        let transfer = ftp.put_with_stream("test.bin").await.unwrap();
+        let guard = ftp.get_ref().await;
+        let mut finish = Box::pin(transfer.finish());
+        poll_fn(|cx| {
+            assert!(finish.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+        drop(finish);
+        drop(guard);
+        release.send(()).unwrap();
+        ftp.noop().await.unwrap();
+        ftp.control()
+            .await
+            .unwrap()
+            .guard_multiple_data_connections()
+            .unwrap();
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_resume_partial_reply_after_cancelled_finish() {
+        let (mut ftp, release, server) = delayed_transfer_reply(
+            b"226-transferred\r\nintermediate line\r\n226 comp",
+            b"lete\r\n",
+        )
+        .await;
+        let transfer = ftp.put_with_stream("test.bin").await.unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), transfer.finish())
+                .await
+                .is_err()
+        );
+        release.send(()).unwrap();
+        ftp.noop().await.unwrap();
+        ftp.control()
+            .await
+            .unwrap()
+            .guard_multiple_data_connections()
+            .unwrap();
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_resume_partial_reply_after_cancelled_drain() {
+        let (mut ftp, release, server) = delayed_transfer_reply(
+            b"226-transferred\r\nintermediate line\r\n226 comp",
+            b"lete\r\n",
+        )
+        .await;
+        let transfer = ftp.put_with_stream("test.bin").await.unwrap();
+        drop(transfer);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), ftp.noop())
+                .await
+                .is_err()
+        );
+        release.send(()).unwrap();
+        ftp.noop().await.unwrap();
+        ftp.control()
+            .await
+            .unwrap()
+            .guard_multiple_data_connections()
+            .unwrap();
+        server.join().unwrap();
     }
 }

--- a/crates/suppaftp/src/async_ftp/tokio_ftp/transfer_stream.rs
+++ b/crates/suppaftp/src/async_ftp/tokio_ftp/transfer_stream.rs
@@ -1,0 +1,207 @@
+//! Self-finalizing data stream for tokio FTP transfers.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
+
+use super::control::SharedControl;
+use super::data_stream::DataStream;
+use super::tls::TokioTlsStream;
+use crate::types::{FtpError, FtpResult};
+
+/// Whether the transfer writes to or reads from the server.
+///
+/// Uploads are only complete once the write side has been shut down successfully, so a shutdown
+/// error fails an upload; downloads have already read the whole payload, so a shutdown error is
+/// ignored and the server's completion reply is authoritative.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Direction {
+    /// `STOR` / `APPE`: data flows to the server.
+    Upload,
+    /// `RETR`, listings and custom data commands: data flows from the server.
+    Download,
+}
+
+/// Data connection of an FTP transfer that finalizes itself.
+///
+/// Returned by [`ImplAsyncFtpStream::put_with_stream`], [`ImplAsyncFtpStream::append_with_stream`],
+/// [`ImplAsyncFtpStream::retr_as_stream`] and [`ImplAsyncFtpStream::custom_data_command`]. It
+/// implements [`AsyncRead`] and [`AsyncWrite`] by delegating to the underlying [`DataStream`].
+///
+/// Once the payload has been written or read, call [`TransferStream::finish`]: it shuts down the
+/// data socket and reads the server's completion reply on the control connection, which is the
+/// only way to learn whether the transfer succeeded.
+///
+/// A stream that is merely dropped cannot await, so it closes its socket (without a TLS
+/// `close_notify`, which strict servers may report as a failed transfer) and defers the reply:
+/// the next command on the client consumes it before sending anything, so the control connection
+/// never desynchronizes. The transfer outcome is lost in that case and only logged.
+///
+/// While a `TransferStream` is alive the client refuses to open another data connection with
+/// [`FtpError::DataConnectionAlreadyOpen`]. The stream owns no reference to the client and is
+/// [`Send`] whenever the TLS stream is, so it can be moved to another task and finished there.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use suppaftp::tokio::AsyncFtpStream;
+/// use tokio::io::AsyncWriteExt;
+///
+/// # async fn run() {
+/// let mut ftp = AsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+/// ftp.login("test", "test").await.unwrap();
+/// let mut upload = ftp.put_with_stream("hello.txt").await.unwrap();
+/// upload.write_all(b"hello, world!").await.unwrap();
+/// // Reads the `226` reply; the control connection is ready for the next command.
+/// upload.finish().await.unwrap();
+/// assert_eq!(ftp.size("hello.txt").await.unwrap(), 13);
+/// # }
+/// ```
+///
+/// [`ImplAsyncFtpStream::put_with_stream`]: super::ImplAsyncFtpStream::put_with_stream
+/// [`ImplAsyncFtpStream::append_with_stream`]: super::ImplAsyncFtpStream::append_with_stream
+/// [`ImplAsyncFtpStream::retr_as_stream`]: super::ImplAsyncFtpStream::retr_as_stream
+/// [`ImplAsyncFtpStream::custom_data_command`]: super::ImplAsyncFtpStream::custom_data_command
+/// [`FtpError::DataConnectionAlreadyOpen`]: crate::FtpError::DataConnectionAlreadyOpen
+#[must_use = "call `finish().await` to close the data connection and read the transfer reply"]
+#[derive(Debug)]
+pub struct TransferStream<T>
+where
+    T: TokioTlsStream + Send,
+{
+    /// Data socket; `None` once the transfer has been finalized or detached.
+    data: Option<DataStream<T>>,
+    control: SharedControl<T>,
+    direction: Direction,
+}
+
+impl<T> TransferStream<T>
+where
+    T: TokioTlsStream + Send,
+{
+    /// Wraps an open data connection so that it completes the transfer on `control`.
+    pub(super) fn new(
+        data: DataStream<T>,
+        control: SharedControl<T>,
+        direction: Direction,
+    ) -> Self {
+        Self {
+            data: Some(data),
+            control,
+            direction,
+        }
+    }
+
+    /// Returns a reference to the underlying [`DataStream`].
+    pub fn get_ref(&self) -> &DataStream<T> {
+        self.data
+            .as_ref()
+            .expect("data stream is present until the transfer is finished")
+    }
+
+    /// Returns a mutable reference to the underlying [`DataStream`].
+    pub fn get_mut(&mut self) -> &mut DataStream<T> {
+        self.data
+            .as_mut()
+            .expect("data stream is present until the transfer is finished")
+    }
+
+    /// Shuts down the data connection and reads the transfer completion reply.
+    ///
+    /// After this call the client can issue the next command.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::ConnectionError`] if an upload cannot be shut down cleanly or the
+    /// control connection cannot be read, and [`FtpError::UnexpectedResponse`] if the server
+    /// reports that the transfer failed (any reply other than `226` or `250`).
+    pub async fn finish(mut self) -> FtpResult<()> {
+        let Some(mut data) = self.data.take() else {
+            return Ok(());
+        };
+        // Close the write side so TLS streams send close_notify before being dropped, then close
+        // the socket: the server only sends the completion reply once the data connection is gone.
+        let shutdown = data.shutdown().await;
+        drop(data);
+        let reply = self.control.lock().await.complete_transfer().await;
+        if self.direction == Direction::Upload {
+            shutdown.map_err(FtpError::ConnectionError)?;
+        }
+        reply
+    }
+
+    /// Detaches the data socket; the returned stream no longer completes the transfer on drop.
+    ///
+    /// Used by [`super::ImplAsyncFtpStream::abort`], which reads the reply itself.
+    pub(super) fn detach(mut self) -> DataStream<T> {
+        self.data
+            .take()
+            .expect("data stream is present until the transfer is finished")
+    }
+
+    /// Whether the transfer has already been finalized.
+    fn is_finished(&self) -> bool {
+        self.data.is_none()
+    }
+}
+
+impl<T> AsyncRead for TransferStream<T>
+where
+    T: TokioTlsStream + Send,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(Pin::into_inner(self).get_mut()).poll_read(cx, buf)
+    }
+}
+
+impl<T> AsyncWrite for TransferStream<T>
+where
+    T: TokioTlsStream + Send,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(Pin::into_inner(self).get_mut()).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(Pin::into_inner(self).get_mut()).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(Pin::into_inner(self).get_mut()).poll_shutdown(cx)
+    }
+}
+
+impl<T> Drop for TransferStream<T>
+where
+    T: TokioTlsStream + Send,
+{
+    fn drop(&mut self) {
+        if self.is_finished() {
+            return;
+        }
+        // Closing the socket makes the server send the completion reply; it cannot be awaited
+        // here, so it is left for the next command to drain.
+        drop(self.data.take());
+        match self.control.try_lock() {
+            Ok(mut cc) => {
+                cc.data_connection_open = false;
+                cc.pending_transfer_reply = true;
+                warn!(
+                    "transfer stream dropped without finish(); its reply is read by the next command"
+                );
+            }
+            Err(_) => warn!(
+                "transfer stream dropped without finish() while the control connection is busy; the control connection is out of sync"
+            ),
+        }
+    }
+}

--- a/crates/suppaftp/src/lib.rs
+++ b/crates/suppaftp/src/lib.rs
@@ -223,7 +223,6 @@ use sync_ftp::NoTlsStream;
 pub use sync_ftp::{ImplFtpStream, PassiveStreamBuilder, TlsStream};
 pub use types::{FtpError, FtpResult, Mode};
 pub type FtpStream = ImplFtpStream<NoTlsStream>;
-pub use sync_ftp::DataStream;
 // -- export secure (native-tls)
 #[cfg(feature = "native-tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
@@ -231,6 +230,7 @@ pub use sync_ftp::NativeTlsConnector;
 #[cfg(feature = "native-tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
 use sync_ftp::NativeTlsStream;
+pub use sync_ftp::{ControlSocket, DataStream, TransferStream};
 #[cfg(feature = "native-tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
 pub type NativeTlsFtpStream = ImplFtpStream<NativeTlsStream>;

--- a/crates/suppaftp/src/sync_ftp.rs
+++ b/crates/suppaftp/src/sync_ftp.rs
@@ -146,6 +146,7 @@ where
     }
 
     /// Switch to explicit secure mode if possible (FTPS), using a provided SSL configuration.
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] before sending `AUTH` if a transfer is alive.
     /// This method does nothing if the connect is already secured.
     ///
     /// ## Example
@@ -168,6 +169,10 @@ where
         tls_connector: impl TlsConnector<Stream = T> + Send + Sync + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
+        // Reject a live transfer before asking the server to change the control protocol.
+        if Arc::strong_count(&self.control) != 1 {
+            return Err(FtpError::DataConnectionAlreadyOpen);
+        }
         {
             let mut cc = self.control();
             // Ask the server to start securing data.
@@ -304,9 +309,14 @@ where
     /// Perform clear command channel (CCC).
     /// Once the command is performed, the command channel will be encrypted no more.
     /// The data stream will still be secure.
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] before sending `CCC` if a transfer is alive.
     #[cfg(feature = "secure")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secure")))]
     pub fn clear_command_channel(mut self) -> FtpResult<Self> {
+        // Reject a live transfer before asking the server to change the control protocol.
+        if Arc::strong_count(&self.control) != 1 {
+            return Err(FtpError::DataConnectionAlreadyOpen);
+        }
         {
             let mut cc = self.control();
             // Ask the server to stop securing data
@@ -426,7 +436,7 @@ where
     /// data stream opened.
     ///
     /// The data connection is finished once `reader` returns, whether it succeeded or not, so the
-    /// control connection is always left in sync.
+    /// control connection can be reused after successful cleanup.
     ///
     /// ```rust,ignore
     /// use suppaftp::{FtpStream, FtpError};
@@ -1985,7 +1995,7 @@ mod test {
         let container_t = container.clone();
 
         ftp_stream.passive_stream_builder(move |addr| {
-            let mut addr = addr.clone();
+            let mut addr = addr;
             let port = addr.port();
             let mapped = container_t.get_mapped_port(port);
 

--- a/crates/suppaftp/src/sync_ftp.rs
+++ b/crates/suppaftp/src/sync_ftp.rs
@@ -2,17 +2,22 @@
 //!
 //! This module contains the definition for all Sync implementation of suppaftp
 
+mod control;
 mod data_stream;
 mod tls;
+mod transfer_stream;
 
-use std::io::{BufRead, BufReader, Cursor, Read, Write, copy};
+use std::io::{BufRead, BufReader, Cursor, Read, copy};
 #[cfg(not(feature = "secure"))]
 use std::marker::PhantomData;
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::sync::{Arc, MutexGuard};
 use std::time::{Duration, Instant};
 
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 // export
+pub use control::ControlSocket;
+use control::{ControlChannel, SharedControl};
 pub use data_stream::DataStream;
 #[cfg(feature = "secure")]
 pub use tls::TlsConnector;
@@ -21,6 +26,7 @@ pub use tls::{NativeTlsConnector, NativeTlsStream};
 pub use tls::{NoTlsStream, TlsStream};
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 pub use tls::{RustlsConnector, RustlsStream};
+pub use transfer_stream::TransferStream;
 
 use super::Status;
 use super::regex::{EPSV_PORT_RE, MDTM_RE, PASV_PORT_RE, SIZE_RE};
@@ -36,19 +42,19 @@ use crate::types::Features;
 pub type PassiveStreamBuilder = dyn Fn(SocketAddr) -> FtpResult<TcpStream> + Send + Sync;
 
 /// Stream to interface with the FTP server. This interface is only for the command stream.
+///
+/// The control connection is shared with the [`TransferStream`]s handed out by the data
+/// commands, so that each transfer can close its data connection and read the completion reply
+/// on its own; see [`TransferStream`] for details.
 pub struct ImplFtpStream<T>
 where
     T: TlsStream,
 {
-    reader: BufReader<DataStream<T>>,
+    /// Control connection, locked for the duration of each command.
+    control: SharedControl<T>,
     mode: Mode,
     nat_workaround: bool,
     welcome_msg: Option<String>,
-    /// flags whether a data connection is currently open
-    ///
-    /// Since it isn't possible to have multiple data connections at the same time,
-    /// this flag is used to track whether a data connection is currently open.
-    data_connection_open: bool,
     active_timeout: Duration,
     passive_stream_builder: Box<PassiveStreamBuilder>,
     #[cfg(not(feature = "secure"))]
@@ -83,11 +89,10 @@ where
     pub fn connect_with_stream(stream: TcpStream) -> FtpResult<Self> {
         debug!("Established connection with server");
         let mut ftp_stream = Self {
-            reader: BufReader::new(DataStream::Tcp(stream)),
+            control: ControlChannel::shared(DataStream::Tcp(stream)),
             mode: Mode::Passive,
             nat_workaround: false,
             welcome_msg: None,
-            data_connection_open: false,
             active_timeout: Duration::from_secs(60),
             passive_stream_builder: Self::default_passive_stream_builder(),
             #[cfg(feature = "secure")]
@@ -98,7 +103,8 @@ where
             marker: PhantomData {},
         };
         debug!("Reading server response...");
-        match ftp_stream.read_response(Status::Ready) {
+        let ready = ftp_stream.control().read_response(Status::Ready);
+        match ready {
             Ok(response) => {
                 let welcome_msg = response.as_string().ok();
                 debug!("Server READY; response: {:?}", welcome_msg);
@@ -158,23 +164,29 @@ where
     #[cfg(feature = "secure")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secure")))]
     pub fn into_secure(
-        mut self,
+        self,
         tls_connector: impl TlsConnector<Stream = T> + Send + Sync + 'static,
         domain: &str,
     ) -> FtpResult<Self> {
-        // Ask the server to start securing data.
-        debug!("Initializing TLS auth");
-        self.perform(Command::Auth)?;
-        self.read_response(Status::AuthOk)?;
+        {
+            let mut cc = self.control();
+            // Ask the server to start securing data.
+            debug!("Initializing TLS auth");
+            cc.perform(Command::Auth)?;
+            cc.read_response(Status::AuthOk)?;
+        }
         debug!("TLS OK; initializing ssl stream");
+        let plain = control::into_exclusive(self.control)?
+            .reader
+            .into_inner()
+            .into_tcp_stream()?;
         let stream = tls_connector
-            .connect(domain, self.reader.into_inner().into_tcp_stream()?)
+            .connect(domain, plain)
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
-        let mut secured_ftp_tream = Self {
-            reader: BufReader::new(DataStream::Ssl(Box::new(stream))),
+        let secured_ftp_tream = Self {
+            control: ControlChannel::shared(DataStream::Ssl(Box::new(stream))),
             mode: self.mode,
-            data_connection_open: self.data_connection_open,
             nat_workaround: self.nat_workaround,
             passive_stream_builder: self.passive_stream_builder,
             tls_ctx: Some(Box::new(tls_connector)),
@@ -182,12 +194,15 @@ where
             welcome_msg: self.welcome_msg,
             active_timeout: self.active_timeout,
         };
-        // Set protection buffer size
-        secured_ftp_tream.perform(Command::Pbsz(0))?;
-        secured_ftp_tream.read_response(Status::CommandOk)?;
-        // Change the level of data protectio to Private
-        secured_ftp_tream.perform(Command::Prot(ProtectionLevel::Private))?;
-        secured_ftp_tream.read_response(Status::CommandOk)?;
+        {
+            let mut cc = secured_ftp_tream.control();
+            // Set protection buffer size
+            cc.perform(Command::Pbsz(0))?;
+            cc.read_response(Status::CommandOk)?;
+            // Change the level of data protectio to Private
+            cc.perform(Command::Prot(ProtectionLevel::Private))?;
+            cc.read_response(Status::CommandOk)?;
+        }
         Ok(secured_ftp_tream)
     }
 
@@ -216,33 +231,17 @@ where
         domain: &str,
     ) -> FtpResult<Self> {
         debug!("Connecting to server (secure)");
-        let stream = TcpStream::connect(addr)
-            .map_err(FtpError::ConnectionError)
-            .map(|stream| {
-                debug!("Established connection with server");
-                Self {
-                    reader: BufReader::new(DataStream::Tcp(stream)),
-                    mode: Mode::Passive,
-                    nat_workaround: false,
-                    data_connection_open: false,
-                    passive_stream_builder: Self::default_passive_stream_builder(),
-                    welcome_msg: None,
-                    tls_ctx: None,
-                    domain: None,
-                    active_timeout: Duration::from_secs(60),
-                }
-            })?;
+        let stream = TcpStream::connect(addr).map_err(FtpError::ConnectionError)?;
         debug!("Established connection with server");
         debug!("TLS OK; initializing ssl stream");
         let stream = tls_connector
-            .connect(domain, stream.reader.into_inner().into_tcp_stream()?)
+            .connect(domain, stream)
             .map_err(|e| FtpError::SecureError(format!("{e}")))?;
         debug!("TLS Steam OK");
         let mut stream = Self {
-            reader: BufReader::new(DataStream::Ssl(Box::new(stream))),
+            control: ControlChannel::shared(DataStream::Ssl(Box::new(stream))),
             mode: Mode::Passive,
             nat_workaround: false,
-            data_connection_open: false,
             tls_ctx: Some(Box::new(tls_connector)),
             passive_stream_builder: Self::default_passive_stream_builder(),
             domain: Some(String::from(domain)),
@@ -250,14 +249,10 @@ where
             active_timeout: Duration::from_secs(60),
         };
         debug!("Reading server response...");
-        match stream.read_response(Status::Ready) {
-            Ok(response) => {
-                let welcome_msg = response.as_string().ok();
-                debug!("Server READY; response: {:?}", welcome_msg);
-                stream.welcome_msg = welcome_msg;
-            }
-            Err(err) => return Err(err),
-        }
+        let response = stream.control().read_response(Status::Ready)?;
+        let welcome_msg = response.as_string().ok();
+        debug!("Server READY; response: {:?}", welcome_msg);
+        stream.welcome_msg = welcome_msg;
 
         Ok(stream)
     }
@@ -267,33 +262,39 @@ where
         self.welcome_msg.as_deref()
     }
 
-    /// Returns a reference to the underlying [`TcpStream`].
+    /// Returns a locked view of the underlying control [`TcpStream`].
     ///
-    /// Example:
-    /// ```ignore
-    /// use suppaftp::FtpStream;
-    /// use std::net::TcpStream;
+    /// The returned [`ControlSocket`] dereferences to the socket and keeps the control connection
+    /// locked while alive, so drop it before finishing a [`TransferStream`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
     /// use std::time::Duration;
     ///
-    /// let stream = FtpStream::connect("127.0.0.1:21")
-    ///                        .expect("Couldn't connect to the server...");
-    /// stream.get_ref().set_read_timeout(Some(Duration::from_secs(10)))
-    ///                 .expect("set_read_timeout call failed");
+    /// use suppaftp::FtpStream;
+    ///
+    /// let stream = FtpStream::connect("127.0.0.1:21").expect("Couldn't connect to the server...");
+    /// stream
+    ///     .get_ref()
+    ///     .set_read_timeout(Some(Duration::from_secs(10)))
+    ///     .expect("set_read_timeout call failed");
     /// ```
-    pub fn get_ref(&self) -> &TcpStream {
-        self.reader.get_ref().get_ref()
+    pub fn get_ref(&self) -> ControlSocket<'_, T> {
+        ControlSocket::lock(&self.control)
     }
 
     /// Log in to the FTP server.
     pub fn login<S: AsRef<str>>(&mut self, user: S, password: S) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Signin in with user '{}'", user.as_ref());
-        self.perform(Command::User(user.as_ref().to_string()))?;
-        self.read_response_in(&[Status::LoggedIn, Status::NeedPassword])
+        cc.perform(Command::User(user.as_ref().to_string()))?;
+        cc.read_response_in(&[Status::LoggedIn, Status::NeedPassword])
             .and_then(|Response { status, body: _ }| {
                 if status == Status::NeedPassword {
                     debug!("Password is required");
-                    self.perform(Command::Pass(password.as_ref().to_string()))?;
-                    self.read_response(Status::LoggedIn)?;
+                    cc.perform(Command::Pass(password.as_ref().to_string()))?;
+                    cc.read_response(Status::LoggedIn)?;
                 }
                 debug!("Login OK");
                 Ok(())
@@ -306,109 +307,126 @@ where
     #[cfg(feature = "secure")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secure")))]
     pub fn clear_command_channel(mut self) -> FtpResult<Self> {
-        // Ask the server to stop securing data
-        debug!("performing clear command channel");
-        self.perform(Command::ClearCommandChannel)?;
-        self.read_response(Status::CommandOk)?;
+        {
+            let mut cc = self.control();
+            // Ask the server to stop securing data
+            debug!("performing clear command channel");
+            cc.perform(Command::ClearCommandChannel)?;
+            cc.read_response(Status::CommandOk)?;
+        }
         trace!("CCC OK");
-        self.reader = BufReader::new(DataStream::Tcp(self.reader.into_inner().into_tcp_stream()?));
+        let plain = control::into_exclusive(self.control)?
+            .reader
+            .into_inner()
+            .into_tcp_stream()?;
+        self.control = ControlChannel::shared(DataStream::Tcp(plain));
         Ok(self)
     }
 
     /// Change the current directory to the path specified.
     pub fn cwd<S: AsRef<str>>(&mut self, path: S) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Changing working directory to {}", path.as_ref());
-        self.perform(Command::Cwd(path.as_ref().to_string()))?;
-        self.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
+        cc.perform(Command::Cwd(path.as_ref().to_string()))?;
+        cc.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
             .map(|_| ())
     }
 
     /// Move the current directory to the parent directory.
     pub fn cdup(&mut self) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Going to parent directory");
-        self.perform(Command::Cdup)?;
-        self.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
+        cc.perform(Command::Cdup)?;
+        cc.read_response_in(&[Status::CommandOk, Status::RequestedFileActionOk])
             .map(|_| ())
     }
 
     /// Gets the current directory
     pub fn pwd(&mut self) -> FtpResult<String> {
+        let mut cc = self.control();
         debug!("Getting working directory");
-        self.perform(Command::Pwd)?;
-        self.read_response(Status::PathCreated)
-            .and_then(|response| {
-                let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
-                let status = response.status;
-                match (body.find('"'), body.rfind('"')) {
-                    (Some(begin), Some(end)) if begin < end => Ok(body[begin + 1..end].to_string()),
-                    _ => Err(FtpError::UnexpectedResponse(Response::new(
-                        status,
-                        response.body,
-                    ))),
-                }
-            })
+        cc.perform(Command::Pwd)?;
+        cc.read_response(Status::PathCreated).and_then(|response| {
+            let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
+            let status = response.status;
+            match (body.find('"'), body.rfind('"')) {
+                (Some(begin), Some(end)) if begin < end => Ok(body[begin + 1..end].to_string()),
+                _ => Err(FtpError::UnexpectedResponse(Response::new(
+                    status,
+                    response.body,
+                ))),
+            }
+        })
     }
 
     /// This does nothing. This is usually just used to keep the connection open.
     pub fn noop(&mut self) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Pinging server");
-        self.perform(Command::Noop)?;
-        self.read_response(Status::CommandOk).map(|_| ())
+        cc.perform(Command::Noop)?;
+        cc.read_response(Status::CommandOk).map(|_| ())
     }
 
     /// The EPRT command allows for the specification of an extended address
     /// for the data connection. The extended address MUST consist of the
     /// network protocol as well as the network and transport addresses
     pub fn eprt(&mut self, address: SocketAddr) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("EPRT with address {address}");
-        self.perform(Command::Eprt(address))?;
-        self.read_response(Status::CommandOk).map(|_| ())
+        cc.perform(Command::Eprt(address))?;
+        cc.read_response(Status::CommandOk).map(|_| ())
     }
 
     /// This creates a new directory on the server.
     pub fn mkdir<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Creating directory at {}", pathname.as_ref());
-        self.perform(Command::Mkd(pathname.as_ref().to_string()))?;
+        cc.perform(Command::Mkd(pathname.as_ref().to_string()))?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 257.
-        self.read_response_in(&[Status::PathCreated, Status::CommandOk])
+        cc.read_response_in(&[Status::PathCreated, Status::CommandOk])
             .map(|_| ())
     }
 
     /// Sets the type of file to be transferred. That is the implementation
     /// of `TYPE` command.
     pub fn transfer_type(&mut self, file_type: FileType) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Setting transfer type {}", file_type);
-        self.perform(Command::Type(file_type))?;
-        self.read_response(Status::CommandOk).map(|_| ())
+        cc.perform(Command::Type(file_type))?;
+        cc.read_response(Status::CommandOk).map(|_| ())
     }
 
     /// Quits the current FTP session.
     pub fn quit(&mut self) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Quitting stream");
-        self.perform(Command::Quit)?;
-        self.read_response(Status::Closing).map(|_| ())
+        cc.perform(Command::Quit)?;
+        cc.read_response(Status::Closing).map(|_| ())
     }
 
     /// Renames the file from_name to to_name
     pub fn rename<S: AsRef<str>>(&mut self, from_name: S, to_name: S) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!(
             "Renaming '{}' to '{}'",
             from_name.as_ref(),
             to_name.as_ref()
         );
-        self.perform(Command::RenameFrom(from_name.as_ref().to_string()))?;
-        self.read_response(Status::RequestFilePending)
-            .and_then(|_| {
-                self.perform(Command::RenameTo(to_name.as_ref().to_string()))?;
-                // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
-                self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
-                    .map(|_| ())
-            })
+        cc.perform(Command::RenameFrom(from_name.as_ref().to_string()))?;
+        cc.read_response(Status::RequestFilePending).and_then(|_| {
+            cc.perform(Command::RenameTo(to_name.as_ref().to_string()))?;
+            // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
+            cc.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
+                .map(|_| ())
+        })
     }
 
     /// The implementation of `RETR` command where `filename` is the name of the file
     /// to download from FTP and `reader` is the function which operates with the
     /// data stream opened.
+    ///
+    /// The data connection is finished once `reader` returns, whether it succeeded or not, so the
+    /// control connection is always left in sync.
     ///
     /// ```rust,ignore
     /// use suppaftp::{FtpStream, FtpError};
@@ -430,14 +448,13 @@ where
     where
         F: FnMut(&mut dyn Read) -> FtpResult<D>,
     {
-        match self.retr_as_stream(file_name) {
-            Ok(mut stream) => {
-                let result = reader(&mut stream)?;
-                self.finalize_retr_stream(stream)?;
-                Ok(result)
-            }
-            Err(err) => Err(err),
-        }
+        let mut stream = self.retr_as_stream(file_name)?;
+        let result = reader(&mut stream);
+        // Always finish, but report the reader's error first: it is the root cause.
+        let finished = stream.finish();
+        let value = result?;
+        finished?;
+        Ok(value)
     }
 
     /// Simple way to retr a file from the server. This stores the file in a buffer in memory.
@@ -466,48 +483,57 @@ where
         .map(Cursor::new)
     }
 
-    /// Retrieves the file name specified from the server as a readable stream.
-    /// This method is a more complicated way to retrieve a file.
-    /// The reader returned should be dropped.
-    /// Also you will have to read the response to make sure it has the correct value.
-    /// Once file has been read, call [`ImplFtpStream::finalize_retr_stream`]
-    pub fn retr_as_stream<S: AsRef<str>>(&mut self, file_name: S) -> FtpResult<DataStream<T>> {
+    /// Retrieves the file `file_name` from the server as a readable [`TransferStream`].
+    ///
+    /// Read the payload from the returned stream, then call [`TransferStream::finish`] to close
+    /// the data connection and read the server's completion reply. Until then any other data
+    /// command fails with [`FtpError::DataConnectionAlreadyOpen`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use std::io::Read;
+    ///
+    /// use suppaftp::FtpStream;
+    ///
+    /// let mut ftp = FtpStream::connect("127.0.0.1:21").unwrap();
+    /// ftp.login("test", "test").unwrap();
+    /// let mut download = ftp.retr_as_stream("hello.txt").unwrap();
+    /// let mut buf = Vec::new();
+    /// download.read_to_end(&mut buf).unwrap();
+    /// download.finish().unwrap();
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server refuses the `RETR` command.
+    pub fn retr_as_stream<S: AsRef<str>>(&mut self, file_name: S) -> FtpResult<TransferStream<T>> {
         debug!("Retrieving '{}'", file_name.as_ref());
-        let (_, data_stream) = self.data_command_with_response(
+        let (_, stream) = self.open_transfer(
             Command::Retr(file_name.as_ref().to_string()),
             &[Status::AboutToSend, Status::AlreadyOpen],
         )?;
-        Ok(data_stream)
-    }
-
-    /// Finalize retr stream; must be called once the requested file, got previously with [`ImplFtpStream::retr_as_stream`] has been read
-    pub fn finalize_retr_stream(&mut self, stream: impl Read) -> FtpResult<()> {
-        debug!("Finalizing retr stream");
-        // Drop stream NOTE: must be done first, otherwise server won't return any response
-        drop(stream);
-        // mark data channel as closed
-        self.data_connection_open = false;
-        trace!("dropped stream");
-        // Then read response
-        self.read_response_in(&[Status::ClosingDataConnection, Status::RequestedFileActionOk])
-            .map(|_| ())
+        Ok(stream)
     }
 
     /// Removes the remote pathname from the server.
     pub fn rmdir<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Removing directory {}", pathname.as_ref());
-        self.perform(Command::Rmd(pathname.as_ref().to_string()))?;
+        cc.perform(Command::Rmd(pathname.as_ref().to_string()))?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
-        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
+        cc.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .map(|_| ())
     }
 
     /// Remove the remote file from the server.
     pub fn rm<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Removing file {}", filename.as_ref());
-        self.perform(Command::Dele(filename.as_ref().to_string()))?;
+        cc.perform(Command::Dele(filename.as_ref().to_string()))?;
         // Some non-compliant servers (e.g. bftpd) reply with 200 instead of 250.
-        self.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
+        cc.read_response_in(&[Status::RequestedFileActionOk, Status::CommandOk])
             .map(|_| ())
     }
 
@@ -518,43 +544,57 @@ where
         // Get stream
         let mut data_stream = self.put_with_stream(filename.as_ref())?;
         let bytes = copy(r, &mut data_stream).map_err(FtpError::ConnectionError)?;
-        self.finalize_put_stream(data_stream)?;
+        data_stream.finish()?;
         Ok(bytes)
     }
 
-    /// Send PUT command and returns a BufWriter, which references the file created on the server
-    /// The returned stream must be then correctly manipulated to write the content of the source file to the remote destination
-    /// The stream must be then correctly dropped.
-    /// Once you've finished the write, YOU MUST CALL THIS METHOD: [`ImplFtpStream::finalize_put_stream`]
-    pub fn put_with_stream<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<DataStream<T>> {
+    /// Sends `STOR` and returns a writable [`TransferStream`] for the file `filename`.
+    ///
+    /// Write the payload to the returned stream, then call [`TransferStream::finish`] to close
+    /// the data connection and read the server's completion reply. Until then any other data
+    /// command fails with [`FtpError::DataConnectionAlreadyOpen`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use std::io::Write;
+    ///
+    /// use suppaftp::FtpStream;
+    ///
+    /// let mut ftp = FtpStream::connect("127.0.0.1:21").unwrap();
+    /// ftp.login("test", "test").unwrap();
+    /// let mut upload = ftp.put_with_stream("hello.txt").unwrap();
+    /// upload.write_all(b"hello, world!").unwrap();
+    /// upload.finish().unwrap();
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server refuses the `STOR` command.
+    pub fn put_with_stream<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<TransferStream<T>> {
         debug!("Put file {}", filename.as_ref());
-        let (_, stream) = self.data_command_with_response(
+        let (_, stream) = self.open_transfer(
             Command::Store(filename.as_ref().to_string()),
             &[Status::AlreadyOpen, Status::AboutToSend],
         )?;
         Ok(stream)
     }
 
-    /// Finalize put when using stream
-    /// This method must be called once the file has been written and
-    /// [`ImplFtpStream::put_with_stream`] has been used to write the file
-    pub fn finalize_put_stream(&mut self, stream: impl Write) -> FtpResult<()> {
-        debug!("Finalizing put stream");
-        // Drop stream NOTE: must be done first, otherwise server won't return any response
-        drop(stream);
-        // mark data channel as closed
-        self.data_connection_open = false;
-        trace!("Stream dropped");
-        // Read response
-        self.read_response_in(&[Status::ClosingDataConnection, Status::RequestedFileActionOk])
-            .map(|_| ())
-    }
-
-    /// Open specified file for appending data. Returns the stream to append data to specified file.
-    /// Once you've finished the write, YOU MUST CALL THIS METHOD: [`ImplFtpStream::finalize_put_stream`]
-    pub fn append_with_stream<S: AsRef<str>>(&mut self, filename: S) -> FtpResult<DataStream<T>> {
+    /// Sends `APPE` and returns a writable [`TransferStream`] appending to the file `filename`.
+    ///
+    /// Behaves like [`ImplFtpStream::put_with_stream`], except that the data is appended.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server refuses the `APPE` command.
+    pub fn append_with_stream<S: AsRef<str>>(
+        &mut self,
+        filename: S,
+    ) -> FtpResult<TransferStream<T>> {
         debug!("Appending to file {}", filename.as_ref());
-        let (_, stream) = self.data_command_with_response(
+        let (_, stream) = self.open_transfer(
             Command::Appe(filename.as_ref().to_string()),
             &[Status::AlreadyOpen, Status::AboutToSend],
         )?;
@@ -566,24 +606,35 @@ where
         // Get stream
         let mut data_stream = self.append_with_stream(filename)?;
         let bytes = copy(r, &mut data_stream).map_err(FtpError::ConnectionError)?;
-        self.finalize_put_stream(Box::new(data_stream))?;
+        data_stream.finish()?;
         Ok(bytes)
     }
 
-    /// abort the previous FTP service command
-    pub fn abort(&mut self, data_stream: impl Read + 'static) -> FtpResult<()> {
+    /// Aborts the transfer running on `transfer` with the `ABOR` command.
+    ///
+    /// The data connection is closed and the server's abort replies (`426` followed by `226`,
+    /// or a single `226`) are consumed, so the control connection is ready for the next command.
+    /// `transfer` must have been obtained from this client.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::UnexpectedResponse`] if the server does not acknowledge the abort.
+    pub fn abort(&mut self, transfer: TransferStream<T>) -> FtpResult<()> {
         debug!("Aborting active file transfer");
-        self.perform(Command::Abor)?;
+        // Detach the socket first: the stream must not finalize itself while the lock is held.
+        let data_stream = transfer.detach();
+        let mut cc = self.control();
+        cc.perform(Command::Abor)?;
         // Drop stream NOTE: must be done first, otherwise server won't return any response
         drop(data_stream);
         // mark data channel as closed
-        self.data_connection_open = false;
+        cc.data_connection_open = false;
         trace!("dropped stream");
         let response =
-            self.read_response_in(&[Status::ClosingDataConnection, Status::TransferAborted])?;
+            cc.read_response_in(&[Status::ClosingDataConnection, Status::TransferAborted])?;
         // If server sent 426 (TransferAborted), expect a follow-up 226
         if response.status == Status::TransferAborted {
-            self.read_response(Status::ClosingDataConnection)?;
+            cc.read_response(Status::ClosingDataConnection)?;
         }
         debug!("Transfer aborted");
         Ok(())
@@ -596,9 +647,10 @@ where
     ///
     /// It is possible to cancel the REST command, sending a REST command with offset 0
     pub fn resume_transfer(&mut self, offset: usize) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Requesting to resume transfer at offset {}", offset);
-        self.perform(Command::Rest(offset))?;
-        self.read_response(Status::RequestFilePending)?;
+        cc.perform(Command::Rest(offset))?;
+        cc.read_response(Status::RequestFilePending)?;
         debug!("Resume transfer accepted");
         Ok(())
     }
@@ -664,10 +716,11 @@ where
     /// Execute `MLST` command which returns the machine-processable listing of a file.
     /// If `pathname` is omited then the list of files in the current directory will be
     pub fn mlst(&mut self, pathname: Option<&str>) -> FtpResult<String> {
+        let mut cc = self.control();
         debug!("Reading {} path information", pathname.unwrap_or("working"));
 
-        self.perform(Command::Mlst(pathname.map(|x| x.to_string())))?;
-        let response = self.read_response_in(&[Status::RequestedFileActionOk])?;
+        cc.perform(Command::Mlst(pathname.map(|x| x.to_string())))?;
+        let response = cc.read_response_in(&[Status::RequestedFileActionOk])?;
         // read body at line 1
         let response_str = String::from_utf8_lossy(&response.body).to_string();
         match response_str.lines().nth(1) {
@@ -679,9 +732,10 @@ where
 
     /// Retrieves the modification time of the file at `pathname` if it exists.
     pub fn mdtm<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<NaiveDateTime> {
+        let mut cc = self.control();
         debug!("Getting modification time for {}", pathname.as_ref());
-        self.perform(Command::Mdtm(pathname.as_ref().to_string()))?;
-        let response: Response = self.read_response(Status::File)?;
+        cc.perform(Command::Mdtm(pathname.as_ref().to_string()))?;
+        let response: Response = cc.read_response(Status::File)?;
         let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
 
         match MDTM_RE.captures(&body) {
@@ -715,9 +769,10 @@ where
 
     /// Retrieves the size of the file in bytes at `pathname` if it exists.
     pub fn size<S: AsRef<str>>(&mut self, pathname: S) -> FtpResult<usize> {
+        let mut cc = self.control();
         debug!("Getting file size for {}", pathname.as_ref());
-        self.perform(Command::Size(pathname.as_ref().to_string()))?;
-        let response: Response = self.read_response(Status::File)?;
+        cc.perform(Command::Size(pathname.as_ref().to_string()))?;
+        let response: Response = cc.read_response(Status::File)?;
         let body = response.as_string().map_err(|_| FtpError::BadResponse)?;
 
         match SIZE_RE.captures(&body) {
@@ -728,18 +783,19 @@ where
 
     /// Retrieves the features supported by the server, through the FEAT command.
     pub fn feat(&mut self) -> FtpResult<Features> {
+        let mut cc = self.control();
         debug!("Getting server supported features");
         // Send FEAT command
-        self.perform(Command::Feat)?;
+        cc.perform(Command::Feat)?;
 
         // Read the response
-        let response = self.read_response(Status::System)?;
+        let response = cc.read_response(Status::System)?;
 
         let first_line = String::from_utf8_lossy(&response.body);
         let mut feat_lines = vec![first_line.to_string()];
         loop {
             let mut line = Vec::new();
-            let line_sz = self.read_line(&mut line)?;
+            let line_sz = cc.read_line(&mut line)?;
             if line_sz == 0 {
                 // EOF reached
                 break;
@@ -757,21 +813,23 @@ where
 
     /// Set option `option` with an optional value
     pub fn opts(&mut self, option: impl ToString, value: Option<impl ToString>) -> FtpResult<()> {
+        let mut cc = self.control();
         debug!("Getting server supported features");
-        self.perform(Command::Opts(
+        cc.perform(Command::Opts(
             option.to_string(),
             value.map(|x| x.to_string()),
         ))?;
-        self.read_response(Status::CommandOk)?;
+        cc.read_response(Status::CommandOk)?;
 
         Ok(())
     }
 
     /// Execute a command on the server and return the response
     pub fn site(&mut self, command: impl ToString) -> FtpResult<Response> {
+        let mut cc = self.control();
         debug!("Sending SITE command: {}", command.to_string());
-        self.perform(Command::Site(command.to_string()))?;
-        self.read_response(Status::CommandOk)
+        cc.perform(Command::Site(command.to_string()))?;
+        cc.read_response(Status::CommandOk)
     }
 
     /// Perform custom command.
@@ -789,57 +847,43 @@ where
         command: impl ToString,
         expected_code: &[Status],
     ) -> FtpResult<Response> {
+        let mut cc = self.control();
         let command = command.to_string();
         debug!("Sending custom command: {}", command);
-        self.perform(Command::Custom(command))?;
-        self.read_response_in(expected_code)
+        cc.perform(Command::Custom(command))?;
+        cc.read_response_in(expected_code)
     }
 
     /// Perform a custom command using the data connection.
-    /// It returns both the [`Response`] and the [`DataStream`].
     ///
-    /// The [`DataStream`] implements both [`Write`] and [`Read`] and so it can be written or read to interact with the
-    /// data channel.
+    /// It returns both the [`Response`] and a [`TransferStream`], which implements both
+    /// [`std::io::Write`] and [`Read`] and so it can be written or read to interact with the data
+    /// channel.
     ///
-    /// If you want you can easily parse lines from the [`DataStream`] using [`Self::get_lines_from_stream`].
+    /// If you want you can easily parse lines from the stream using [`Self::get_lines_from_stream`].
     ///
-    /// The stream must eventually be closed using [`Self::close_data_connection`].
+    /// Once done, call [`TransferStream::finish`] to close the data connection and read the
+    /// server's completion reply.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::DataConnectionAlreadyOpen`] if a transfer is still in progress, and
+    /// [`FtpError::UnexpectedResponse`] if the server's reply is not in `expected_code`.
     pub fn custom_data_command(
         &mut self,
         command: impl ToString,
         expected_code: &[Status],
-    ) -> FtpResult<(Response, DataStream<T>)> {
+    ) -> FtpResult<(Response, TransferStream<T>)> {
         let command = command.to_string();
         debug!("Sending custom data command: {}", command);
-        let (response, data_stream) =
-            self.data_command_with_response(Command::Custom(command), expected_code)?;
-        Ok((response, data_stream))
+        self.open_transfer(Command::Custom(command), expected_code)
     }
 
-    /// Close data connection.
-    ///
-    /// Call this function when you're done with the stream obtained with [`Self::custom_data_command`].
-    ///
-    /// # Warning
-    ///
-    /// Passing any other [`Read`] which is not the [`DataStream`]
-    /// obtained with [`Self::custom_data_command`] may lead to undefined behavior.
-    pub fn close_data_connection(&mut self, stream: impl Read) -> FtpResult<()> {
-        debug!("closing data connection");
-        // Drop stream NOTE: must be done first, otherwise server won't return any response
-        drop(stream);
-        // mark data channel as closed
-        self.data_connection_open = false;
-        trace!("dropped stream");
-        // Then read response
-        self.read_response_in(&[Status::ClosingDataConnection, Status::RequestedFileActionOk])
-            .map(|_| ())
-    }
-
-    /// Read a [`DataStream`] line by line.
-    pub fn get_lines_from_stream(
-        data_stream: &mut BufReader<DataStream<T>>,
-    ) -> FtpResult<Vec<String>> {
+    /// Read a data stream line by line.
+    pub fn get_lines_from_stream<R>(data_stream: &mut R) -> FtpResult<Vec<String>>
+    where
+        R: BufRead,
+    {
         let mut lines: Vec<String> = Vec::new();
 
         loop {
@@ -871,135 +915,61 @@ where
         Ok(lines)
     }
 
-    /// Read response from stream
-    fn read_response(&mut self, expected_code: Status) -> FtpResult<Response> {
-        self.read_response_in(&[expected_code])
+    /// Locks the control connection for the duration of one command.
+    fn control(&self) -> MutexGuard<'_, ControlChannel<T>> {
+        control::lock(&self.control)
     }
 
-    /// Retrieve single line response
-    fn read_response_in(&mut self, expected_code: &[Status]) -> FtpResult<Response> {
-        let mut line = Vec::new();
-        let mut body: Vec<u8> = Vec::new();
-        self.read_line(&mut line)?;
-        body.extend(line.iter());
-
-        trace!("CC IN: {:?}", line);
-
-        if line.len() < 5 {
-            return Err(FtpError::BadResponse);
-        }
-
-        let code_word: u32 = self.code_from_buffer(&line, 3)?;
-        let mut code = Status::from(code_word);
-
-        trace!("Code parsed from response: {} ({})", code, code_word);
-
-        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
-        // including glFTPd, use a different operative code. FEAT remains special because
-        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
-        // M-DOCUMENTED-MAGIC: FTP replies start with a three-digit code and one separator.
-        let expected = [line[0], line[1], line[2], 0x20];
-        let feat_opener = [line[0], line[1], line[2], b'-'];
-        let is_terminal = |reply: &[u8]| {
-            reply.len() >= 4
-                && reply[0].is_ascii_digit()
-                && reply[1].is_ascii_digit()
-                && reply[2].is_ascii_digit()
-                && (reply[3] == b' '
-                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
-        };
-        trace!("CC IN: {:?}", line);
-        while !is_terminal(&line) {
-            line.clear();
-            let bytes_read = self.read_line(&mut line)?;
-            if bytes_read == 0 {
-                return Err(FtpError::ConnectionError(std::io::Error::new(
-                    std::io::ErrorKind::UnexpectedEof,
-                    "connection closed during multiline response",
-                )));
-            }
-            body.extend(line.iter());
-            trace!("CC IN: {:?}", line);
-        }
-
-        if line[0..4] != expected {
-            code = Status::from(self.code_from_buffer(&line, 3)?);
-            trace!("Code updated from terminal response: {}", code);
-        }
-
-        let response: Response = Response::new(code, body);
-        // Return Ok or error with response
-        if expected_code.contains(&code) {
-            Ok(response)
-        } else {
-            Err(FtpError::UnexpectedResponse(response))
-        }
-    }
-
-    /// Read bytes from reader until 0x0A or EOF is found
-    fn read_line(&mut self, line: &mut Vec<u8>) -> FtpResult<usize> {
-        self.reader
-            .read_until(0x0A, line.as_mut())
-            .map_err(FtpError::ConnectionError)?;
-        Ok(line.len())
-    }
-
-    /// Get code from buffer
-    fn code_from_buffer(&self, buf: &[u8], len: usize) -> Result<u32, FtpError> {
-        if buf.len() < len {
-            return Err(FtpError::BadResponse);
-        }
-        let buffer = buf[0..len].to_vec();
-        let as_string = String::from_utf8(buffer).map_err(|_| FtpError::BadResponse)?;
-        as_string.parse::<u32>().map_err(|_| FtpError::BadResponse)
-    }
-
-    /// Write data to stream with command to perform
-    fn perform(&mut self, command: Command) -> FtpResult<()> {
-        let command = command.to_string();
-        crate::command::validate_command_line(&command)?;
-        trace!("CC OUT: {}", command.trim_end_matches("\r\n"));
-
-        let stream = self.reader.get_mut();
-        stream
-            .write_all(command.as_bytes())
-            .map_err(FtpError::ConnectionError)
+    /// Opens the data connection for `cmd` and wraps it into a self-finalizing [`TransferStream`].
+    fn open_transfer(
+        &self,
+        cmd: Command,
+        expected_code: &[Status],
+    ) -> FtpResult<(Response, TransferStream<T>)> {
+        let mut cc = self.control();
+        let (response, data_stream) =
+            self.data_command_with_response(&mut cc, cmd, expected_code)?;
+        Ok((
+            response,
+            TransferStream::new(data_stream, Arc::clone(&self.control)),
+        ))
     }
 
     /// Execute command which send data back in a separate stream
-    fn data_command(&mut self, cmd: Command) -> FtpResult<DataStream<T>> {
+    fn data_command(&self, cc: &mut ControlChannel<T>, cmd: Command) -> FtpResult<DataStream<T>> {
         // guard data connection
-        self.guard_multiple_data_connections()?;
+        cc.guard_multiple_data_connections()?;
 
         let stream = match self.mode {
-            Mode::Active => self
-                .active()
-                .and_then(|listener| self.perform(cmd).map(|_| listener))
-                .and_then(|listener| {
-                    let start = Instant::now();
-                    loop {
-                        match listener.accept() {
-                            Ok((stream, _)) => break Ok(stream),
-                            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                                if start.elapsed() > self.active_timeout {
-                                    break Err(FtpError::ConnectionError(
-                                        std::io::ErrorKind::WouldBlock.into(),
-                                    ));
-                                }
-                                std::thread::sleep(Duration::from_millis(100));
+            Mode::Active => {
+                let listener = self.active(cc)?;
+                cc.perform(cmd)?;
+                let start = Instant::now();
+                loop {
+                    match listener.accept() {
+                        Ok((stream, _)) => break stream,
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            if start.elapsed() > self.active_timeout {
+                                return Err(FtpError::ConnectionError(
+                                    std::io::ErrorKind::WouldBlock.into(),
+                                ));
                             }
-                            Err(e) => break Err(FtpError::ConnectionError(e)),
+                            std::thread::sleep(Duration::from_millis(100));
                         }
+                        Err(e) => return Err(FtpError::ConnectionError(e)),
                     }
-                })?,
-            Mode::ExtendedPassive => self
-                .epsv()
-                .and_then(|addr| self.perform(cmd).map(|_| addr))
-                .and_then(|addr| (self.passive_stream_builder)(addr))?,
-            Mode::Passive => self
-                .pasv()
-                .and_then(|addr| self.perform(cmd).map(|_| addr))
-                .and_then(|addr| (self.passive_stream_builder)(addr))?,
+                }
+            }
+            Mode::ExtendedPassive => {
+                let addr = self.epsv(cc)?;
+                cc.perform(cmd)?;
+                (self.passive_stream_builder)(addr)?
+            }
+            Mode::Passive => {
+                let addr = self.pasv(cc)?;
+                cc.perform(cmd)?;
+                (self.passive_stream_builder)(addr)?
+            }
         };
 
         #[cfg(not(feature = "secure"))]
@@ -1019,7 +989,7 @@ where
         };
 
         if result.is_ok() {
-            self.data_connection_open = true;
+            cc.data_connection_open = true;
         }
         result
     }
@@ -1031,24 +1001,25 @@ where
     /// failed command never leaves the client believing a data connection is still open, which would
     /// otherwise make every subsequent data command fail with [`FtpError::DataConnectionAlreadyOpen`].
     fn data_command_with_response(
-        &mut self,
+        &self,
+        cc: &mut ControlChannel<T>,
         cmd: Command,
         expected_code: &[Status],
     ) -> FtpResult<(Response, DataStream<T>)> {
-        let data_stream = self.data_command(cmd)?;
-        match self.read_response_in(expected_code) {
+        let data_stream = self.data_command(cc, cmd)?;
+        match cc.read_response_in(expected_code) {
             Ok(response) => Ok((response, data_stream)),
             Err(err) => {
                 // server rejected the command: drop the data stream and reset the open flag
                 drop(data_stream);
-                self.data_connection_open = false;
+                cc.data_connection_open = false;
                 Err(err)
             }
         }
     }
 
     /// Create a new tcp listener and send a PORT command for it
-    fn active(&mut self) -> FtpResult<TcpListener> {
+    fn active(&self, cc: &mut ControlChannel<T>) -> FtpResult<TcpListener> {
         debug!("Starting local tcp listener...");
         let conn = TcpListener::bind("0.0.0.0:0").map_err(FtpError::ConnectionError)?;
         conn.set_nonblocking(true)
@@ -1057,14 +1028,11 @@ where
         let addr = conn.local_addr().map_err(FtpError::ConnectionError)?;
         trace!("Local address is {}", addr);
 
-        let ip = match self.reader.get_mut() {
-            DataStream::Tcp(stream) => stream.local_addr().map_err(FtpError::ConnectionError)?.ip(),
-            DataStream::Ssl(stream) => stream
-                .get_ref()
-                .local_addr()
-                .map_err(FtpError::ConnectionError)?
-                .ip(),
-        };
+        let ip = cc
+            .socket()
+            .local_addr()
+            .map_err(FtpError::ConnectionError)?
+            .ip();
 
         debug!("Active mode, listening on {}:{}", ip, addr.port());
 
@@ -1074,56 +1042,46 @@ where
                 let lsb = addr.port() % 256;
                 let ip_port = format!("{},{},{}", ip.to_string().replace('.', ","), msb, lsb);
                 debug!("Running PORT command");
-                self.perform(Command::Port(ip_port))?;
+                cc.perform(Command::Port(ip_port))?;
             }
             std::net::IpAddr::V6(_) => {
                 debug!("Running EPRT command");
-                self.perform(Command::Eprt(SocketAddr::new(ip, addr.port())))?;
+                cc.perform(Command::Eprt(SocketAddr::new(ip, addr.port())))?;
             }
         }
-        self.read_response(Status::CommandOk)?;
+        cc.read_response(Status::CommandOk)?;
 
         Ok(conn)
     }
 
     /// Runs the EPSV to enter Extended passive mode.
-    fn epsv(&mut self) -> FtpResult<SocketAddr> {
+    fn epsv(&self, cc: &mut ControlChannel<T>) -> FtpResult<SocketAddr> {
         debug!("EPSV command");
-        self.perform(Command::Epsv)?;
+        cc.perform(Command::Epsv)?;
         // PASV response format : 229 Entering Extended Passive Mode (|||PORT|)
-        let response: Response = self.read_response(Status::ExtendedPassiveMode)?;
+        let response: Response = cc.read_response(Status::ExtendedPassiveMode)?;
         let response_str = response.as_string().map_err(|_| FtpError::BadResponse)?;
         let caps = EPSV_PORT_RE
             .captures(&response_str)
             .ok_or_else(|| FtpError::UnexpectedResponse(response.clone()))?;
         let new_port = caps[1].parse::<u16>().map_err(|_| FtpError::BadResponse)?;
         trace!("Got port number from EPSV: {}", new_port);
-        let mut remote = self
-            .reader
-            .get_ref()
-            .get_ref()
-            .peer_addr()
-            .map_err(FtpError::ConnectionError)?;
+        let mut remote = cc.socket().peer_addr().map_err(FtpError::ConnectionError)?;
         remote.set_port(new_port);
         trace!("Remote address for extended passive mode is {}", remote);
         Ok(remote)
     }
 
     /// Runs the PASV command  to enter passive mode.
-    fn pasv(&mut self) -> FtpResult<SocketAddr> {
+    fn pasv(&self, cc: &mut ControlChannel<T>) -> FtpResult<SocketAddr> {
         debug!("PASV command");
-        self.perform(Command::Pasv)?;
+        cc.perform(Command::Pasv)?;
         // PASV response format : 227 Entering Passive Mode (h1,h2,h3,h4,p1,p2).
-        let response = self.read_response(Status::PassiveMode)?;
+        let response = cc.read_response(Status::PassiveMode)?;
         let addr = Self::parse_passive_address_from_response(response)?;
         trace!("Passive address: {addr}",);
         if self.nat_workaround {
-            let mut remote = self
-                .reader
-                .get_ref()
-                .get_ref()
-                .peer_addr()
-                .map_err(FtpError::ConnectionError)?;
+            let mut remote = cc.socket().peer_addr().map_err(FtpError::ConnectionError)?;
             remote.set_port(addr.port());
             trace!("Replacing site local address {} with {}", addr, remote);
             Ok(remote)
@@ -1161,12 +1119,11 @@ where
     }
 
     /// Execute a command which returns list of strings in a separate stream
-    fn stream_lines(&mut self, cmd: Command, open_code: Status) -> FtpResult<Vec<String>> {
-        let (_, stream) =
-            self.data_command_with_response(cmd, &[open_code, Status::AlreadyOpen])?;
+    fn stream_lines(&self, cmd: Command, open_code: Status) -> FtpResult<Vec<String>> {
+        let (_, stream) = self.open_transfer(cmd, &[open_code, Status::AlreadyOpen])?;
         let mut data_stream = BufReader::new(stream);
         let lines = Self::get_lines_from_stream(&mut data_stream);
-        self.finalize_retr_stream(data_stream)?;
+        data_stream.into_inner().finish()?;
         lines
     }
 
@@ -1174,23 +1131,12 @@ where
     fn default_passive_stream_builder() -> Box<PassiveStreamBuilder> {
         Box::new(|addr| TcpStream::connect(addr).map_err(FtpError::ConnectionError))
     }
-
-    /// guard against multiple data connections
-    ///
-    /// If `data_connection_open` is true, returns an [`FtpError::DataConnectionAlreadyOpen`] indicating that a data connection is already open.
-    /// Otherwise, returns Ok(()).
-    fn guard_multiple_data_connections(&self) -> FtpResult<()> {
-        if self.data_connection_open {
-            Err(FtpError::DataConnectionAlreadyOpen)
-        } else {
-            Ok(())
-        }
-    }
 }
 
 #[cfg(test)]
 mod test {
 
+    use std::io::Write;
     use std::net::IpAddr;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -1423,7 +1369,7 @@ mod test {
             let mut buffer = Vec::new();
             assert!(reader.read_to_end(&mut buffer).is_ok());
             // Finalize
-            assert!(stream.finalize_retr_stream(Box::new(reader)).is_ok());
+            assert!(reader.finish().is_ok());
             // Verify file matches
             assert_eq!(buffer.as_slice(), "test data\ntest data\n".as_bytes());
             // Rename
@@ -1526,7 +1472,7 @@ mod test {
             6
         );
         // Finalize
-        assert!(stream.finalize_put_stream(transfer_stream).is_ok());
+        assert!(transfer_stream.finish().is_ok());
         // Get size
         //assert_eq!(stream.size("test.bin").unwrap(), 11);
         // Remove file
@@ -1573,7 +1519,7 @@ mod test {
             let mut reader = BufReader::new(data_stream);
             FtpStream::get_lines_from_stream(&mut reader).expect("Failed to get lines from stream");
             // finalize
-            assert!(stream.close_data_connection(reader).is_ok());
+            assert!(reader.into_inner().finish().is_ok());
         });
     }
 
@@ -1633,7 +1579,7 @@ mod test {
             // Append via stream
             let mut data_stream = stream.append_with_stream("append_stream.txt").unwrap();
             data_stream.write_all(b"part2").unwrap();
-            stream.finalize_put_stream(data_stream).unwrap();
+            data_stream.finish().unwrap();
             // Verify content
             let content = stream
                 .retr_as_buffer("append_stream.txt")
@@ -1718,7 +1664,7 @@ mod test {
                 _ => panic!("Expected DataConnectionAlreadyOpen error"),
             }
 
-            assert!(stream.close_data_connection(reader).is_ok());
+            assert!(reader.into_inner().finish().is_ok());
         });
     }
 
@@ -1734,7 +1680,7 @@ mod test {
             let mut reader = BufReader::new(data_stream);
             FtpStream::get_lines_from_stream(&mut reader).expect("Failed to get lines from stream");
             // finalize
-            assert!(stream.close_data_connection(reader).is_ok());
+            assert!(reader.into_inner().finish().is_ok());
 
             // Now it should be possible to open another data connection
             let (response, data_stream) = stream
@@ -1744,7 +1690,7 @@ mod test {
             let mut reader = BufReader::new(data_stream);
             FtpStream::get_lines_from_stream(&mut reader).expect("Failed to get lines from stream");
             // finalize
-            assert!(stream.close_data_connection(reader).is_ok());
+            assert!(reader.into_inner().finish().is_ok());
         });
     }
 
@@ -1868,6 +1814,143 @@ mod test {
             assert!(!files.is_empty());
 
             assert!(stream.rm("list_test.txt").is_ok());
+        })
+    }
+
+    #[test]
+    fn should_upload_via_stream_and_finish() {
+        with_test_ftp_stream(|stream| {
+            assert!(stream.transfer_type(FileType::Binary).is_ok());
+            let mut upload = stream.put_with_stream("upload.bin").unwrap();
+            upload.write_all(b"0123456789").unwrap();
+            upload
+                .finish()
+                .expect("finish should read the transfer reply");
+            // The control connection is in sync: the next commands work.
+            assert_eq!(stream.size("upload.bin").unwrap(), 10);
+            assert_eq!(stream.nlst(None).unwrap().as_slice(), &["upload.bin"]);
+            assert!(stream.rm("upload.bin").is_ok());
+        })
+    }
+
+    #[test]
+    fn should_download_via_stream_and_finish() {
+        with_test_ftp_stream(|stream| {
+            assert!(stream.transfer_type(FileType::Binary).is_ok());
+            let mut reader = Cursor::new("download me".as_bytes());
+            assert!(stream.put_file("download.txt", &mut reader).is_ok());
+            let mut download = stream.retr_as_stream("download.txt").unwrap();
+            let mut buffer = Vec::new();
+            download.read_to_end(&mut buffer).unwrap();
+            download
+                .finish()
+                .expect("finish should read the transfer reply");
+            assert_eq!(buffer, b"download me");
+            // The control connection is in sync: the next commands work.
+            assert!(stream.pwd().is_ok());
+            assert_eq!(stream.size("download.txt").unwrap(), 11);
+            assert!(stream.rm("download.txt").is_ok());
+        })
+    }
+
+    #[test]
+    fn should_finalize_dropped_stream() {
+        with_test_ftp_stream(|stream| {
+            assert!(stream.transfer_type(FileType::Binary).is_ok());
+            let mut upload = stream.put_with_stream("dropped.bin").unwrap();
+            upload.write_all(b"dropped").unwrap();
+            // Drop without finish(): the stream reads the reply on its own.
+            drop(upload);
+            assert_eq!(stream.size("dropped.bin").unwrap(), 7);
+            let content = stream.retr_as_buffer("dropped.bin").unwrap().into_inner();
+            assert_eq!(content, b"dropped");
+            assert!(stream.rm("dropped.bin").is_ok());
+        })
+    }
+
+    #[test]
+    fn should_read_a_single_reply_on_finish_then_drop() {
+        with_test_ftp_stream(|stream| {
+            assert!(stream.transfer_type(FileType::Binary).is_ok());
+            // A short read timeout makes a second (spurious) reply read fail slowly and visibly.
+            let timeout = Duration::from_millis(500);
+            stream.get_ref().set_read_timeout(Some(timeout)).unwrap();
+            let mut upload = stream.put_with_stream("single.bin").unwrap();
+            upload.write_all(b"single").unwrap();
+            let started = Instant::now();
+            upload
+                .finish()
+                .expect("finish should read exactly one reply");
+            assert!(
+                started.elapsed() < timeout,
+                "finish() took {:?}: a second reply read blocked until the timeout",
+                started.elapsed()
+            );
+            // The control connection is in sync: the next commands work.
+            assert!(stream.noop().is_ok());
+            assert_eq!(stream.size("single.bin").unwrap(), 6);
+            stream.get_ref().set_read_timeout(None).unwrap();
+            assert!(stream.rm("single.bin").is_ok());
+        })
+    }
+
+    #[test]
+    fn should_reject_data_commands_while_a_transfer_stream_is_alive() {
+        with_test_ftp_stream(|stream| {
+            assert!(stream.transfer_type(FileType::Binary).is_ok());
+            let mut upload = stream.put_with_stream("alive.bin").unwrap();
+            upload.write_all(b"alive").unwrap();
+            assert!(matches!(
+                stream.list(None),
+                Err(FtpError::DataConnectionAlreadyOpen)
+            ));
+            assert!(matches!(
+                stream.retr_as_stream("alive.bin"),
+                Err(FtpError::DataConnectionAlreadyOpen)
+            ));
+            assert!(matches!(
+                stream.put_with_stream("other.bin"),
+                Err(FtpError::DataConnectionAlreadyOpen)
+            ));
+            upload.finish().unwrap();
+            // Once finished, data commands work again.
+            assert_eq!(stream.nlst(None).unwrap().as_slice(), &["alive.bin"]);
+            assert!(stream.rm("alive.bin").is_ok());
+        })
+    }
+
+    #[test]
+    fn should_finish_transfer_stream_on_another_thread() {
+        with_test_ftp_stream(|stream| {
+            assert!(stream.transfer_type(FileType::Binary).is_ok());
+            let upload = stream.put_with_stream("threaded.bin").unwrap();
+            let handle = std::thread::spawn(move || {
+                let mut upload = upload;
+                upload.write_all(b"from another thread").unwrap();
+                upload.finish()
+            });
+            handle
+                .join()
+                .expect("uploader thread panicked")
+                .expect("finish should succeed on another thread");
+            assert_eq!(stream.size("threaded.bin").unwrap(), 19);
+            assert!(stream.rm("threaded.bin").is_ok());
+        })
+    }
+
+    #[test]
+    fn should_finalize_transfer_when_retr_callback_fails() {
+        with_test_ftp_stream(|stream| {
+            assert!(stream.transfer_type(FileType::Binary).is_ok());
+            let mut reader = Cursor::new("callback".as_bytes());
+            assert!(stream.put_file("callback_err.txt", &mut reader).is_ok());
+            let result: FtpResult<()> =
+                stream.retr("callback_err.txt", |_| Err(FtpError::BadResponse));
+            assert!(matches!(result, Err(FtpError::BadResponse)));
+            // The failed callback must not leave the data connection flagged as open.
+            assert_eq!(stream.size("callback_err.txt").unwrap(), 8);
+            assert!(stream.list(None).is_ok());
+            assert!(stream.rm("callback_err.txt").is_ok());
         })
     }
 

--- a/crates/suppaftp/src/sync_ftp/control.rs
+++ b/crates/suppaftp/src/sync_ftp/control.rs
@@ -1,0 +1,257 @@
+//! Control-connection state shared between an FTP client and its in-flight data transfer.
+//!
+//! The control connection (command socket, reply reader, and the "data connection open" flag)
+//! lives behind an [`Arc`]`<`[`Mutex`]`>` so that a [`super::TransferStream`] can finalize itself:
+//! once the data socket is closed, the stream locks the control connection, clears the flag and
+//! reads the server's completion reply. FTP allows a single data connection per session, so the
+//! lock never serializes anything that could have run concurrently before.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::ops::Deref;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use super::data_stream::DataStream;
+use super::tls::TlsStream;
+use crate::Status;
+use crate::command::Command;
+use crate::types::{FtpError, FtpResult, Response};
+
+/// Replies that complete a data transfer: `226` or `250`.
+pub(super) const TRANSFER_COMPLETE: &[Status] =
+    &[Status::ClosingDataConnection, Status::RequestedFileActionOk];
+
+/// Shared, lockable handle to a [`ControlChannel`].
+pub(super) type SharedControl<T> = Arc<Mutex<ControlChannel<T>>>;
+
+/// Command socket plus the reply reader and the data-connection bookkeeping.
+#[derive(Debug)]
+pub(super) struct ControlChannel<T>
+where
+    T: TlsStream,
+{
+    /// Buffered reader over the control socket; writes go through [`BufReader::get_mut`].
+    pub(super) reader: BufReader<DataStream<T>>,
+    /// Whether a data connection is currently open.
+    ///
+    /// FTP forbids more than one data connection at a time, so this flag guards every data
+    /// command against opening a second one.
+    pub(super) data_connection_open: bool,
+}
+
+/// Locks `control`, recovering the inner state if a previous holder panicked.
+pub(super) fn lock<T>(control: &Mutex<ControlChannel<T>>) -> MutexGuard<'_, ControlChannel<T>>
+where
+    T: TlsStream,
+{
+    control
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Unwraps a shared control channel that is no longer referenced by any transfer.
+///
+/// # Errors
+///
+/// Returns [`FtpError::DataConnectionAlreadyOpen`] if a [`super::TransferStream`] still holds a
+/// reference to the control channel.
+#[cfg(feature = "secure")]
+pub(super) fn into_exclusive<T>(control: SharedControl<T>) -> FtpResult<ControlChannel<T>>
+where
+    T: TlsStream,
+{
+    Arc::try_unwrap(control)
+        .map(|mutex| {
+            mutex
+                .into_inner()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+        })
+        .map_err(|_| FtpError::DataConnectionAlreadyOpen)
+}
+
+impl<T> ControlChannel<T>
+where
+    T: TlsStream,
+{
+    /// Wraps `stream` as a fresh control channel with no data connection open.
+    pub(super) fn new(stream: DataStream<T>) -> Self {
+        Self {
+            reader: BufReader::new(stream),
+            data_connection_open: false,
+        }
+    }
+
+    /// Wraps `stream` into a [`SharedControl`].
+    pub(super) fn shared(stream: DataStream<T>) -> SharedControl<T> {
+        Arc::new(Mutex::new(Self::new(stream)))
+    }
+
+    /// Returns the control socket.
+    pub(super) fn socket(&self) -> &TcpStream {
+        self.reader.get_ref().get_ref()
+    }
+
+    /// Sends `command` on the control connection.
+    pub(super) fn perform(&mut self, command: Command) -> FtpResult<()> {
+        let command = command.to_string();
+        crate::command::validate_command_line(&command)?;
+        trace!("CC OUT: {}", command.trim_end_matches("\r\n"));
+
+        self.reader
+            .get_mut()
+            .write_all(command.as_bytes())
+            .map_err(FtpError::ConnectionError)
+    }
+
+    /// Reads one reply and checks that its status is `expected_code`.
+    pub(super) fn read_response(&mut self, expected_code: Status) -> FtpResult<Response> {
+        self.read_response_in(&[expected_code])
+    }
+
+    /// Reads one (possibly multi-line) reply and checks that its status is in `expected_code`.
+    pub(super) fn read_response_in(&mut self, expected_code: &[Status]) -> FtpResult<Response> {
+        let mut line = Vec::new();
+        let mut body: Vec<u8> = Vec::new();
+        self.read_line(&mut line)?;
+        body.extend(line.iter());
+
+        trace!("CC IN: {:?}", line);
+
+        if line.len() < 5 {
+            return Err(FtpError::BadResponse);
+        }
+
+        let code_word: u32 = code_from_buffer(&line, 3)?;
+        let mut code = Status::from(code_word);
+
+        trace!("Code parsed from response: {} ({})", code, code_word);
+
+        // RFC 959 requires the terminal line to repeat the opening code, but some servers,
+        // including glFTPd, use a different operative code. FEAT remains special because
+        // `feat` reads its continuation lines after `read_response` returns the `211-` opener.
+        // FTP replies start with a three-digit code and one separator.
+        let expected = [line[0], line[1], line[2], 0x20];
+        let feat_opener = [line[0], line[1], line[2], b'-'];
+        let is_terminal = |reply: &[u8]| {
+            reply.len() >= 4
+                && reply[0].is_ascii_digit()
+                && reply[1].is_ascii_digit()
+                && reply[2].is_ascii_digit()
+                && (reply[3] == b' '
+                    || (expected_code.contains(&Status::System) && reply[0..4] == feat_opener))
+        };
+        trace!("CC IN: {:?}", line);
+        while !is_terminal(&line) {
+            line.clear();
+            let bytes_read = self.read_line(&mut line)?;
+            if bytes_read == 0 {
+                return Err(FtpError::ConnectionError(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed during multiline response",
+                )));
+            }
+            body.extend(line.iter());
+            trace!("CC IN: {:?}", line);
+        }
+
+        if line[0..4] != expected {
+            code = Status::from(code_from_buffer(&line, 3)?);
+            trace!("Code updated from terminal response: {}", code);
+        }
+
+        let response: Response = Response::new(code, body);
+        // Return Ok or error with response
+        if expected_code.contains(&code) {
+            Ok(response)
+        } else {
+            Err(FtpError::UnexpectedResponse(response))
+        }
+    }
+
+    /// Reads bytes from the control connection until `\n` or EOF is found.
+    pub(super) fn read_line(&mut self, line: &mut Vec<u8>) -> FtpResult<usize> {
+        self.reader
+            .read_until(0x0A, line.as_mut())
+            .map_err(FtpError::ConnectionError)?;
+        Ok(line.len())
+    }
+
+    /// Fails with [`FtpError::DataConnectionAlreadyOpen`] if a data connection is open.
+    pub(super) fn guard_multiple_data_connections(&self) -> FtpResult<()> {
+        if self.data_connection_open {
+            Err(FtpError::DataConnectionAlreadyOpen)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Marks the data connection as closed and reads the transfer completion reply.
+    ///
+    /// The data socket must already be closed, otherwise the server never sends the reply.
+    pub(super) fn complete_transfer(&mut self) -> FtpResult<()> {
+        self.data_connection_open = false;
+        trace!("data connection closed; reading transfer reply");
+        self.read_response_in(TRANSFER_COMPLETE).map(|_| ())
+    }
+}
+
+/// Parses the leading `len` bytes of `buf` as a numeric reply code.
+fn code_from_buffer(buf: &[u8], len: usize) -> FtpResult<u32> {
+    if buf.len() < len {
+        return Err(FtpError::BadResponse);
+    }
+    let buffer = buf[0..len].to_vec();
+    let as_string = String::from_utf8(buffer).map_err(|_| FtpError::BadResponse)?;
+    as_string.parse::<u32>().map_err(|_| FtpError::BadResponse)
+}
+
+/// Locked view of the control socket of an [`super::ImplFtpStream`].
+///
+/// Dereferences to the underlying [`TcpStream`], so socket options such as timeouts can be set
+/// on the control connection. The control connection stays locked for as long as this value is
+/// alive: drop it before finishing or dropping a [`super::TransferStream`], which needs the same
+/// lock to read the transfer reply.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::time::Duration;
+///
+/// use suppaftp::FtpStream;
+///
+/// let stream = FtpStream::connect("127.0.0.1:21").unwrap();
+/// stream
+///     .get_ref()
+///     .set_read_timeout(Some(Duration::from_secs(10)))
+///     .unwrap();
+/// ```
+#[derive(Debug)]
+pub struct ControlSocket<'a, T>
+where
+    T: TlsStream,
+{
+    guard: MutexGuard<'a, ControlChannel<T>>,
+}
+
+impl<'a, T> ControlSocket<'a, T>
+where
+    T: TlsStream,
+{
+    /// Locks `control` and exposes its socket.
+    pub(super) fn lock(control: &'a Mutex<ControlChannel<T>>) -> Self {
+        Self {
+            guard: lock(control),
+        }
+    }
+}
+
+impl<T> Deref for ControlSocket<'_, T>
+where
+    T: TlsStream,
+{
+    type Target = TcpStream;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard.socket()
+    }
+}

--- a/crates/suppaftp/src/sync_ftp/control.rs
+++ b/crates/suppaftp/src/sync_ftp/control.rs
@@ -255,3 +255,65 @@ where
         self.guard.socket()
     }
 }
+
+#[cfg(all(test, feature = "secure"))]
+mod tls_transition_tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::super::tls::{NoTlsStream, TlsConnector};
+    use crate::{FtpError, FtpResult, FtpStream};
+
+    #[derive(Debug)]
+    struct UnusedConnector;
+
+    impl TlsConnector for UnusedConnector {
+        type Stream = NoTlsStream;
+
+        fn connect(&self, _: &str, _: std::net::TcpStream) -> FtpResult<Self::Stream> {
+            panic!("TLS must not start while a transfer owns the control connection")
+        }
+    }
+
+    #[test]
+    fn should_reject_tls_changes_before_sending_commands() {
+        for secure in [false, true] {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let address = listener.local_addr().unwrap();
+            let server = thread::spawn(move || {
+                let (socket, _) = listener.accept().unwrap();
+                socket
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                let mut reader = BufReader::new(socket);
+                reader.get_mut().write_all(b"220 ready\r\n").unwrap();
+                let mut command = String::new();
+                reader.read_line(&mut command).unwrap();
+                if !command.is_empty() {
+                    let reply: &[u8] = if secure {
+                        b"234 start TLS\r\n"
+                    } else {
+                        b"200 cleared\r\n"
+                    };
+                    reader.get_mut().write_all(reply).unwrap();
+                    reader.read_to_end(&mut Vec::new()).unwrap();
+                }
+                command
+            });
+            let ftp = FtpStream::connect(address).unwrap();
+            // A live transfer retains this handle even when a TLS transition consumes the client.
+            let transfer_control = Arc::clone(&ftp.control);
+            let result = if secure {
+                ftp.into_secure(UnusedConnector, "localhost")
+            } else {
+                ftp.clear_command_channel()
+            };
+            assert!(matches!(result, Err(FtpError::DataConnectionAlreadyOpen)));
+            drop(transfer_control);
+            assert_eq!(server.join().unwrap(), "");
+        }
+    }
+}

--- a/crates/suppaftp/src/sync_ftp/transfer_stream.rs
+++ b/crates/suppaftp/src/sync_ftp/transfer_stream.rs
@@ -1,0 +1,163 @@
+//! Self-finalizing data stream for FTP transfers.
+
+use std::io::{Read, Result as IoResult, Write};
+
+use super::control::{SharedControl, lock};
+use super::data_stream::DataStream;
+use super::tls::TlsStream;
+use crate::types::FtpResult;
+
+/// Data connection of an FTP transfer that finalizes itself.
+///
+/// Returned by [`ImplFtpStream::put_with_stream`], [`ImplFtpStream::append_with_stream`],
+/// [`ImplFtpStream::retr_as_stream`] and [`ImplFtpStream::custom_data_command`]. It implements
+/// [`Read`] and [`Write`] by delegating to the underlying [`DataStream`].
+///
+/// Once the payload has been written or read, call [`TransferStream::finish`]: it closes the data
+/// socket and reads the server's completion reply on the control connection, which is the only
+/// way to learn whether the transfer succeeded. A stream that is merely dropped performs the same
+/// procedure on a best-effort basis, logging instead of returning the error, so the control
+/// connection never desynchronizes; the transfer outcome is lost in that case.
+///
+/// While a `TransferStream` is alive the client refuses to open another data connection with
+/// [`FtpError::DataConnectionAlreadyOpen`]. The stream owns no reference to the client and is
+/// [`Send`] whenever the TLS stream is, so it can be moved to another thread and finished there.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::io::Write;
+///
+/// use suppaftp::FtpStream;
+///
+/// let mut ftp = FtpStream::connect("127.0.0.1:21").unwrap();
+/// ftp.login("test", "test").unwrap();
+/// let mut upload = ftp.put_with_stream("hello.txt").unwrap();
+/// upload.write_all(b"hello, world!").unwrap();
+/// // Reads the `226` reply; the control connection is ready for the next command.
+/// upload.finish().unwrap();
+/// assert_eq!(ftp.size("hello.txt").unwrap(), 13);
+/// ```
+///
+/// [`ImplFtpStream::put_with_stream`]: super::ImplFtpStream::put_with_stream
+/// [`ImplFtpStream::append_with_stream`]: super::ImplFtpStream::append_with_stream
+/// [`ImplFtpStream::retr_as_stream`]: super::ImplFtpStream::retr_as_stream
+/// [`ImplFtpStream::custom_data_command`]: super::ImplFtpStream::custom_data_command
+/// [`FtpError::DataConnectionAlreadyOpen`]: crate::FtpError::DataConnectionAlreadyOpen
+#[must_use = "call `finish()` to close the data connection and read the transfer reply"]
+#[derive(Debug)]
+pub struct TransferStream<T>
+where
+    T: TlsStream,
+{
+    /// Data socket; `None` once the transfer has been finalized or detached.
+    data: Option<DataStream<T>>,
+    control: SharedControl<T>,
+}
+
+impl<T> TransferStream<T>
+where
+    T: TlsStream,
+{
+    /// Wraps an open data connection so that it completes the transfer on `control`.
+    pub(super) fn new(data: DataStream<T>, control: SharedControl<T>) -> Self {
+        Self {
+            data: Some(data),
+            control,
+        }
+    }
+
+    /// Returns a reference to the underlying [`DataStream`].
+    pub fn get_ref(&self) -> &DataStream<T> {
+        self.data
+            .as_ref()
+            .expect("data stream is present until the transfer is finished")
+    }
+
+    /// Returns a mutable reference to the underlying [`DataStream`].
+    pub fn get_mut(&mut self) -> &mut DataStream<T> {
+        self.data
+            .as_mut()
+            .expect("data stream is present until the transfer is finished")
+    }
+
+    /// Closes the data connection and reads the transfer completion reply.
+    ///
+    /// After this call the client can issue the next command.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FtpError::ConnectionError`] if the control connection cannot be read and
+    /// [`FtpError::UnexpectedResponse`] if the server reports that the transfer failed (any
+    /// reply other than `226` or `250`).
+    ///
+    /// [`FtpError::ConnectionError`]: crate::FtpError::ConnectionError
+    /// [`FtpError::UnexpectedResponse`]: crate::FtpError::UnexpectedResponse
+    pub fn finish(mut self) -> FtpResult<()> {
+        self.finalize()
+    }
+
+    /// Detaches the data socket; the returned stream no longer completes the transfer on drop.
+    ///
+    /// Used by [`super::ImplFtpStream::abort`], which reads the reply itself.
+    pub(super) fn detach(mut self) -> DataStream<T> {
+        self.data
+            .take()
+            .expect("data stream is present until the transfer is finished")
+    }
+
+    /// Whether the transfer has already been finalized.
+    fn is_finished(&self) -> bool {
+        self.data.is_none()
+    }
+
+    /// Closes the data socket, then reads the completion reply on the control connection.
+    ///
+    /// Idempotent: a second call is a no-op, so `finish()` followed by `Drop` reads one reply.
+    fn finalize(&mut self) -> FtpResult<()> {
+        let Some(data) = self.data.take() else {
+            return Ok(());
+        };
+        // The socket must be closed before reading the reply, otherwise the server never sends
+        // it. Dropping the socket never touches the control lock, so no lock is held here.
+        drop(data);
+        lock(&self.control).complete_transfer()
+    }
+}
+
+impl<T> Read for TransferStream<T>
+where
+    T: TlsStream,
+{
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        self.get_mut().read(buf)
+    }
+}
+
+impl<T> Write for TransferStream<T>
+where
+    T: TlsStream,
+{
+    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+        self.get_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        self.get_mut().flush()
+    }
+}
+
+impl<T> Drop for TransferStream<T>
+where
+    T: TlsStream,
+{
+    fn drop(&mut self) {
+        if self.is_finished() {
+            return;
+        }
+        debug!("transfer stream dropped without finish(); finalizing the transfer");
+        if let Err(err) = self.finalize() {
+            warn!("failed to finalize a dropped transfer stream: {err}");
+        }
+    }
+}

--- a/crates/suppaftp/src/sync_ftp/transfer_stream.rs
+++ b/crates/suppaftp/src/sync_ftp/transfer_stream.rs
@@ -17,7 +17,11 @@ use crate::types::FtpResult;
 /// socket and reads the server's completion reply on the control connection, which is the only
 /// way to learn whether the transfer succeeded. A stream that is merely dropped performs the same
 /// procedure on a best-effort basis, logging instead of returning the error, so the control
-/// connection never desynchronizes; the transfer outcome is lost in that case.
+/// connection can be reused after successful cleanup. Drop can block while waiting for the
+/// server, and the transfer outcome is lost in that case.
+///
+/// Finish the transfer before issuing any other command on the client, even when finishing
+/// on another thread or task. Flush buffered writers before recovering their inner transfer.
 ///
 /// While a `TransferStream` is alive the client refuses to open another data connection with
 /// [`FtpError::DataConnectionAlreadyOpen`]. The stream owns no reference to the client and is

--- a/crates/suppaftp/src/test_container.rs
+++ b/crates/suppaftp/src/test_container.rs
@@ -56,7 +56,7 @@ pub struct AsyncPureFtpRunner {
 impl AsyncPureFtpRunner {
     pub async fn start() -> Self {
         use testcontainers::runners::AsyncRunner;
-        let container = AlpineFtpServer::default()
+        let container = AlpineFtpServer
             .start()
             .await
             .expect("Failed to start container");
@@ -107,9 +107,7 @@ pub struct SyncPureFtpRunner {
 impl SyncPureFtpRunner {
     pub fn start() -> Self {
         use testcontainers::runners::SyncRunner;
-        let container = AlpineFtpServer::default()
-            .start()
-            .expect("Failed to start container");
+        let container = AlpineFtpServer.start().expect("Failed to start container");
 
         let resp = container
             .exec(

--- a/dprint.json
+++ b/dprint.json
@@ -20,16 +20,17 @@
   },
   "excludes": [
     "**/target",
+    ".claude/plans",
+    ".superpowers",
+    "docs/superpowers",
     "Cargo.lock",
-    "assets",
-    "CHANGELOG.md",
-    "LICENSE-APACHE",
-    "LICENSE-MIT"
+    "coverage",
+    "lcov.info"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.22.1.wasm",
-    "https://plugins.dprint.dev/toml-0.7.0.wasm",
-    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.22.1.wasm@4906fbb038977732aae0e216e4b0b957e2722f8d79282660ccb36d27dd051f17",
+    "https://plugins.dprint.dev/toml-0.7.0.wasm@0126c8112691542d30b52a639076ecc83e07bace877638cee7c6915fd36b8629",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm@40a2fdda7040317eb1b23520f3a00769a5571eedb049c4ca9175c1b9eeba01ae",
     "https://plugins.dprint.dev/dprint/exec-0.6.2.json@df98f54ffd3092b8a841aedd6d098a2651f16d0a796a40535774f1a8b4b9d463"
   ]
 }

--- a/just/changelog.just
+++ b/just/changelog.just
@@ -1,37 +1,18 @@
-# Print the unreleased changelog section to stdout (preview only), e.g. `just changelog_preview 8.1.0`
+# Preview unreleased Conventional Commits for a version.
 [group('changelog')]
 changelog_preview version:
-    git-cliff --config cliff.toml --unreleased --tag "v{{ version }}" --strip all
+  git-cliff --config cliff.toml --unreleased --tag "v{{ version }}" --strip all
 
-# Add a new entry to CHANGELOG.md from the unreleased conventional commits, e.g. `just changelog 8.1.0`
+# Generate CHANGELOG.md through the requested version.
 [group('changelog')]
 changelog version:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    tag="v{{ version }}"
-    section="$(git-cliff --config cliff.toml --unreleased --tag "$tag" --strip all)"
-    if [ -z "$section" ]; then
-        echo "No unreleased conventional commits found; nothing to add." >&2
-        exit 0
-    fi
-    anchor="$(echo "{{ version }}" | tr -d '.')"
-    secfile="$(mktemp)"
-    tmp="$(mktemp)"
-    printf '%s\n' "$section" > "$secfile"
-    # Insert a TOC entry before the first existing version entry and the rendered
-    # section before the first existing version heading, keeping the title + TOC.
-    awk -v secfile="$secfile" -v ver="{{ version }}" -v anc="$anchor" '
-        !toc_done && /^[[:space:]]*- \[[0-9]/ {
-            print "    - [" ver "](#" anc ")"
-            toc_done = 1
-        }
-        !body_done && /^## [0-9]/ {
-            while ((getline line < secfile) > 0) print line
-            print ""
-            body_done = 1
-        }
-        { print }
-    ' CHANGELOG.md > "$tmp"
-    rm -f "$secfile"
-    mv "$tmp" CHANGELOG.md
-    echo "CHANGELOG.md updated for $tag"
+  git-cliff --config cliff.toml --tag "v{{ version }}" --output CHANGELOG.md
+  just fmt CHANGELOG.md
+
+# Tag a version and create a GitHub release with the changelog section as notes. Does not publish to crates.io.
+[group('changelog')]
+gh_release version:
+  notes="$(just changelog_preview {{ version }})" && \
+  git tag "v{{ version }}" && \
+  git push origin "v{{ version }}" && \
+  echo "$notes" | gh release create "v{{ version }}" --title "v{{ version }}" --notes-file -


### PR DESCRIPTION
# Description

Streaming transfers now own their cleanup across sync, Tokio, and smol clients. Call `finish()` to close a transfer and check the server's result. Dropping a stream attempts cleanup, with async clients reading the completion reply before the next command.

Async cleanup now survives cancellation and a locked control socket, including partially received replies. TLS mode changes reject outstanding transfers before asking the server to switch protocols. The commit description explains the migration, and the API docs describe command ordering and cleanup limits.

This is a breaking API change. `TransferStream::finish()` replaces `finalize_put_stream`, `finalize_retr_stream`, and `close_data_connection`. Streaming methods and async retrieval callbacks use `TransferStream`, and `get_ref()` returns a control-socket guard that async clients obtain with `.await`.

Validation: all 11 supported feature configurations pass under coverage, with 85.60% line coverage and 86.90% region coverage. Eleven new regression tests reproduced the review findings before the fixes and pass afterward. `just check_code`, Clippy including tests, and 17 documentation tests pass. Two runs hit Docker port-mapping failures before FTP setup and passed when rerun with lower concurrency. The Docker fixture uses plain FTP, so live FTPS handshakes and TLS shutdown error paths remain largely uncovered.

## Checklist

- [x] I have read the [AI Policy](https://github.com/veeso/suppaftp/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/veeso/suppaftp/blob/main/CONTRIBUTING.md).
- [x] I have added rustdoc documentation for any new public API.
- [x] I have added tests covering my changes.
- [x] `just check_code` passes locally.
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org) format (the `CHANGELOG.md` is generated from them at release time).

## AI Disclosure

Codex reviewed the branch, fixed the findings, added regression tests, updated the documentation, and ran validation and coverage checks. Codex also prepared the follow-up commit and this draft PR description.
